### PR TITLE
fix(critical): _state branch bootstrap — setup creates it, write block self-heals

### DIFF
--- a/.opencode/command/otherness.setup.md
+++ b/.opencode/command/otherness.setup.md
@@ -111,9 +111,55 @@ state = {
   "handoff": None
 }
 with open('.otherness/state.json', 'w') as f:
-    json.dump(state, f, indent=2)
+     json.dump(state, f, indent=2)
 print("Created .otherness/state.json")
 EOF
+fi
+```
+
+## Step 6 — Create _state branch for state persistence
+
+The `_state` branch is where otherness stores its persistent memory across sessions.
+It must exist on the remote before `/otherness.run` can write state.
+
+```bash
+if ! git ls-remote --heads origin _state | grep -q '_state'; then
+  echo "Creating _state branch for state persistence..."
+  CURRENT_BRANCH=$(git branch --show-current)
+  REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
+
+  # Create an orphan branch (no shared history with main)
+  git checkout --orphan _state
+  git rm -rf . --quiet 2>/dev/null || true   # clear index — orphan starts empty
+
+  # Write initial state.json
+  mkdir -p .otherness
+  python3 - "$REPO" << 'EOF'
+import json, sys
+repo = sys.argv[1]
+state = {
+  "version": "1.3",
+  "mode": "standalone",
+  "repo": repo,
+  "current_queue": None,
+  "features": {},
+  "engineer_slots": {"ENGINEER-1": None, "ENGINEER-2": None, "ENGINEER-3": None},
+  "bounded_sessions": {},
+  "session_heartbeats": {"STANDALONE": {"last_seen": None, "cycle": 0}},
+  "handoff": None
+}
+with open('.otherness/state.json', 'w') as f:
+    json.dump(state, f, indent=2)
+print("Wrote .otherness/state.json")
+EOF
+
+  git add .otherness/state.json
+  git commit -m "state: initialize _state branch"
+  git push origin _state
+  git checkout "$CURRENT_BRANCH" --quiet
+  echo "_state branch created and pushed."
+else
+  echo "_state branch already exists — skipping."
 fi
 ```
 

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -38,7 +38,7 @@ git show origin/_state:.otherness/state.json > .otherness/state.json 2>/dev/null
 ```bash
 # After modifying .otherness/state.json, push to _state branch only:
 python3 - <<'PYEOF'
-import subprocess, json, os, tempfile, time
+import subprocess, json, os, tempfile, time, shutil
 
 # Read current state
 state = json.load(open('.otherness/state.json'))
@@ -46,6 +46,43 @@ state = json.load(open('.otherness/state.json'))
 # Write to _state branch via a temp worktree (retries up to 3× on push conflict)
 state_wt = os.path.join(tempfile.gettempdir(), 'otherness-state-' + str(os.getpid()))
 msg = os.environ.get('STATE_MSG','state update')
+
+# Bootstrap _state branch if it doesn't exist (first run on a new project)
+_check = subprocess.run(['git','ls-remote','--heads','origin','_state'],
+                        capture_output=True, text=True)
+if not _check.stdout.strip():
+    print("State: _state branch missing — bootstrapping...")
+    boot = tempfile.mkdtemp(prefix='otherness-boot-')
+    try:
+        repo_raw = subprocess.check_output(['git','remote','get-url','origin'],text=True).strip()
+        repo_slug = repo_raw.split('github.com')[-1].strip(':/').rstrip('/')
+        if repo_slug.endswith('.git'): repo_slug = repo_slug[:-4]
+        subprocess.run(['git','clone','--no-local','.',boot,'--quiet'], capture_output=True)
+        subprocess.run(['git','-C',boot,'checkout','--orphan','_state'], capture_output=True)
+        subprocess.run(['git','-C',boot,'rm','-rf','.'], capture_output=True)
+        os.makedirs(os.path.join(boot,'.otherness'), exist_ok=True)
+        initial = {
+            "version":"1.3","mode":"standalone","repo":repo_slug,
+            "current_queue":None,"features":{},
+            "engineer_slots":{"ENGINEER-1":None,"ENGINEER-2":None,"ENGINEER-3":None},
+            "bounded_sessions":{},
+            "session_heartbeats":{"STANDALONE":{"last_seen":None,"cycle":0}},
+            "handoff":None
+        }
+        json.dump(initial, open(os.path.join(boot,'.otherness','state.json'),'w'), indent=2)
+        subprocess.run(['git','-C',boot,'add','.otherness/state.json'])
+        subprocess.run(['git','-C',boot,'commit','-m','state: initialize _state branch'],
+                       capture_output=True)
+        r = subprocess.run(['git','-C',boot,'push','origin','_state'], capture_output=True)
+        if r.returncode == 0:
+            print("State: _state branch bootstrapped successfully")
+        else:
+            print("State: bootstrap push failed — will retry below")
+    except Exception as e:
+        print(f"State: bootstrap error: {e}")
+    finally:
+        shutil.rmtree(boot, ignore_errors=True)
+
 for attempt in range(3):
     try:
         subprocess.run(['git','worktree','add',state_wt,'origin/_state','--no-checkout'],


### PR DESCRIPTION
## The production bug

All new projects set up with otherness have **no persistent state**. The `_state` branch is never created. Every session runs blind with no memory of previous sessions. Evidence: `pnz1990/alibi` has been shipping PRs for weeks with `features: {}` forever.

## Root cause

`otherness.setup.md` creates `.otherness/state.json` locally but never pushes a `_state` branch. The state write block then calls `git worktree add origin/_state` — which exits 128 (fatal) **silently** (captured output) — and fails on every attempt.

## Fix 1 — otherness.setup.md Step 6 (new)

Creates the `_state` orphan branch and pushes it during setup. Idempotent — skips if already exists.

## Fix 2 — standalone.md state write block (defensive)

Before the retry loop: checks `git ls-remote --heads origin _state`. If missing, clones the repo to a temp dir, creates the orphan branch, pushes it, then continues normally. Catches all projects set up before this fix.

## Risk tier

- `agents/standalone.md` — **CRITICAL tier** → [NEEDS HUMAN]
- `.opencode/command/otherness.setup.md` — **HIGH tier**

[NEEDS HUMAN: critical-tier-change]

## Validation

- `bash scripts/validate.sh` — PASSED
- `bash scripts/lint.sh` — PASSED

Closes #41

---
*Opened autonomously by [otherness](https://github.com/pnz1990/otherness).*