### PR TITLE
feat(skills): learn session — crewAI patterns → new skill + 2 new sections

### DIFF
--- a/agents/skills/PROVENANCE.md
+++ b/agents/skills/PROVENANCE.md
@@ -98,3 +98,33 @@ jo-inc/camofox-browser (irrelevant)
 
 **standalone.md changes:**
 - Phase 2d: load agent-coding-discipline skill, add surgical changes and verifiable goals checkpoints
+
+---
+
+## 2026-04-14 — crewAIInc/crewAI (automated learn session, issue #21)
+
+**Files read:**
+- `README.md` (full — 48,000 chars)
+- `docs.crewai.com` — Crews vs Flows architecture overview
+
+**Repos assessed:** 3 (microsoft/autogen — maintenance mode, less signal; langchain-ai/langchain — too broad; crewAIInc/crewAI — highest signal for this session)
+
+**Patterns extracted:** 3
+
+**Disposition:**
+
+- `autonomy-precision-spectrum` → EXTENDED_SKILL (agents/skills/autonomous-workflow-patterns.md §Autonomy-Precision Spectrum)
+  Crews (autonomous, uncertain path) vs Flows (precise, event-driven). Key insight: choose per step, not per system. Maps directly to otherness's coordinator (flow-like) vs engineer/QA (crew-like) phases. Added with concrete otherness-specific routing pattern.
+
+- `conditional-routing-on-state` → EXTENDED_SKILL (agents/skills/autonomous-workflow-patterns.md §Conditional Routing on State)
+  Route on structured state values (confidence level, counts), not just binary pass/fail. Directly applicable to improving coordinator queue-empty handling. Added with concrete bash routing pattern.
+
+- `role-identity-trinity` → NEW_SKILL (agents/skills/role-based-agent-identity.md)
+  role + goal + backstory as a three-part constraint on agent judgment, not just a label. Backstory calibrates how the agent resolves ambiguous cases. Includes: tools-vs-tasks separation, concrete phase identity pattern for otherness.
+
+**Rejected patterns:**
+
+- `telemetry-collection-design` (CrewAI) — not transferable: specific to Python framework usage tracking; not relevant to otherness's markdown/git-based operation
+- `uv-over-pip-install` (CrewAI) — not transferable: Python packaging toolchain choice; otherness has no Python packages
+- `crew-control-plane-architecture` (CrewAI AMP) — not transferable: requires a persistent service layer; otherness is stateless by design
+- `role-backstory-as-persona` (CrewAI) — partially captured; the persona aspect (flavor text) was excluded; only the judgment-calibration aspect was extracted

