### PR TITLE
fix: make standalone agent generic, add /otherness.onboard command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install gh && gh auth login
 
 #### [python3](https://python.org)
 
-**What it provides:** Inline YAML parsing and JSON read/write. Agents use it exclusively to parse `otherness-config.yaml` and read/write `.maqa/state.json`. Only standard library modules are used (`re`, `json`, `os`, `datetime`). No pip packages required.
+**What it provides:** Inline YAML parsing and JSON read/write. Agents use it exclusively to parse `otherness-config.yaml` and read/write `.otherness/state.json`. Only standard library modules are used (`re`, `json`, `os`, `datetime`). No pip packages required.
 
 **Why it's required:** Config parsing and state management. Failures are wrapped in `2>/dev/null` fallbacks so the agent degrades gracefully rather than crashing.
 
@@ -86,7 +86,7 @@ uv tool install specify-cli    # or: pip install specify-cli
 
 #### [MAQA extension](https://github.com/GenieRobot/spec-kit-maqa-ext)
 
-**What it provides:** Entry-point shells and `.maqa/state.json` conventions that otherness reads and writes. otherness is built *on top of* MAQA — it adds the actual agent behavior (loops, roles, GitHub PM) that MAQA's shells redirect to.
+**What it provides:** Entry-point shells and `.otherness/state.json` conventions that otherness reads and writes. otherness is built *on top of* MAQA — it adds the actual agent behavior (loops, roles, GitHub PM) that MAQA's shells redirect to.
 
 #### [aide extension](https://github.com/mnriem/spec-kit-extensions)
 

