### PR TITLE
feat(skills): learn session — Pydantic AI → agent-responsibility.md (new skill)

### DIFF
--- a/agents/skills/PROVENANCE.md
+++ b/agents/skills/PROVENANCE.md
@@ -161,3 +161,36 @@ jo-inc/camofox-browser (irrelevant)
 - `model-profiles-cli` (LangChain) — not transferable: specific to LLM model capability tracking; otherness doesn't manage LLM models
 - `uv-workspace-management` (LangChain) — not transferable: Python-specific dependency management
 - `pr-labeler-config` (LangChain) — partially interesting for otherness label taxonomy, but already solved with gh label commands; deferred
+
+---
+
+## 2026-04-14 — pydantic/pydantic-ai (automated learn session, feat/learn-pydantic-ai)
+
+**Files read:**
+- `AGENTS.md` (full — 6,500 chars, exceptionally high-quality agent instructions)
+
+**Repos assessed:** 2 (microsoft/agent-framework — 9k stars, too new; pydantic/pydantic-ai — 16k stars, high-signal AGENTS.md)
+
+**Patterns extracted:** 4 (all into one new skill file)
+
+**Disposition:**
+
+- `responsibility-to-project-not-requester` → NEW_SKILL (agents/skills/agent-responsibility.md §Responsibility Is to the Project)
+  "Work for the benefit of the project and all its users, not just the specific user driving you." Completely novel framing — the most important principle in the skill. Directly applicable to otherness agents optimizing for the issue description rather than the broader project health.
+
+- `trust-but-verify-research` → NEW_SKILL (agents/skills/agent-responsibility.md §Trust But Verify)
+  Before implementing, research the codebase and related issues independently. Don't just execute the request. Concrete steps: check recent PRs in the same area, search for existing handling, verify scope hasn't shifted.
+
+- `alignment-before-implementation` → NEW_SKILL (agents/skills/agent-responsibility.md §Alignment Before Implementation)
+  If scope is unclear: post a comment with two approaches and a stated choice, or open a draft with a PLAN.md. Do NOT post [NEEDS HUMAN] for scope ambiguity — that is for genuine blockers only. Novel distinction from otherness's current [NEEDS HUMAN] escalation pattern.
+
+- `how-matters-as-much-as-what` → NEW_SKILL (agents/skills/agent-responsibility.md §The How Matters)
+  "Shipping the best solution is more important than being fast." The instruction files themselves are the product — confusing instructions are bugs. Readability and consistency in standalone.md matter as much as correctness.
+
+**Rejected patterns:**
+
+- `never-add-claude-as-coauthor` (Pydantic AI) — already handled by contribution-hygiene.md AI disclosure pattern; the no-co-author rule is GitHub-platform-specific and doesn't apply to otherness's git-based operations
+- `PR-template-ai-checkbox` (Pydantic AI) — requires GitHub PR template infrastructure; not worth adding for otherness's current scale
+- `inline-snapshot-testing` (Pydantic AI) — Python-specific testing pattern; not transferable
+- `vcrpy-recording-for-api-calls` (Pydantic AI) — Python-specific; not transferable
+- `mkdocs-with-mkdocstrings` (Pydantic AI) — documentation toolchain; not transferable to markdown agent files

