### PR TITLE
docs(onboarding): mention job_family in setup guides and setup command

### DIFF
--- a/.opencode/command/otherness.setup.md
+++ b/.opencode/command/otherness.setup.md
@@ -165,6 +165,6 @@ fi
 
 ## Done
 
-Edit `otherness-config.yaml` to configure your CI, GitHub Projects board, and agent settings.
+Edit `otherness-config.yaml` to configure your CI, GitHub Projects board, and agent settings. If your project has a UI, add `project.job_family: FEE`; for platform/infrastructure projects use `SysDE`; backend-only projects can omit the field (defaults to `SDE`).
 
 Then run `/otherness.run` to start the autonomous team.

--- a/onboarding-existing-project.md
+++ b/onboarding-existing-project.md
@@ -78,6 +78,8 @@ Agents will read your answers from `AGENTS.md` and `docs/aide/`. The more accura
 
 This creates `otherness-config.yaml` from the template and auto-fills `project.repo` and `project.name` from your git remote. Edit the file to configure CI, board, and cycle settings.
 
+If your project has a UI (web app, mobile app, frontend), set `project.job_family: FEE`. For infrastructure/platform projects, set `project.job_family: SysDE`. For backend-only projects the default (`SDE`) is correct — you can omit the field.
+
 Start with `mode: standalone` regardless of team size — get one working loop before adding parallelism.
 
 ---

--- a/onboarding-new-project.md
+++ b/onboarding-new-project.md
@@ -50,6 +50,8 @@ This creates `.specify/`, `.opencode/`, and scaffolding files.
 
 This creates `otherness-config.yaml` from the template and auto-fills `project.repo` and `project.name` from your git remote. Edit the file to configure CI, board field IDs, and cycle settings.
 
+If your project has a UI (web app, mobile app, frontend), set `project.job_family: FEE`. For infrastructure/platform projects, set `project.job_family: SysDE`. For backend-only projects the default (`SDE`) is correct — you can omit the field.
+
 ---
 
 ## Step 4 — Create AGENTS.md


### PR DESCRIPTION
Three surgical additions at the config-edit step of each onboarding guide. Closes #70.