### PR TITLE
feat(skills): learn session — LangChain patterns → new skill + 2 extensions

### DIFF
--- a/agents/skills/PROVENANCE.md
+++ b/agents/skills/PROVENANCE.md
@@ -128,3 +128,36 @@ jo-inc/camofox-browser (irrelevant)
 - `uv-over-pip-install` (CrewAI) — not transferable: Python packaging toolchain choice; otherness has no Python packages
 - `crew-control-plane-architecture` (CrewAI AMP) — not transferable: requires a persistent service layer; otherness is stateless by design
 - `role-backstory-as-persona` (CrewAI) — partially captured; the persona aspect (flavor text) was excluded; only the judgment-calibration aspect was extracted
+
+---
+
+## 2026-04-14 — langchain-ai/langchain (automated learn session, feat/learn-langchain)
+
+**Files read:**
+- `AGENTS.md` (full — global development guidelines, 6,000+ chars)
+
+**Repos assessed:** 1 (langchain-ai/langchain — highest-signal general AI framework with detailed AGENTS.md)
+
+**Patterns extracted:** 3
+
+**Disposition:**
+
+- `ai-disclosure-in-prs` → NEW_SKILL (agents/skills/contribution-hygiene.md §AI Disclosure in Every PR)
+  LangChain requires AI contributors to add a disclosure footer to every PR. Directly applicable to otherness — every standalone agent PR should identify itself as AI-generated. Added with exact footer text.
+
+- `commit-scope-enforcement` → NEW_SKILL (agents/skills/contribution-hygiene.md §Commit Scope Is Not Optional)
+  LangChain: "All PR titles must include a scope with no exceptions." Otherness already uses conventional commits but doesn't enforce scope strictly. Added concrete check.
+
+- `stable-interface-gate` → EXTENDED_SKILL (agents/skills/reconciling-implementations.md §Stable Interface Gate)
+  LangChain: "Always attempt to preserve function signatures for exported/public methods." Maps to otherness's state.json field stability and agent command interface stability. Added as a QA approval gate for PRs that rename/remove public fields.
+
+**Also extracted to contribution-hygiene.md:**
+- `pr-description-why-not-what` — describe the why of changes, not what the diff contains
+- `remove-dead-code-before-commit` — AI agents often leave commented-out prior approaches
+
+**Rejected patterns:**
+
+- `monorepo-layer-architecture` (LangChain) — not transferable: requires a multi-package Python monorepo; otherness is a single markdown repo
+- `model-profiles-cli` (LangChain) — not transferable: specific to LLM model capability tracking; otherness doesn't manage LLM models
+- `uv-workspace-management` (LangChain) — not transferable: Python-specific dependency management
+- `pr-labeler-config` (LangChain) — partially interesting for otherness label taxonomy, but already solved with gh label commands; deferred