--- a/agents/skills/README.md
+++ b/agents/skills/README.md
@@ -12,6 +12,7 @@ Skills are **additive only** — never delete content from a skill file (see con
 | `agent-coding-discipline.md` | About to write or modify code | Phase 2d (ENG — TDD) |
 | `reconciling-implementations.md` | Reviewing a PR as QA | Phase 3 (QA — ADVERSARIAL REVIEW) |
 | `autonomous-workflow-patterns.md` | Designing a multi-step feature or reviewing workflow logic | Phase 2a, 2d, or 3 |
+| `role-based-agent-identity.md` | Writing or improving agent instructions (standalone.md, onboard.md) | Phase 4 (SM) or when updating agent files |
 
 ## Skill summaries
 
@@ -33,9 +34,15 @@ Gap classification: WRONG (fix code), STALE (surface to human), SMELL (fix code)
 Approval and request-changes criteria. Live-cluster coverage gate for user journeys.
 
 ### `autonomous-workflow-patterns.md`
-Workflow design patterns from Archon (YAML workflow engine). Transferable to otherness markdown
+Workflow design patterns from Archon and CrewAI. Transferable to otherness markdown
 loops: deterministic vs AI nodes, human approval as first-class gate, context refresh in long
 loops, failure handling. Use when designing how a multi-step feature should be broken down.
+
+### `autonomous-workflow-patterns.md`
+Workflow design patterns from Archon and CrewAI. Covers: human approval as a named gate vs emergency stop; deterministic vs AI steps; context refresh in long loops; single registry for extension points; autonomy-precision spectrum (crews vs flows); conditional routing on state values. Use when deciding how to structure a multi-step implementation.
+
+### `role-based-agent-identity.md`
+Role identity patterns from CrewAI. The role+goal+backstory trinity as a behavior constraint (not just a label). Backstory calibrates agent judgment on ambiguous cases. Roles vs tools vs task contracts. Use when writing or improving agent phase instructions to ensure consistent behavior across diverse inputs.
 
 ## `PROVENANCE.md`
 Audit trail of `/otherness.learn` sessions. Records what was learned, from which repo, on what

--- a/agents/skills/autonomous-workflow-patterns.md
+++ b/agents/skills/autonomous-workflow-patterns.md
@@ -1,7 +1,9 @@
 # Skill: Autonomous Workflow Patterns
 
 <!-- provenance: coleam00/Archon, README.md, 2026-04-14 -->
+<!-- provenance: crewAIInc/crewAI, README.md, 2026-04-14 -->
 <!-- otherness-learn: Archon's YAML workflow model; human approval as first-class gate; deterministic vs AI nodes; context refresh in long loops -->
+<!-- otherness-learn: CrewAI's autonomy-precision spectrum; Crews vs Flows; conditional routing on state -->
 
 Load this skill when designing or reviewing how a feature is implemented across multiple steps.
 
@@ -95,3 +97,67 @@ The anti-pattern it prevents: dispatch logic scattered across multiple files, wh
 Applied to the ALIBI project: the 14 clue type evaluators are defined as a registry in `src/engine/clues.ts`. The generator, the solver, the QA checklist, and the Playwright test suite all reference the same type names. If a new clue type is added, it is added to the registry once, and all consumers automatically handle it.
 
 This is not just an architecture tip — it is a correctness property: an entity that exists in the registry but not in all consumers is a bug.
+
+---
+
+## Autonomy-Precision Spectrum: Choose Per Step <!-- provenance: crewAIInc/crewAI, README.md, 2026-04-14 -->
+
+CrewAI distinguishes two execution modes:
+
+- **Crews** (autonomous): agents collaborate dynamically, delegate to each other, and decide how to solve a problem. Use when the path to the output is genuinely uncertain.
+- **Flows** (precise): deterministic event-driven steps with exact state transitions and conditional routing. Use when the execution path must be controlled and reproducible.
+
+The key insight: **both are needed, and the choice is per-step, not per-system.**
+
+```python
+# Crews: for uncertain problem-solving (agent decides how)
+@listen(fetch_data)
+def analyze_with_crew(self, data):
+    crew = Crew(agents=[analyst, researcher], tasks=[...])
+    return crew.kickoff(inputs=data)
+
+# Flows: for routing on outcome (precise control)
+@router(analyze_with_crew)
+def route_on_confidence(self):
+    if self.state.confidence > 0.8:
+        return "high_confidence"
+    return "low_confidence"
+```
+
+**The otherness implication:** The coordinator (Phase 1) and SM/PM phases are Flows — their behavior must be deterministic given the same state. The engineer (Phase 2) and QA (Phase 3) are Crews — they require genuine agent judgment. When a step in the loop feels "wrong," ask: is this step in the wrong mode? A deterministic step that uses AI judgment will produce inconsistent results. An AI judgment step with hard-coded behavior will fail on novel inputs.
+
+**Concrete check for otherness items:** Before implementing, classify each task step:
+- If you can write an exact command that will always produce the correct result → command step (deterministic)
+- If the right action depends on reading the specific content → AI step (agent judgment)
+
+Mixing these two types in the same "step" is the source of most agent loop inconsistencies.
+
+---
+
+## Conditional Routing on State, Not Just Success/Failure <!-- provenance: crewAIInc/crewAI, README.md, 2026-04-14 -->
+
+In CrewAI Flows, routing decisions are made on **structured state values**, not just pass/fail:
+
+```python
+@router(analyze_with_crew)
+def determine_next_steps(self):
+    if self.state.confidence > 0.8:
+        return "high_confidence"
+    elif self.state.confidence > 0.5:
+        return "medium_confidence"
+    return "low_confidence"
+```
+
+This is richer than binary success/failure because it allows the workflow to adapt to the *degree* of success.
+
+**The otherness implication:** The coordinator's item selection already does this implicitly (state=todo vs assigned vs in_review vs done). But the routing logic for "what to do when queue is empty" currently branches only on count=0. Consider: an empty queue due to all items being done is different from an empty queue due to all items being in_review waiting for CI, which is different from all items being needs-human.
+
+**Concrete pattern for otherness coordinator:**
+```bash
+# Not just "is the queue empty?" — but "why is it empty?"
+if   [ $TODO_COUNT   -gt 0 ]; then  # claim next item
+elif [ $REVIEW_COUNT -gt 0 ]; then  # wait for CI, check for mergeability
+elif [ $BLOCKED_COUNT -gt 0 ]; then # post [STANDALONE] BLOCKED, wait for human
+else                                # queue truly empty — generate next batch
+fi
+```

--- a/agents/skills/role-based-agent-identity.md
+++ b/agents/skills/role-based-agent-identity.md
@@ -1,0 +1,69 @@
+# Skill: Role-Based Agent Identity
+
+<!-- provenance: crewAIInc/crewAI, README.md + docs.crewai.com, 2026-04-14 -->
+<!-- otherness-learn: CrewAI's role+goal+backstory trinity; role identity as behavior constraint; description vs identity -->
+
+Load this skill when writing agent instructions (standalone.md, bounded-standalone.md, onboard.md)
+or when designing a new agent phase or role.
+
+---
+
+## The Role Identity Trinity <!-- provenance: crewAIInc/crewAI, README.md, 2026-04-14 -->
+
+CrewAI gives each agent three identity fields:
+
+```yaml
+researcher:
+  role: "{topic} Senior Data Researcher"
+  goal: "Uncover cutting-edge developments in {topic}"
+  backstory: "You're a seasoned researcher with a knack for finding the most
+              relevant information and presenting it clearly."
+```
+
+These three fields work together:
+- **Role**: what the agent *is* (a noun phrase, not a verb phrase)
+- **Goal**: what the agent is trying to achieve (measurable, specific)
+- **Backstory**: how the agent's past shapes its judgment (gives it a perspective, not just a task)
+
+The backstory is the surprising one. It is not just flavor text. It calibrates the agent's *judgment* — the decisions it makes when the spec does not specify exactly what to do. An agent with "You're known for finding the most relevant information" will reject tangential findings. An agent with "You excel at comprehensive coverage" will include everything.
+
+**The otherness implication:** otherness's phase headers (`[🎯 COORD]`, `[🔨 ENG]`, `[🔍 QA]`, etc.) are role labels but are missing explicit goals and backstory. When the agent needs to make a judgment call — e.g., "should I open a follow-up issue or fix it in this PR?" — it has no backstory to anchor the decision.
+
+---
+
+## Role Identity as Behavior Constraint, Not Just Label <!-- provenance: crewAIInc/crewAI, README.md, 2026-04-14 -->
+
+The role+goal+backstory trinity is a *constraint* on behavior, not just a description. Two agents with the same task but different identities will make different judgment calls:
+
+| Identity | Same task: "review a PR" | Different outcome |
+|---|---|---|
+| "Senior QA with zero-tolerance for regressions" | Blocks on any test missing | More rejections |
+| "Pragmatic reviewer focused on shipping velocity" | Approves with follow-up items | More approvals |
+
+Neither is wrong — the identity tells the agent *how to weight* the tradeoffs.
+
+**The otherness implication:** The QA phase has a clear identity ("adversarial"), but the coordinator's identity is underspecified. When the coordinator is unsure whether to claim an item or wait, what backstory shapes that judgment? Defining it explicitly would produce more consistent behavior.
+
+**Concrete pattern for otherness:** Each phase in standalone.md could have an explicit identity block at its header:
+
+```
+[🔍 QA] — ADVERSARIAL REVIEWER
+Role: Adversarial QA engineer
+Goal: Find reasons to REJECT. Every merged bug is a failure.
+Backstory: You have been burned by rushed merges. You now assume every PR
+           has at least one correctness bug until proven otherwise.
+```
+
+This is not required today, but if the QA phase is producing inconsistent reviews (sometimes blocking on smells, sometimes not), adding explicit backstory is the lever to tune it.
+
+---
+
+## Roles Do Not Own Tools; Tasks Do <!-- provenance: crewAIInc/crewAI, docs, 2026-04-14 -->
+
+In CrewAI, tools are assigned to agents at the role level, but a task's `expected_output` determines what the agent must actually produce. The role shapes *how* the agent works; the task contract shapes *what* it delivers.
+
+This separation prevents a common failure: an agent with broad tool access and a vague task produces whatever it finds most interesting, not what was asked for.
+
+**The otherness implication:** The spec obligation (declaring-designs skill, Zone 1) is the "expected_output" equivalent. Without it, the engineer produces what seems most interesting. The spec obligation anchors the output, independent of what tools or approaches the agent chooses.
+
+**Concrete check:** Every Phase 2 task must have: (1) a spec with at least one falsifiable obligation, and (2) a concrete success criterion stated in tasks.md before writing code. If these are missing, the engineer will optimize for something other than the spec.


### PR DESCRIPTION
## /otherness.learn session — crewAIInc/crewAI

Studied crewAIInc/crewAI (48k stars, production multi-agent framework).

**New skill:** `role-based-agent-identity.md`
- Role+goal+backstory trinity as behavior constraint
- Backstory calibrates agent judgment on ambiguous cases
- Tools vs roles vs task contracts separation

**Extended:** `autonomous-workflow-patterns.md`
- Autonomy-precision spectrum: choose crew (uncertain) vs flow (precise) per step
- Conditional routing on state values, not just binary pass/fail

**Updated:** PROVENANCE.md, skills/README.md

Skills count: 4 → 5. **MEDIUM tier** — skills only. Autonomous merge.

Closes #21