### PR TITLE
fix(tooling): add missing .opencode/command/otherness.onboard.md command entrypoint

### DIFF
--- a/.opencode/command/otherness.onboard.md
+++ b/.opencode/command/otherness.onboard.md
@@ -1,0 +1,18 @@
+---
+description: "One-shot onboarding for existing projects — reads the codebase, generates docs/aide/ drafts and seeds state.json, opens a PR for review. Run once before /otherness.run."
+---
+
+```bash
+AGENTS_PATH=$(python3 -c "
+import re, os
+section = None
+for line in open('otherness-config.yaml'):
+    s = re.match(r'^(\w[\w_]*):', line)
+    if s: section = s.group(1)
+    if section == 'maqa':
+        m = re.match(r'^\s+agents_path:\s*[\"\'']?([^\"\'#\n]+)[\"\'']?', line)
+        if m: print(os.path.expanduser(m.group(1).strip())); break
+" 2>/dev/null || echo "$HOME/.otherness/agents")
+```
+
+Read and follow `$AGENTS_PATH/onboard.md`.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -65,6 +65,12 @@ REQUIRED=(
   "$(cd "$(dirname "$0")/.." && pwd)/docs/aide/vision.md"
   "$(cd "$(dirname "$0")/.." && pwd)/docs/aide/roadmap.md"
   "$(cd "$(dirname "$0")/.." && pwd)/docs/aide/definition-of-done.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.run.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.onboard.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.setup.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.status.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.upgrade.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.learn.md"
 )
 MISSING_FILES=0
 for f in "${REQUIRED[@]}"; do


### PR DESCRIPTION
## Problem

`agents/onboard.md` exists and README.md documents `/otherness.onboard` as a user-facing command, but `.opencode/command/otherness.onboard.md` was missing. Running `/otherness.onboard` from OpenCode would fail with a command-not-found error.

Caught by PM validation Scenario 4 (README vs .opencode/command/).

## Fix

- Add `.opencode/command/otherness.onboard.md` following the same pattern as `otherness.run.md` (thin wrapper that reads `agents/onboard.md`)
- Extend `scripts/validate.sh` required files list to include all 6 command files, so this class of gap is caught in CI automatically

## Risk tier

`.opencode/command/` and `scripts/validate.sh` — **LOW tier**. No runtime impact on deployed agent behavior.

## Validation

- `bash scripts/validate.sh` — PASSED
- `bash scripts/lint.sh` — PASSED

Closes #12