--- a/agents/onboard.md
+++ b/agents/onboard.md
@@ -1,0 +1,467 @@
+---
+name: otherness.onboard
+description: "One-shot onboarding agent. Reads an existing codebase and generates all docs/aide/ files and seeds .otherness/state.json. Run once before /otherness.run on existing projects."
+tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
+> **These instructions live at `~/.otherness/agents/` and are auto-updated from GitHub on every startup.**
+> Never edit them locally — push changes to your otherness fork instead.
+
+> **Working directory**: Run from the **main repo directory** of the project you are onboarding.
+
+## What this does
+
+You are the ONBOARDING AGENT. You run exactly once on an existing project that does not yet
+have `docs/aide/` files or `.otherness/state.json`. You read the codebase and produce those
+files as drafts, then open a PR for human review.
+
+You do NOT implement features. You do NOT modify code. You only create:
+- `docs/aide/vision.md`
+- `docs/aide/roadmap.md`
+- `docs/aide/definition-of-done.md`
+- `docs/aide/progress.md`
+- `.otherness/state.json` (seeded with done items)
+- `otherness-config.yaml` (if not already present)
+
+After the PR is merged, the human runs `/otherness.run` to start the autonomous loop.
+
+---
+
+## SELF-UPDATE
+
+```bash
+git -C ~/.otherness pull --quiet 2>/dev/null || true
+echo "[ONBOARD] Agent files up to date."
+```
+
+---
+
+## STEP 1 — Read the project
+
+```bash
+REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
+REPO_NAME=$(basename $(git rev-parse --show-toplevel))
+echo "[ONBOARD] Onboarding $REPO"
+```
+
+Read these files in order. Extract everything relevant. Take notes mentally.
+
+1. `README.md` — what the project is, how to run it, key features
+2. `AGENTS.md` — tech stack, build/test commands, anti-patterns, code standards
+3. `.specify/memory/constitution.md` — if it exists, core architectural rules
+4. `Makefile` or build scripts — what commands exist
+5. `.github/workflows/` — CI setup, what the build/test/lint commands actually are
+6. `docs/` — any existing user docs
+7. Recent git log — what has been built so far:
+   ```bash
+   git log --oneline -50
+   ```
+8. Existing GitHub issues:
+   ```bash
+   gh issue list --repo $REPO --state open --json number,title,labels --limit 50
+   ```
+9. Merged PRs — understand what has shipped:
+   ```bash
+   gh pr list --repo $REPO --state merged --json number,title,mergedAt --limit 100 \
+     --jq 'sort_by(.mergedAt) | .[] | "#\(.number) \(.title[:70])"'
+   ```
+10. Existing `.specify/specs/` if present — understand what has been specced
+11. `web/src/` or `src/` — top-level structure to understand product domains
+
+---
+
+## STEP 2 — Identify what is done vs what remains
+
+From the merged PRs, git log, and existing specs:
+- List all capabilities that are already built and working
+- Identify what is explicitly in-progress or partially done
+- Identify gaps: features mentioned in README or docs but not yet built
+- Look at open GitHub issues for planned work
+
+```bash
+# Check if there are open issues that represent planned work
+gh issue list --repo $REPO --state open --json number,title,labels \
+  --jq '.[] | "#\(.number) [\(.labels[].name // "no-label")] \(.title[:60])"' 2>/dev/null | head -30
+```
+
+---
+
+## STEP 3 — Determine project config
+
+Extract from `AGENTS.md` if present, otherwise infer:
+
+```bash
+PROJECT_NAME=$(python3 -c "
+import re
+for line in open('AGENTS.md'):
+    m = re.match(r'^PROJECT_NAME:\s*(\S+)', line.strip())
+    if m: print(m.group(1)); break
+" 2>/dev/null || basename $(git rev-parse --show-toplevel))
+
+BUILD_COMMAND=$(python3 -c "
+import re
+for line in open('AGENTS.md'):
+    m = re.match(r'^BUILD_COMMAND:\s*(.+)', line.strip())
+    if m: print(m.group(1)); break
+" 2>/dev/null || echo "")
+
+TEST_COMMAND=$(python3 -c "
+import re
+for line in open('AGENTS.md'):
+    m = re.match(r'^TEST_COMMAND:\s*(.+)', line.strip())
+    if m: print(m.group(1)); break
+" 2>/dev/null || echo "")
+
+REPORT_ISSUE=$(python3 -c "
+import re
+for line in open('AGENTS.md'):
+    m = re.match(r'^REPORT_ISSUE:\s*(\S+)', line.strip())
+    if m: print(m.group(1)); break
+" 2>/dev/null || echo "TBD")
+
+echo "PROJECT=$PROJECT_NAME BUILD=$BUILD_COMMAND TEST=$TEST_COMMAND REPORT=$REPORT_ISSUE"
+```
+
+---
+
+## STEP 4 — Create docs/aide/
+
+```bash
+mkdir -p docs/aide
+```
+
+### `docs/aide/vision.md`
+
+Write this from the product perspective based on README + existing docs.
+Answer: what problem does this solve, for whom, what are the non-negotiable constraints?
+Use present tense — describe what exists today.
+
+Template:
+```markdown
+# <PROJECT_NAME>: Vision
+
+> Created: YYYY-MM-DD
+> Status: Active
+
+## What This Is
+
+<One paragraph: what the product does, who uses it, why it exists.>
+
+## Key Design Constraints
+
+<2-5 architectural decisions that will not change. Extract from AGENTS.md and constitution.md.>
+
+## Current Status
+
+<One paragraph: how mature is the project today? What milestone is it at?>
+```
+
+### `docs/aide/roadmap.md`
+
+For existing projects: completed stages are ✅, in-progress are 🔄, planned are 📋.
+Base stages on actual shipped PRs and open issues.
+
+Template:
+```markdown
+# <PROJECT_NAME>: Development Roadmap
+
+> Based on: docs/aide/vision.md
+
+---
+
+## Stage 0: Foundation — ✅ Complete
+
+**Goal**: Core infrastructure and basic functionality.
+
+### Shipped
+<List major merged PRs / capabilities>
+
+---
+
+## Stage N: <Current stage> — 🔄 In Progress
+
+**Goal**: <What this stage delivers>
+
+### In Progress
+<What's actively being worked on>
+
+### Remaining
+<What's left in this stage>
+
+---
+
+## Stage N+1: <Next stage> — 📋 Planned
+
+**Goal**: <What this stage delivers>
+```
+
+### `docs/aide/definition-of-done.md`
+
+Identify 3-5 user-facing scenarios from README, existing E2E tests, or open issues.
+Write them as journeys with exact commands and expected output.
+
+Template:
+```markdown
+# Definition of Done
+
+> The project is complete when every journey below passes end-to-end.
+
+---
+
+## Journey 1: <name>
+
+**The user story**: <who does what and why>
+
+### Steps
+
+\`\`\`bash
+# Exact commands a user would run
+\`\`\`
+
+### Pass criteria
+
+- [ ] <specific observable outcome>
+
+---
+
+## Journey Status
+
+| Journey | Status | Notes |
+|---|---|---|
+| 1: <name> | ❌ Not validated | |
+```
+
+Look for existing E2E test files, integration tests, or README "quick start" sections
+to extract realistic journeys — don't invent them.
+
+### `docs/aide/progress.md`
+
+Honest snapshot of current state, derived from merged PRs and open issues.
+
+Template:
+```markdown
+# <PROJECT_NAME>: Current Progress
+
+> Updated by standalone agent after each batch.
+
+## Current State
+
+- **Active queue**: none (not started with otherness yet)
+- **Completed stages**: <list>
+- **In-flight items**: none
+
+## Stage Completion
+
+| Stage | Name | Status | Notes |
+|---|---|---|---|
+| 0 | Foundation | ✅ Complete | <N> features shipped |
+
+## Recent Merged PRs (last 20)
+
+<List the last 20 merged PRs with numbers and titles>
+```
+
+---
+
+## STEP 5 — Seed `.otherness/state.json`
+
+```bash
+mkdir -p .otherness
+```
+
+Generate the features map from merged PRs and any `.specify/specs/` directories:
+
+```bash
+# Generate features entries from merged PRs
+python3 - <<'EOF'
+import subprocess, json, re
+
+# Get merged PRs
+result = subprocess.run(
+    ['gh', 'pr', 'list', '--repo',
+     subprocess.check_output(['git','remote','get-url','origin'],text=True).strip()
+                            .split('github.com')[-1].strip(':/'),
+     '--state', 'merged', '--json', 'number,title,mergedAt', '--limit', '200'],
+    capture_output=True, text=True
+)
+
+prs = json.loads(result.stdout) if result.returncode == 0 else []
+features = {}
+for pr in prs:
+    key = f"pr-{pr['number']}"
+    features[key] = {
+        "state": "done",
+        "assigned_to": None,
+        "pr_number": pr['number'],
+        "pr_merged": True,
+        "title": pr['title'][:60]
+    }
+
+# Also add any .specify/specs/ directories
+import os
+specs_dir = '.specify/specs'
+if os.path.isdir(specs_dir):
+    for spec in sorted(os.listdir(specs_dir)):
+        if os.path.isdir(os.path.join(specs_dir, spec)):
+            key = f"spec-{spec}"
+            if key not in features:
+                features[key] = {
+                    "state": "done",
+                    "assigned_to": None,
+                    "pr_number": None,
+                    "pr_merged": True,
+                    "title": spec
+                }
+
+import datetime
+state = {
+    "version": "1.2",
+    "project": os.path.basename(os.getcwd()),
+    "mode": "standalone",
+    "initialized": datetime.datetime.utcnow().strftime('%Y-%m-%d'),
+    "last_updated": datetime.datetime.utcnow().strftime('%Y-%m-%d'),
+    "current_queue": None,
+    "last_sm_review": None,
+    "last_pm_review": None,
+    "batches_since_competitive_analysis": 0,
+    "session_heartbeats": {},
+    "features": features
+}
+
+with open('.otherness/state.json', 'w') as f:
+    json.dump(state, f, indent=2)
+
+print(f"Seeded state.json with {len(features)} done items")
+EOF
+```
+
+---
+
+## STEP 6 — Create `otherness-config.yaml` if not present
+
+```bash
+if [ ! -f "otherness-config.yaml" ]; then
+  REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
+  PR_LABEL=$(python3 -c "
+import re
+for line in open('AGENTS.md'):
+    m = re.match(r'^PR_LABEL:\s*(\S+)', line.strip())
+    if m: print(m.group(1)); break
+" 2>/dev/null || basename $(git rev-parse --show-toplevel))
+  REPORT_ISSUE=$(python3 -c "
+import re
+for line in open('AGENTS.md'):
+    m = re.match(r'^REPORT_ISSUE:\s*(\S+)', line.strip())
+    if m: print(m.group(1)); break
+" 2>/dev/null || echo "TBD")
+
+cat > otherness-config.yaml << YAML
+# otherness config — edit board field IDs after creating the GitHub Projects board
+project:
+  name: $(basename $(git rev-parse --show-toplevel))
+  repo: $REPO
+  report_issue: $REPORT_ISSUE
+  board_url: ""
+  pr_label: "$PR_LABEL"
+
+maqa:
+  mode: standalone
+  agents_path: ~/.otherness/agents
+  status_update_cycles: 5
+  product_validation_cycles: 3
+
+ci:
+  provider: github-actions
+  github_actions:
+    workflow: ci.yml
+  wait_timeout_seconds: 1200
+  block_on_red: true
+
+github_projects:
+  project_id: ""
+  project_number: ""
+  linked_repo: $REPO
+  status_field_id: ""
+  todo_option_id: ""
+  in_progress_option_id: ""
+  in_review_option_id: ""
+  done_option_id: ""
+  blocked_option_id: ""
+  team_field_id: ""
+  team_standalone_option_id: ""
+  priority_field_id: ""
+  priority_critical_option_id: ""
+  priority_high_option_id: ""
+  priority_medium_option_id: ""
+  priority_low_option_id: ""
+  size_field_id: ""
+  size_xs_option_id: ""
+  size_s_option_id: ""
+  size_m_option_id: ""
+  size_l_option_id: ""
+  size_xl_option_id: ""
+  start_date_field_id: ""
+  target_date_field_id: ""
+YAML
+  echo "Created otherness-config.yaml — fill in board field IDs after creating the GitHub Projects board"
+fi
+```
+
+---
+
+## STEP 7 — Open a PR for human review
+
+```bash
+REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
+BRANCH="otherness-onboard"
+
+git checkout -b "$BRANCH"
+git add docs/aide/ .otherness/state.json otherness-config.yaml
+git commit -m "chore: otherness onboarding — add docs/aide, state.json, config"
+git push origin "$BRANCH"
+
+gh pr create --repo $REPO \
+  --base main \
+  --head "$BRANCH" \
+  --title "chore: otherness onboarding" \
+  --body "## Otherness Onboarding
+
+This PR was generated by \`/otherness.onboard\`.
+
+### What's in this PR
+
+- \`docs/aide/vision.md\` — product vision (auto-generated, please review)
+- \`docs/aide/roadmap.md\` — staged roadmap (auto-generated, please review)
+- \`docs/aide/definition-of-done.md\` — user journeys (auto-generated, please review)
+- \`docs/aide/progress.md\` — current progress snapshot
+- \`.otherness/state.json\` — state seeded with all merged PRs as done
+- \`otherness-config.yaml\` — project config (fill in board field IDs if using GitHub Projects)
+
+### What to review
+
+1. Read \`docs/aide/vision.md\` — does it accurately describe the product?
+2. Read \`docs/aide/roadmap.md\` — are the stages correct? Is anything missing?
+3. Read \`docs/aide/definition-of-done.md\` — are these the right user journeys?
+4. Check \`.otherness/state.json\` — are all listed items truly done?
+
+### After merging
+
+1. Create the GitHub report issue (see onboarding-existing-project.md Step 9)
+2. Create GitHub labels (kind/*, area/*, priority/*, size/*)
+3. Update \`otherness-config.yaml\` with board field IDs if using GitHub Projects
+4. Run \`/otherness.run\`
+
+The agent will read these files and generate the first queue automatically."
+```
+
+---
+
+## STEP 8 — Report
+
+Post a summary of what was generated. Include:
+- Files created
+- Number of done items seeded in state.json
+- Anything that needs human review before merging
+- The PR URL
+
+**Exit.** Your job is done. The human reviews and merges the PR, then runs `/otherness.run`.

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -322,16 +322,18 @@ Read these — in order, no skipping. Keep it fast: skim what you know, read car
 1. `AGENTS.md` — identity, commands, anti-patterns, label taxonomy (most important)
 2. `.otherness/state.json` — queue, in-flight items, handoff note
 3. `docs/aide/vision.md` — product intent
