### PR TITLE
feat(skills): learn session — OpenHands → ephemeral-pr-artifacts.md (new skill)

### DIFF
--- a/agents/skills/PROVENANCE.md
+++ b/agents/skills/PROVENANCE.md
@@ -164,6 +164,35 @@ jo-inc/camofox-browser (irrelevant)
 
 ---
 
+## 2026-04-14 — All-Hands-AI/OpenHands (automated learn session, feat/learn-openhands)
+
+**Files read:**
+- `AGENTS.md` (full — 7,500+ chars, operational AI software engineer system)
+
+**Repos assessed:** 1 (All-Hands-AI/OpenHands — 71k stars, actively maintained)
+
+**Patterns extracted:** 3 (into one new skill file)
+
+**Disposition:**
+
+- `pr-ephemeral-artifacts` → NEW_SKILL (agents/skills/ephemeral-pr-artifacts.md §The .pr/ Directory)
+  `.pr/` directory for reviewer context that auto-cleans on merge. Applicable to otherness CRITICAL tier PRs — adds design.md explaining reasoning without polluting the repo.
+
+- `specific-git-staging` → NEW_SKILL (agents/skills/ephemeral-pr-artifacts.md §Specific Git Staging)
+  `git add <file>` not `git add .`. Prevents autonomous agents from accidentally staging state files, temp outputs, or scratch files. Added with audit checklist and the one valid exception (temp state worktree).
+
+- `trigger-based-skill-loading` → NEW_SKILL (agents/skills/ephemeral-pr-artifacts.md §Trigger-Based Skill Loading)
+  Load skills only when the current task matches trigger keywords. As otherness skills library grows, loading all files every phase wastes context. Added as an improvement direction with concrete header format.
+
+**Rejected patterns:**
+
+- `lockfile-version-preservation` — not transferable: Python/JS lockfiles; otherness has no dependencies
+- `enterprise-directory-pattern` — not transferable: requires separate licensed codebase layer
+- `settings-ui-patterns` — not transferable: React frontend; otherness has no UI
+- `microagent-frontmatter-format` — partially captured in trigger-based-skill-loading; YAML format is OpenHands-specific
+
+---
+
 ## 2026-04-14 — pydantic/pydantic-ai (automated learn session, feat/learn-pydantic-ai)
 
 **Files read:**

