### PR TITLE
fix(critical): remove remaining git push origin main — QA cleanup + bounded-standalone

### DIFF
--- a/agents/bounded-standalone.md
+++ b/agents/bounded-standalone.md
@@ -420,9 +420,8 @@ s['bounded_sessions'][os.environ['AGENT_ID']]['current_item']='$NEXT_ISSUE'
 s['bounded_sessions'][os.environ['AGENT_ID']]['branch']='$BRANCH'
 with open('.otherness/state.json','w') as f: json.dump(s,f,indent=2)
 "
-  git add .otherness/state.json
-  git commit -m "state: [$AGENT_NAME] claimed #$NEXT_ISSUE"
-  git push origin main
+  export STATE_MSG="[$AGENT_NAME] claimed #$NEXT_ISSUE"
+  # run the STATE MANAGEMENT write block from the top of this file
   move_board_card $NEXT_ISSUE $OPT_IN_PROGRESS
 else
   echo "[$AGENT_NAME] ⚡ Branch $BRANCH already exists — another session claimed #$NEXT_ISSUE. Trying next."

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -758,9 +758,8 @@ s['features']['$ITEM_ID']['state']='done'
 s['features']['$ITEM_ID']['pr_merged']=True
 with open('.otherness/state.json','w') as f: json.dump(s,f,indent=2)
 EOF
-git add .otherness/state.json
-git commit -m "state: [$MY_SESSION_ID] $ITEM_ID done"
-git push origin main
+export STATE_MSG="[$MY_SESSION_ID] $ITEM_ID done"
+# run the STATE MANAGEMENT write block from the top of this file
 
 # Reset for next item
 ITEM_ID="" ; MY_BRANCH="" ; MY_WORKTREE="" ; MY_SESSION_ID=""


### PR DESCRIPTION
## Completes the push-to-main eradication (companion to PR #36)

Two violations not in PR #36's scope:

**`standalone.md` line 763 — Phase 3 QA cleanup after merge**
Ran on every item completion. This was the highest-frequency violation — every PR merged wrote state to main. Now uses canonical write block.

**`bounded-standalone.md` line 425 — claim section**
Bounded session item claim wrote state to main. Now uses canonical write block.

After both #36 and this PR merge: zero functional `git push origin main` calls in either agent file.

## Risk tier

Both files — **CRITICAL tier** → [NEEDS HUMAN]

[NEEDS HUMAN: critical-tier-change]

Closes #42

---
*Opened autonomously by [otherness](https://github.com/pnz1990/otherness).*