### PR TITLE
feat(skills): add agents/skills/README.md — skill index with load guidance

### DIFF
--- a/agents/skills/README.md
+++ b/agents/skills/README.md
@@ -1,0 +1,54 @@
+# Skills Index
+
+This directory contains reusable skill files loaded by the agent during the loop.
+
+Skills are **additive only** — never delete content from a skill file (see constitution §IV).
+
+## When to load each skill
+
+| Skill file | Load when | Phase |
+|---|---|---|
+| `declaring-designs.md` | Writing or evaluating a `spec.md` | Phase 2a (ENG — SPEC-FIRST) |
+| `agent-coding-discipline.md` | About to write or modify code | Phase 2d (ENG — TDD) |
+| `reconciling-implementations.md` | Reviewing a PR as QA | Phase 3 (QA — ADVERSARIAL REVIEW) |
+| `autonomous-workflow-patterns.md` | Designing a multi-step feature or reviewing workflow logic | Phase 2a, 2d, or 3 |
+
+## Skill summaries
+
+### `declaring-designs.md`
+Spec quality standard. Defines the three-zone structure (Obligations / Implementer's judgment /
+Scoped out), 11 properties every spec must have, gap classification (WRONG / STALE), and the
+spec template. Use this to write specs and to evaluate whether an existing spec is good enough
+to implement from.
+
+### `agent-coding-discipline.md`
+Surgical changes and verifiable goals. Three principles: touch only what the task requires;
+write the minimum code that satisfies the spec; define a concrete success criterion before
+writing a line. Addresses the most common autonomous coding failure modes: over-building,
+over-refactoring, shipping without verifiable completion.
+
+### `reconciling-implementations.md`
+QA checklist in priority order: Correctness → Performance → Observability → Testing → Simplicity.
+Gap classification: WRONG (fix code), STALE (surface to human), SMELL (fix code), MISS (new issue).
+Approval and request-changes criteria. Live-cluster coverage gate for user journeys.
+
+### `autonomous-workflow-patterns.md`
+Workflow design patterns from Archon (YAML workflow engine). Transferable to otherness markdown
+loops: deterministic vs AI nodes, human approval as first-class gate, context refresh in long
+loops, failure handling. Use when designing how a multi-step feature should be broken down.
+
+## `PROVENANCE.md`
+Audit trail of `/otherness.learn` sessions. Records what was learned, from which repo, on what
+date, and what was accepted vs rejected. Not a skill — do not load it as one. Read it to
+understand what learning has already been done.
+
+## Growing the skills library
+
+New skills are added by running `/otherness.learn` against high-signal open-source repos.
+Each new skill must meet the quality gate:
+- **Specific**: describes a concrete pattern, not general advice
+- **Falsifiable**: a reader can identify behavior that violates the skill
+- **Novel**: not already captured in an existing skill
+- **Transferable**: applies to otherness on any project, not just the source repo
+
+After adding a new skill, append an entry to `PROVENANCE.md`.


### PR DESCRIPTION
## What

Adds `agents/skills/README.md` — the skill index from docs/aide/roadmap.md Stage 2 deliverable.

## Contents

- Table: all 4 skills, when to load each, which agent phase
- One-paragraph summary of each skill
- Guidance on growing the skills library (quality gate criteria)
- Note on PROVENANCE.md (not a skill, audit trail)

## Risk tier

`agents/skills/README.md` — **MEDIUM tier**. Additive knowledge. No runtime impact.

## Validation

- `bash scripts/validate.sh` — PASSED
- `bash scripts/lint.sh` — PASSED

Closes #11