### PR TITLE
fix(agent-loop): state write block — fetch _state before read, log silent fallback

### DIFF
--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -87,6 +87,9 @@ for attempt in range(3):
     try:
         subprocess.run(['git','worktree','add',state_wt,'origin/_state','--no-checkout'],
                        capture_output=True)
+        # Fetch latest _state into worktree before reading, to avoid stale ref on retry
+        subprocess.run(['git','-C',state_wt,'fetch','origin','_state','--quiet'],
+                       capture_output=True)
         subprocess.run(['git','-C',state_wt,'checkout','_state','--','.otherness/state.json'],
                        capture_output=True)
 
@@ -98,6 +101,7 @@ for attempt in range(3):
             remote.update(state)
             merged = remote
         except Exception:
+            print(f"State: no readable remote state — writing local state as authoritative")
             merged = state
         json.dump(merged, open(remote_path,'w'), indent=2)
 


### PR DESCRIPTION
## Problem

The canonical state write block was silently failing to read the latest remote state on retry attempts. Two related issues:

1. **Stale ref on retry**: On the second and third retry attempts (after a push conflict), the worktree's `origin/_state` ref was stale — the fetch happened outside the loop (before the worktree was created) but the worktree itself was only tracking what it was given at creation time. Adding a fetch *inside* the worktree before the checkout fixes this.

2. **Silent fallback**: When the remote `state.json` couldn't be read (fresh `_state` branch, corrupt file, path mismatch), the `except Exception` clause fell through to `merged = state` (local wins) silently. This is the correct behavior, but it was undetectable in logs — discovered only when the batch-6 state appeared to be lost.

## Fix

```python
# Before checkout — fetch latest _state into the worktree
subprocess.run(['git','-C',state_wt,'fetch','origin','_state','--quiet'], capture_output=True)

# On fallback — log it
except Exception:
    print(f"State: no readable remote state — writing local state as authoritative")
    merged = state
```

## Risk: CRITICAL tier

Touches `agents/standalone.md`. Minimal change: +2 lines. No logic changed when things work correctly. Only the retry path and the fallback message are affected.

Self-review (5-point):
1. SPEC — acceptance criterion: `grep -c 'fetch.*_state.*quiet' ~/.otherness/agents/standalone.md` ≥ 2 (one in main write block, one in the retry). ✅
2. FAILURE MODES — if fetch fails inside worktree: captured, execution continues to checkout which will use whatever ref the worktree already has — same as before. ✅
3. GLOBAL DEPLOYMENT — additive. No existing path removed. Backward compatible. ✅
4. SIMPLICITY — minimum change to fix the diagnosed issue. ✅
5. ROADMAP — operational reliability improvement; aligns with Stage 1 hardening goals. ✅

[NEEDS HUMAN: critical-tier-change]