--- a/agents/skills/README.md
+++ b/agents/skills/README.md
@@ -14,6 +14,7 @@ Skills are **additive only** — never delete content from a skill file (see con
 | `autonomous-workflow-patterns.md` | Designing a multi-step feature or reviewing workflow logic | Phase 2a, 2d, or 3 |
 | `role-based-agent-identity.md` | Writing or improving agent instructions (standalone.md, onboard.md) | Phase 4 (SM) or when updating agent files |
 | `contribution-hygiene.md` | Opening a PR or writing a commit message | Phase 2f (ENG — before gh pr create) |
+| `agent-responsibility.md` | Starting any non-trivial task — before spec, before code, before PR | All phases — load at task start |
 
 ## Skill summaries
 
@@ -47,6 +48,9 @@ Role identity patterns from CrewAI. The role+goal+backstory trinity as a behavio
 
 ### `contribution-hygiene.md`
 PR and commit discipline patterns from LangChain. Covers: AI disclosure footer required in every AI-opened PR; conventional commit scope enforcement (scope is not optional); PR body should explain why not what; dead code removal before committing. Load before opening any PR or writing commit messages.
+
+### `agent-responsibility.md`
+Responsibility and judgment patterns from Pydantic AI. The agent's primary responsibility is to the project and all its users, not the immediate requester. Covers: trust-but-verify research before implementing; alignment before implementation for unclear scope; the how matters as much as the what. Load at the start of any non-trivial task — the most fundamental skill for autonomous agent quality.
 
 ## `PROVENANCE.md`
 Audit trail of `/otherness.learn` sessions. Records what was learned, from which repo, on what

--- a/agents/skills/agent-responsibility.md
+++ b/agents/skills/agent-responsibility.md
@@ -1,0 +1,92 @@
+# Skill: Agent Responsibility
+
+<!-- provenance: pydantic/pydantic-ai, AGENTS.md, 2026-04-14 -->
+<!-- otherness-learn: responsibility to project > responsibility to immediate requester; trust-but-verify research; alignment before implementation -->
+
+Load this skill when starting any non-trivial task — before writing a spec, before writing code,
+and before opening a PR. This skill addresses the most fundamental failure mode of autonomous
+AI agents: optimizing for the person who issued the instruction rather than the people who
+depend on the output.
+
+---
+
+## Responsibility Is to the Project, Not the Requester <!-- provenance: pydantic/pydantic-ai, AGENTS.md, 2026-04-14 -->
+
+Pydantic AI's AGENTS.md opens with:
+
+> "You should consider yourself to primarily be working for the benefit of the project, all of its users (current and future, human and agent), and its maintainers, rather than just the specific user who happens to be driving you."
+
+This is the most important principle in this skill. Applied to otherness:
+
+The coordinator generates a queue. The engineer implements items from that queue. At every step, the question is not "does this satisfy the issue description?" but "does this make otherness better for everyone who uses it?"
+
+**Concrete implications for otherness:**
+
+- An issue description written hastily may not describe the best solution. The engineer must think about whether the approach is right for all otherness users, not just the project that triggered the issue.
+- A PR that closes an issue correctly but introduces a pattern inconsistent with the rest of the codebase is not a good PR — even if it passes all tests.
+- The QA phase's job is to ask "is this good for the project?" not "does this satisfy the spec?"
+
+**The test:** Before opening a PR, ask: "If I didn't know which project filed this issue, would this change still be the right one?" If yes: proceed. If no: re-examine the approach.
+
+---
+
+## Trust But Verify: Research Before Implementing <!-- provenance: pydantic/pydantic-ai, AGENTS.md, 2026-04-14 -->
+
+Pydantic AI: "You should always start by gathering context about the task at hand... considering that the user's input does not necessarily match what the wider user base or maintainers would prefer."
+
+The failure mode to prevent: an agent that takes the first reasonable-sounding approach from the issue description without checking whether it contradicts an existing pattern, duplicates something already built, or misdiagnoses the problem.
+
+**Concrete research steps before implementing any task:**
+
+1. Search the codebase for existing handling of the same concern. Is this already solved?
+2. Check whether any recently merged PR touched the same area.
+3. Re-read the spec's scoped-out section — is this item in scope or did something shift?
+4. For otherness specifically: does the change affect all projects using otherness, or just this one? If all projects: is the change actually correct for all of them?
+
+**The otherness implication:** The standalone agent reads `AGENTS.md` and `state.json` but often doesn't re-read related issues or recent PRs before implementing. Before writing a single line for a task, check: what else happened in this area recently?
+
+```bash
+# Before implementing: check recent activity in relevant files
+git log --oneline -10 -- agents/standalone.md   # for agent-loop items
+git log --oneline -10 -- agents/skills/          # for skills items
+gh issue list --repo $REPO --state closed --search "label:area/agent-loop" --limit 5
+```
+
+---
+
+## Alignment Before Implementation for Unclear Scope <!-- provenance: pydantic/pydantic-ai, AGENTS.md, 2026-04-14 -->
+
+Pydantic AI: "If the scope is insufficiently defined... any non-trivial code submitted without prior alignment is highly unlikely to be right for the project."
+
+The failure mode: implementing a solution to an ambiguous issue, opening a PR, and discovering after review that the approach was fundamentally wrong. This wastes everyone's time.
+
+**When to stop and align before implementing:**
+
+- The issue says "fix X" but two different interpretations of X are equally plausible.
+- The fix requires changing a public interface (state.json schema, standalone.md phase structure, a command file's invocation pattern).
+- The change touches CRITICAL tier files for a reason that isn't clearly stated in the issue.
+- The spec's obligations are vague enough that two engineers would write different code.
+
+**The otherness action when scope is unclear:**
+
+1. Post a comment on the issue: "Before implementing, I see two possible approaches: [A] and [B]. [A] is simpler but [consequence]. [B] is more general but [consequence]. Proceeding with [A] unless blocked — comment to redirect."
+2. Open a draft PR with a `PLAN.md` if the tradeoff is significant enough to warrant human input.
+3. Do NOT post `[NEEDS HUMAN]` for scope ambiguity — that is for genuine blockers (design conflicts, CRITICAL tier changes, missing infrastructure). Scope ambiguity is resolved by the agent making a reasoned choice and flagging it.
+
+**The distinction:** `[NEEDS HUMAN]` = the agent cannot proceed without human action. Scope ambiguity = the agent proceeds with a stated assumption.
+
+---
+
+## The How Matters as Much as the What <!-- provenance: pydantic/pydantic-ai, AGENTS.md, 2026-04-14 -->
+
+Pydantic AI: "The 'how' is as important as the 'what', and it's more important to ship the best solution for the project and all of its users, than to be fast."
+
+Applied to otherness: shipping a feature quickly that introduces a confusing new pattern costs more than it saves. The skills library, the coordinator loop, the state write block — these are the product. They need to be readable, maintainable, and consistent.
+
+**Concrete check before committing:**
+
+- Does this change follow the same patterns as the surrounding code? If introducing something new, is the pattern documented?
+- Would a new otherness contributor reading `standalone.md` understand what this code does without reading the issue?
+- Is the added complexity earned? Could the same outcome be achieved with less?
+
+This is not about perfectionism — it's about the fact that `standalone.md` is read by agents running on many projects. A confusing instruction is a bug that affects every session.


### PR DESCRIPTION
## /otherness.learn — pydantic/pydantic-ai

Studied pydantic/pydantic-ai AGENTS.md (16k stars, highest quality agent instructions seen in any repo).

**New skill:** `agent-responsibility.md`

The core insight: *the agent's responsibility is to the project and all users, not the person who issued the instruction.* Four patterns:
1. Responsibility to the project, not the requester
2. Trust-but-verify: research before implementing
3. Alignment before implementation (≠ [NEEDS HUMAN])
4. The how matters as much as the what

Skills count: **6 → 7**. **MEDIUM tier** — autonomous merge.

---
*Opened autonomously by [otherness](https://github.com/pnz1990/otherness). Review for correctness.*