--- a/agents/skills/README.md
+++ b/agents/skills/README.md
@@ -13,6 +13,7 @@ Skills are **additive only** — never delete content from a skill file (see con
 | `reconciling-implementations.md` | Reviewing a PR as QA | Phase 3 (QA — ADVERSARIAL REVIEW) |
 | `autonomous-workflow-patterns.md` | Designing a multi-step feature or reviewing workflow logic | Phase 2a, 2d, or 3 |
 | `role-based-agent-identity.md` | Writing or improving agent instructions (standalone.md, onboard.md) | Phase 4 (SM) or when updating agent files |
+| `contribution-hygiene.md` | Opening a PR or writing a commit message | Phase 2f (ENG — before gh pr create) |
 
 ## Skill summaries
 
@@ -43,6 +44,9 @@ Workflow design patterns from Archon and CrewAI. Covers: human approval as a nam
 
 ### `role-based-agent-identity.md`
 Role identity patterns from CrewAI. The role+goal+backstory trinity as a behavior constraint (not just a label). Backstory calibrates agent judgment on ambiguous cases. Roles vs tools vs task contracts. Use when writing or improving agent phase instructions to ensure consistent behavior across diverse inputs.
+
+### `contribution-hygiene.md`
+PR and commit discipline patterns from LangChain. Covers: AI disclosure footer required in every AI-opened PR; conventional commit scope enforcement (scope is not optional); PR body should explain why not what; dead code removal before committing. Load before opening any PR or writing commit messages.
 
 ## `PROVENANCE.md`
 Audit trail of `/otherness.learn` sessions. Records what was learned, from which repo, on what

--- a/agents/skills/contribution-hygiene.md
+++ b/agents/skills/contribution-hygiene.md
@@ -1,0 +1,88 @@
+# Skill: Contribution Hygiene
+
+<!-- provenance: langchain-ai/langchain, AGENTS.md, 2026-04-14 -->
+<!-- otherness-learn: AI disclosure in PRs; conventional commit scope enforcement; clean PR discipline -->
+
+Load this skill when opening a PR or writing a commit message.
+
+These patterns address the most common PR discipline failures in autonomous AI contributions:
+missing context for reviewers, untraceable changes, and stale references.
+
+---
+
+## AI Disclosure in Every PR <!-- provenance: langchain-ai/langchain, AGENTS.md, 2026-04-14 -->
+
+LangChain requires: "Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution."
+
+This is not optional and not just for transparency — it sets reviewer expectations. A PR opened by an AI agent will have different failure modes than a human PR: the agent may have misread the spec, optimized for the wrong metric, or missed a domain-specific constraint that would be obvious to a human.
+
+**The otherness implication:** Every PR opened by the standalone agent must include a footer:
+
+```markdown
+---
+*Opened autonomously by [otherness](https://github.com/pnz1990/otherness). Review for correctness — the agent may have missed domain context visible in issue discussion or recent commits.*
+```
+
+This is not a warning label — it is a reviewer aid. The human reviewing the PR knows to check: did the agent read the right version of the spec? Did it miss a comment on the issue that changed the requirement?
+
+**Concrete check:** Before `gh pr create`, verify the `--body` argument includes the otherness disclosure footer. If not, add it.
+
+---
+
+## Commit Scope Is Not Optional <!-- provenance: langchain-ai/langchain, AGENTS.md, 2026-04-14 -->
+
+LangChain enforces: "All PR titles should include a scope with no exceptions. For example: `feat(langchain): ...`"
+
+The reason: scopeless commits force reviewers to scan the full diff to understand what area changed. With scopes, the reviewer immediately knows which component to examine.
+
+**The otherness implication:** Commit messages already follow conventional commits (`feat(skills): ...`, `fix(agent-loop): ...`). But the rule must be *enforced*, not just encouraged:
+
+- `feat: add thing` — invalid (no scope)
+- `feat(skills): add role-based-agent-identity.md` — valid
+
+**Concrete check when writing commits:**
+1. Is the format `type(scope): description`?
+2. Does the scope match an actual project area (`agent-loop`, `skills`, `tooling`, `docs`, `onboarding`)?
+3. Is the description in lowercase (except proper nouns)?
+
+If any answer is no: fix the commit message before pushing.
+
+---
+
+## PR Description: Why, Not What <!-- provenance: langchain-ai/langchain, AGENTS.md, 2026-04-14 -->
+
+LangChain: "Describe the 'why' of the changes, why the proposed solution is the right one. Limit prose. Highlight areas that require careful review."
+
+The failure mode to prevent: a PR description that summarizes what the diff contains. This is useless — the reviewer can read the diff. What they cannot read from the diff:
+- Why this approach was chosen over alternatives
+- What the spec said this should do
+- Which section of the diff is the risky part
+
+**The otherness implication:** A PR body should contain:
+1. **Problem** — what was broken or missing (one sentence, links issue)
+2. **Fix** — why this approach is correct (not what it does)
+3. **Careful review area** — if one part of the diff is riskier than the rest, say so explicitly
+4. **AI disclosure footer** (see above)
+
+What a PR body should NOT contain:
+- A restatement of the commit message
+- A bullet list of files changed
+- "Closes #X" as the only content
+
+---
+
+## Remove Dead Code Before Committing <!-- provenance: langchain-ai/langchain, AGENTS.md, 2026-04-14 -->
+
+LangChain: "Remove unreachable/commented-out code before committing."
+
+This applies with extra force to AI-generated code, where the agent may leave:
+- A previous approach as a commented-out block
+- A variable that was used in a discarded implementation
+- An import that was added then made unnecessary
+
+**The otherness implication (agent-coding-discipline extension):** Before committing, scan the diff for:
+- Lines starting with `#` that are commented-out code (not comments about the code)
+- Variables declared but never read
+- Imports not referenced in the file
+
+If found: remove them before the commit. A reviewer seeing commented-out code in a PR from an AI agent has no way to know if it was intentional or a mistake.

--- a/agents/skills/reconciling-implementations.md
+++ b/agents/skills/reconciling-implementations.md
@@ -141,5 +141,19 @@ Performance, Observability, Testing, and Simplicity issues may be raised as foll
 if they do not affect correctness — but must be filed as issues before merging, not deferred
 silently.
 
+---
+
+## Stable Interface Gate <!-- provenance: langchain-ai/langchain, AGENTS.md, 2026-04-14 -->
+
+Before approving any PR that modifies an existing function, command, or agent interface:
+
+1. **Check if the symbol is public/exported.** In otherness: any command in `.opencode/command/`, any phase name in `standalone.md`, any field in `state.json` schema, any skill file name referenced in `standalone.md`.
+2. **Check if the signature changed.** For agent instructions: did the calling convention change? For state.json: were existing fields renamed or removed? For command files: did the invocation pattern change?
+3. **If yes: is there a migration path?** If a field is renamed in state.json without migration, existing `_state` branch data breaks all running sessions. If a command file is renamed, users with `/otherness.run` in their muscle memory break.
+
+**The otherness-specific rule:** Fields in `state.json` and phase names in `standalone.md` are public interfaces. Renaming them without a migration step is a breaking change that affects all running sessions (the `_state` branch may have the old field names).
+
+**Concrete gate:** If the diff renames or removes a `state.json` field that is referenced in `standalone.md` (e.g., `features`, `handoff`, `session_heartbeats`): BLOCK the PR until a migration script is added or the rename is confirmed to not affect `_state` data in the wild.
+
 **REQUEST CHANGES** when any Correctness item fails, or when a WRONG or STALE classification
 is found. Maximum 3 QA cycles. If unresolved after 3 cycles, escalate to `[NEEDS HUMAN]`.


### PR DESCRIPTION
## /otherness.learn session — langchain-ai/langchain

Studied langchain-ai/langchain AGENTS.md (133k stars, most widely-used AI agent framework).

**New skill:** `contribution-hygiene.md`
- AI disclosure footer in every AI-opened PR
- Commit scope enforcement (no scopeless commits)
- PR body: why not what; highlight risky areas
- Remove dead code before committing

**Extended:** `reconciling-implementations.md`
- Stable Interface Gate: block PRs that rename/remove public fields without migration

**Updated:** PROVENANCE.md, skills/README.md

Skills count: 5 → 6. **MEDIUM tier** — skills only. Autonomous merge.

---
*Opened autonomously by [otherness](https://github.com/pnz1990/otherness). Review for correctness — the agent may have missed domain context visible in issue discussion or recent commits.*