-4. `docs/design/10-graph-first-architecture.md` — architecture rules
-5. `docs/design/11-graph-purity-tech-debt.md` — what is and isn't blocked
-6. `.specify/memory/constitution.md` — behavioral rules
-7. `.specify/memory/sdlc.md` — process loops
-8. `~/.otherness/agents/gh-features.md`
+4. `.specify/memory/constitution.md` — behavioral rules (if present)
+5. `~/.otherness/agents/gh-features.md`
+
+**Project-specific architecture docs**: after reading `AGENTS.md`, follow any
+architecture doc references it lists (e.g. a "must read before implementing"
+section, anti-patterns table, or design doc links). Every project is different —
+AGENTS.md is the authoritative map. Do not assume any specific file path.
 
 **Only read the remaining docs when they're relevant to your current item:**
 - `docs/aide/roadmap.md`, `docs/aide/definition-of-done.md` — when generating a queue
-- `docs/concepts.md`, `docs/policy-gates.md`, `docs/pipeline-reference.md` — when implementing a feature
-- Other `docs/design/*.md` — when implementing something in that design area
+- User-facing docs referenced in AGENTS.md — when implementing a user-facing feature
+- Any `docs/design/*.md` referenced in AGENTS.md — when implementing in that area
 
 **After reading:**
 ```bash
@@ -503,15 +505,15 @@ All work happens in $MY_WORKTREE on branch $MY_BRANCH.
 2a. SPEC-FIRST: generate/verify spec.md + tasks.md in .specify/specs/<item-id>/.
 
     CONCEPT CONSISTENCY CHECK before writing the spec:
-    1. Extends existing CRD or new one? If new: is a field addition sufficient?
-    2. Existing pattern in codebase to follow?
-    3. CEL component? Use project's existing CEL namespaces (read AGENTS.md).
-    4. New reconciler needed? Answer Watch/Owned/Extension questions from AGENTS.md.
-    5. API naming matches docs/pipeline-reference.md and docs/policy-gates.md?
+    1. Does an existing abstraction already cover this? If so, extend it rather than adding a new one.
+    2. What existing patterns in the codebase should this follow? (search for similar features)
+    3. Re-read AGENTS.md §Anti-Patterns — does this feature risk introducing any of them?
+    4. Does any architecture constraint doc (referenced in AGENTS.md) apply to this feature?
+    5. Does the API/interface naming match the project's existing user-facing docs?
 
-2b. DOC-FIRST: verify/create user-facing doc page before writing Go.
+2b. DOC-FIRST: verify/create user-facing doc page before writing code.
 
-2c. GRAPH-FIRST: re-read docs/design/10-graph-first-architecture.md.
+2c. ARCHITECTURE-FIRST: re-read any architecture constraint docs listed in AGENTS.md.
     Re-read AGENTS.md §Anti-Patterns.
 
 2d. Implement TDD: test first, then code. All in $MY_WORKTREE.
@@ -607,5 +609,5 @@ are ✅ validated live AND human confirms project complete.
 - **Think harder before escalating.** Re-read design docs, search codebase, check issue thread, look at similar PRs.
 - Never exit because the backlog is empty. Find work.
 - Adversarial QA. TDD always. Merge mandatory. Max 3 QA cycles.
-- No new logic leaks without human approval.
+- No anti-patterns (per AGENTS.md) without human approval.
 - Perfection is the direction, not the destination.

--- a/onboarding-existing-project.md
+++ b/onboarding-existing-project.md
@@ -220,9 +220,13 @@ Options:
 
 ---
 
-## Step 7 — Seed `.maqa/state.json`
+## Step 7 — Seed `.otherness/state.json`
 
 The state file must exist before agents start. Create it with the correct current state — mark completed stages as done:
+
+```bash
+mkdir -p .otherness
+```
 
 ```json
 {
@@ -235,16 +239,12 @@ The state file must exist before agents start. Create it with the correct curren
   "last_sm_review": null,
   "last_pm_review": null,
   "batches_since_competitive_analysis": 0,
-  "batches_since_doc_audit": 0,
-  "batches_since_dead_scan": 0,
-  "session_heartbeats": {
-    "STANDALONE":  {"last_seen": null, "cycle": 0}
-  },
-    "features": {
+  "session_heartbeats": {},
+  "features": {
     "<already-completed-item-id>": {
       "state": "done",
       "assigned_to": null,
-      "pr_number": <pr-number>,
+      "pr_number": "<pr-number>",
       "pr_merged": true
     }
   }
@@ -252,6 +252,17 @@ The state file must exist before agents start. Create it with the correct curren
 ```
 
 **Important**: every item that was already implemented before adopting otherness should be listed as `"state": "done"` in `features`. Otherwise the coordinator will re-implement them.
+
+**Tip — auto-seed from merged PRs**: for projects with many merged PRs, generate
+the features map automatically rather than writing it by hand:
+
+```bash
+gh pr list --repo my-org/my-project --state merged \
+  --json number,title --jq \
+  '[.[] | {"key": ("pr-\(.number)"), "value": {"state":"done","assigned_to":null,"pr_number":.number,"pr_merged":true}}] | from_entries'
+```
+
+Pipe that into the `features` key of `state.json`.
 
 ---
 
@@ -287,7 +298,7 @@ cat docs/aide/roadmap.md
 cat docs/aide/definition-of-done.md
 cat AGENTS.md | grep -E "PROJECT_NAME|CLI_BINARY|BUILD_COMMAND|TEST_COMMAND"
 cat otherness-config.yaml
-cat .maqa/state.json | python3 -m json.tool > /dev/null && echo "state.json: valid JSON"
+cat .otherness/state.json | python3 -m json.tool > /dev/null && echo "state.json: valid JSON"
 
 # Check build and test commands work
 eval "$(grep BUILD_COMMAND AGENTS.md | cut -d: -f2- | xargs)"

--- a/onboarding-new-project.md
+++ b/onboarding-new-project.md
@@ -456,11 +456,13 @@ otherness-config.yaml                  ← required (mode, CI, board field IDs)
 docs/aide/vision.md                    ← required (what you're building)
 docs/aide/roadmap.md                   ← required (stages)
 docs/aide/definition-of-done.md       ← required (acceptance criteria)
-docs/aide/progress.md                  ← required (seed with empty tables)
-docs/aide/team.yml                     ← required (source of truth list)
-.specify/memory/constitution.md        ← required (agent behavioral rules)
-.specify/memory/sdlc.md               ← required (process definition)
-.maqa/state.json                       ← required (seed with empty state)
+.otherness/state.json                  ← required (seed with empty state)
 ```
 
 Without any of these, agents will either crash or produce wrong behavior.
+
+**Not required to start** (agents will work without them, or will generate them):
+- `docs/aide/team.yml` — generic boilerplate, not read by runtime agents
+- `docs/aide/pr-template.md` — optional, agents open PRs without it
+- `.specify/memory/constitution.md` — recommended but gracefully absent; agent reads AGENTS.md instead
+- `.specify/memory/sdlc.md` — the process is embedded in `standalone.md`; this file is for the old multi-session model


### PR DESCRIPTION
## What

Three categories of changes to make otherness 100% generic — usable on any project without modification.

## 1. `agents/standalone.md` — remove hardcoded kardinal paths

**Problem**: the reading order hardcoded kardinal-specific files:
- `docs/design/10-graph-first-architecture.md`
- `docs/design/11-graph-purity-tech-debt.md`
- `docs/concepts.md`, `docs/policy-gates.md`, `docs/pipeline-reference.md`

These don't exist in kro-ui or any other project. Running standalone on a new project would fail silently (files not found) and the agent would skip critical architectural context.

**Fix**: reading order now reads `AGENTS.md` first and follows whatever architecture docs it references. Generic, project-agnostic.

Also fixed:
- CONCEPT CONSISTENCY CHECK (Phase 2a): was CRD/CEL/reconciler specific → now generic
- Phase 2b/2c: removed `writing Go` and `GRAPH-FIRST` (kardinal concepts) → generic language
- Hard rules: `No new logic leaks` → `No anti-patterns (per AGENTS.md)`

## 2. `agents/onboard.md` — new one-shot onboarding agent

**Problem**: `onboarding-existing-project.md` says *"This is the hardest part of adopting otherness on an existing project"* about writing `docs/aide/` files — and then just tells you to write them by hand.

**Fix**: new `/otherness.onboard` command that:
1. Reads README, AGENTS.md, constitution, Makefile, CI config, git log, merged PRs, open issues, existing specs
2. Generates `docs/aide/vision.md`, `roadmap.md`, `definition-of-done.md`, `progress.md` as drafts
3. Auto-seeds `.otherness/state.json` from merged PRs (no manual JSON writing)
4. Creates `otherness-config.yaml` if missing
5. Opens a PR for human review

The human reviews the drafts, merges, then runs `/otherness.run`. The "hardest part" becomes a 5-minute review instead of hours of manual writing.

## 3. Docs fixes

- `onboarding-existing-project.md`: `.maqa/state.json` → `.otherness/state.json` (stale path). Add auto-seed tip.
- `onboarding-new-project.md`: minimum viable file set reduced from 10 to 6. `team.yml`, `pr-template.md`, `constitution.md`, `sdlc.md` are not read by runtime agents.
- `README.md`: two `.maqa/state.json` → `.otherness/state.json` fixes.

## Tested on

kro-ui (`pnz1990/kro-ui`) — a React+Go project with 70+ merged specs. The generic standalone.md reads AGENTS.md and adapts to the project's architecture docs without any project-specific changes to the agent file.