--- a/agents/skills/README.md
+++ b/agents/skills/README.md
@@ -15,6 +15,7 @@ Skills are **additive only** — never delete content from a skill file (see con
 | `role-based-agent-identity.md` | Writing or improving agent instructions (standalone.md, onboard.md) | Phase 4 (SM) or when updating agent files |
 | `contribution-hygiene.md` | Opening a PR or writing a commit message | Phase 2f (ENG — before gh pr create) |
 | `agent-responsibility.md` | Starting any non-trivial task — before spec, before code, before PR | All phases — load at task start |
+| `ephemeral-pr-artifacts.md` | Opening a CRITICAL tier PR or any complex PR needing reviewer context | Phase 2f (ENG — before gh pr create) |
 
 ## Skill summaries
 
@@ -51,6 +52,9 @@ PR and commit discipline patterns from LangChain. Covers: AI disclosure footer r
 
 ### `agent-responsibility.md`
 Responsibility and judgment patterns from Pydantic AI. The agent's primary responsibility is to the project and all its users, not the immediate requester. Covers: trust-but-verify research before implementing; alignment before implementation for unclear scope; the how matters as much as the what. Load at the start of any non-trivial task — the most fundamental skill for autonomous agent quality.
+
+### `ephemeral-pr-artifacts.md`
+PR operational patterns from OpenHands. Covers: `.pr/` directory for reviewer context that auto-cleans on merge; `git add <file>` over `git add .` for safe autonomous staging; trigger-based skill loading (improvement direction for when skills library exceeds 15 files). Load before opening any complex or CRITICAL tier PR.
 
 ## `PROVENANCE.md`
 Audit trail of `/otherness.learn` sessions. Records what was learned, from which repo, on what

--- a/agents/skills/ephemeral-pr-artifacts.md
+++ b/agents/skills/ephemeral-pr-artifacts.md
@@ -1,0 +1,100 @@
+# Skill: Ephemeral PR Artifacts
+
+<!-- provenance: All-Hands-AI/OpenHands, AGENTS.md, 2026-04-14 -->
+<!-- otherness-learn: .pr/ ephemeral directory for reviewer context; auto-cleanup on merge; specific git staging -->
+
+Load this skill when implementing a complex feature that would benefit from reviewer context
+beyond the PR description, or when writing git staging commands.
+
+---
+
+## The `.pr/` Directory: Reviewer Context That Cleans Itself Up <!-- provenance: All-Hands-AI/OpenHands, AGENTS.md, 2026-04-14 -->
+
+OpenHands uses a `.pr/` directory at the repo root for PR-specific artifacts:
+
+```
+.pr/
+├── design.md       # Design decisions, why this approach was chosen
+├── analysis.md     # Investigation notes
+└── notes.md        # Context that helps reviewers but isn't needed post-merge
+```
+
+Key properties:
+- `.pr/` is **not** merged to main — a workflow auto-removes it when the PR is approved
+- When `.pr/` exists, a bot posts a notification to the PR alerting reviewers it's there
+- Content goes in `.pr/`, not as a `PLAN.md` in the repo root (which would persist)
+
+**The otherness implication:** For complex CRITICAL tier PRs where the change is subtle, add a `.pr/design.md` explaining the reasoning. The human reviewer sees it in the PR, it disappears on merge. This is better than a long PR description because:
+- It can include diagrams, decision trees, rejected alternatives
+- It's file-searchable, not buried in PR comments
+- It auto-cleans — doesn't pollute the repo
+
+**Concrete use case in otherness:** Any CRITICAL tier PR that touches the state write block, the coordinator phase, or the parallel session protocol should include a `.pr/design.md` with:
+1. What invariant this change preserves
+2. The failure mode it fixes or prevents
+3. Why the chosen approach is safer than the alternative considered
+
+**Implementation:** Add to the PR commit, then note in the PR body that a `.pr/design.md` exists. The reviewer can read it as a file. Since otherness doesn't have the auto-cleanup workflow, manually delete `.pr/` before merging or add a note to the PR checklist.
+
+---
+
+## Specific Git Staging: `git add <file>` Not `git add .` <!-- provenance: All-Hands-AI/OpenHands, AGENTS.md, 2026-04-14 -->
+
+OpenHands: "Prefer specific `git add <filename>` instead of `git add .` to avoid accidentally staging unintended files."
+
+This is particularly important for autonomous agents because:
+- The agent may have created temporary files during investigation that shouldn't be committed
+- State files (`.otherness/state.json`) may have been modified as a side effect of reading them
+- Debug output or scratch files from tool use may exist in the working directory
+
+**The otherness implication:** Every `git add` in standalone.md should be specific. Audit:
+
+```bash
+# Wrong — stages everything including accidental files
+git add .
+git add .otherness/
+
+# Right — stages only the intended files
+git add agents/standalone.md
+git add agents/skills/new-skill.md
+git add docs/aide/metrics.md
+```
+
+**The one exception**: The state write block uses a temp worktree that contains only `.otherness/state.json` — `git add .otherness/state.json` there is fine since the worktree was created clean.
+
+**Concrete check before any commit:** List what `git status` shows and verify every staged file is intentional. If unexpected files appear: `git restore --staged <file>` before committing.
+
+---
+
+## Trigger-Based Skill Loading <!-- provenance: All-Hands-AI/OpenHands, AGENTS.md, 2026-04-14 -->
+
+OpenHands microagents load only when the user's message matches trigger keywords:
+
+```yaml
+---
+triggers:
+- PR review
+- code review
+- review this
+---
+# QA Checklist
+...specialized review content...
+```
+
+Without triggers: always loaded (baseline context). With triggers: loaded on-demand.
+
+**The otherness implication:** Loading all 7+ skill files at the start of every phase adds context that may not be relevant. A QA reviewing a docs-only PR doesn't need `declaring-designs.md` or `agent-coding-discipline.md`. An engineer implementing a learn session doesn't need `reconciling-implementations.md`.
+
+**Current otherness pattern:** "Load skill: read `~/.otherness/agents/skills/<name>.md`" — explicit, manual, always the full file.
+
+**Improvement direction:** Add a trigger comment to each skill file header indicating when to load it. The agent reads the header (first 3 lines) of each skill file at phase start, and only reads the full file if the current task matches the trigger:
+
+```markdown
+# Skill: Reconciling Implementations
+<!-- triggers: PR review, QA, adversarial review, merge decision -->
+<!-- load: always during Phase 3 (QA); on-demand in other phases -->
+```
+
+This reduces context consumption without losing coverage. The full skill is still available — it just isn't loaded unless relevant.
+
+**Note**: This is an improvement direction, not a current requirement. The existing explicit load pattern is correct. This optimization matters when the skills library grows to 15+ files.


### PR DESCRIPTION
## /otherness.learn — All-Hands-AI/OpenHands (71k stars)

**New skill:** `ephemeral-pr-artifacts.md`
- `.pr/` directory: store design rationale for reviewers that auto-cleans on merge — no more burying it in PR descriptions
- `git add <file>` not `git add .`: safe autonomous staging, prevents staging state/scratch files
- Trigger-based skill loading: improvement direction for when skills library exceeds 15 files

Skills count: **7 → 8**. **MEDIUM tier** — autonomous merge.

---
*Opened autonomously by [otherness](https://github.com/pnz1990/otherness). Review for correctness.*