### PR TITLE
feat(agent-loop): state.json schema migration v1.2→v1.3 on startup

### DIFF
--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -231,7 +231,65 @@ git pull origin main --quiet
 
 # Pull latest state from dedicated _state branch
 git fetch origin _state --quiet
-git checkout origin/_state -- .otherness/state.json 2>/dev/null
+git show origin/_state:.otherness/state.json > .otherness/state.json 2>/dev/null || true
+
+# Migrate state.json to current schema (v1.3) if needed — idempotent
+python3 - << 'MIGRATE_EOF'
+import json, os, subprocess
+
+try:
+    with open('.otherness/state.json') as f:
+        s = json.load(f)
+except Exception:
+    # Missing or corrupt — create minimal valid v1.3 state
+    try:
+        r = subprocess.check_output(['git','remote','get-url','origin'],text=True).strip()
+        repo = r.split('github.com')[-1].strip(':/').rstrip('/').rstrip('.git')
+    except Exception:
+        repo = ''
+    s = {'version':'0.0','repo':repo}
+
+if s.get('version') == '1.3':
+    exit(0)   # already current, nothing to do
+
+changes = []
+
+# v1.2 → v1.3: rename 'project' → 'repo'
+if 'project' in s and 'repo' not in s:
+    s['repo'] = s.pop('project')
+    changes.append("renamed 'project' → 'repo'")
+
+# Ensure repo field is populated
+if not s.get('repo'):
+    try:
+        r = subprocess.check_output(['git','remote','get-url','origin'],text=True).strip()
+        s['repo'] = r.split('github.com')[-1].strip(':/').rstrip('/').rstrip('.git')
+        changes.append(f"set repo={s['repo']}")
+    except Exception:
+        pass
+
+# Add missing fields with safe defaults
+for k, default in [
+    ('mode', 'standalone'),
+    ('current_queue', None),
+    ('features', {}),
+    ('engineer_slots', {'ENGINEER-1': None, 'ENGINEER-2': None, 'ENGINEER-3': None}),
+    ('bounded_sessions', {}),
+    ('session_heartbeats', {'STANDALONE': {'last_seen': None, 'cycle': 0}}),
+    ('handoff', None),
+]:
+    if k not in s:
+        s[k] = default
+        changes.append(f"added {k}")
+
+s['version'] = '1.3'
+
+os.makedirs('.otherness', exist_ok=True)
+with open('.otherness/state.json', 'w') as f:
+    json.dump(s, f, indent=2)
+
+print(f"[STANDALONE] Migrated state.json to v1.3: {', '.join(changes) if changes else 'no changes'}")
+MIGRATE_EOF
 
 REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
 REPO_NAME=$(basename $(git rev-parse --show-toplevel))

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -53,5 +53,16 @@ else
   echo "  OK: alibi is alive (last activity ${COMMIT_EPOCH}h ago)"
 fi
 
+# [5b] Schema version check — warn (non-fatal) if alibi state is on old schema
+echo "[5b] Checking alibi state schema version..."
+ALIBI_VER=$(gh api "repos/pnz1990/alibi/contents/.otherness%2Fstate.json?ref=_state" \
+  --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | \
+  python3 -c "import json,sys; print(json.load(sys.stdin).get('version','?'))" 2>/dev/null || echo "?")
+if [ "$ALIBI_VER" = "1.3" ]; then
+  echo "  OK: alibi state.json is v1.3"
+else
+  echo "  WARN: alibi state.json is v$ALIBI_VER (expected 1.3) — migration runs at next startup"
+fi
+
 echo ""
 echo "=== test: PASSED ==="


### PR DESCRIPTION
## What

Adds an auto-migration block to standalone.md that runs on every startup, immediately after reading state.json. Handles v1.0/1.1/1.2 → v1.3.

Evidence: `pnz1990/kro-ui` has been running on v1.2 state (`project` key instead of `repo`, missing `engineer_slots`/`handoff`). After next startup it auto-upgrades.

## Migration (idempotent)

- v1.3 state → exits immediately, no change
- v1.2 state → renames `project`→`repo`, adds missing fields, bumps version
- Missing/corrupt → creates minimal valid v1.3 state with repo from git remote

## Also adds

`scripts/test.sh` [5b]: non-fatal warning when alibi state is on old schema.

## Risk tier

`agents/standalone.md` — **CRITICAL tier** → [NEEDS HUMAN]

[NEEDS HUMAN: critical-tier-change]

Closes #44

---
*Opened autonomously by [otherness](https://github.com/pnz1990/otherness).*