### PR TITLE
docs: arch-audit 2026-04-15 — fix CI-breaking validate rule and correct false claims

### DIFF
--- a/.opencode/command/otherness.arch-audit.md
+++ b/.opencode/command/otherness.arch-audit.md
@@ -1,0 +1,7 @@
+---
+description: "Architectural audit of the current project. Checks documentation against source, finds unused primitives, structural redundancy, and missing reactivity. Produces GitHub issues and a documentation fix PR."
+---
+
+Read and follow `~/.otherness/agents/otherness.arch-audit.md`.
+
+Parse any scope/focus arguments from the user: $ARGUMENTS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,17 +53,20 @@ otherness is a collection of **markdown instruction files** read by OpenCode (th
 ```
 ~/.otherness/                  ← the repo root (git clone at this path)
   agents/
-    standalone.md              ← full autonomous team loop (646 lines)
+    standalone.md              ← full autonomous team loop
     bounded-standalone.md      ← scoped concurrent agent
     onboard.md                 ← existing project onboarding
     otherness.learn.md         ← learning agent — internalize from open-source
+    otherness.arch-audit.md    ← architectural audit agent
     gh-features.md             ← GitHub API reference
     skills/                    ← reusable skill files
       declaring-designs.md     ← spec quality standard
       reconciling-implementations.md  ← QA checklist
       agent-coding-discipline.md      ← surgical changes, verifiable goals
       autonomous-workflow-patterns.md ← workflow design patterns
+      architectural-audit.md   ← four-lens audit methodology
       PROVENANCE.md            ← learning session audit trail
+      README.md                ← skill index
   boundaries/
     README.md
     example.boundary
@@ -83,6 +86,8 @@ otherness is a collection of **markdown instruction files** read by OpenCode (th
       otherness.status.md
       otherness.upgrade.md
       otherness.learn.md
+      otherness.arch-audit.md
+      otherness.cross-agent-monitor.md
   otherness-config.yaml
   otherness-config-template.yaml
   AGENTS.md
@@ -114,15 +119,20 @@ This is the most important section. Every PR must be classified before merge.
 
 ## What "Tests" Mean for otherness
 
-otherness has no unit tests. Its correctness can only be validated by running it on a real project and observing behavior. The `scripts/test.sh` does the following:
+otherness has no unit tests. Its correctness can only be validated by running it on a real project and observing behavior.
 
-1. **Markdown lint** — all `.md` files in `agents/` are well-formed.
-2. **State schema check** — `agents/standalone.md` references all required state.json fields.
-3. **Self-reference check** — `standalone.md` references `AGENTS.md`, `otherness-config.yaml`, and `docs/aide/` correctly (no hardcoded project paths).
-4. **Skills consistency** — every skill referenced in `standalone.md` (`Load skill: read ...`) exists on disk.
+`scripts/validate.sh` (BUILD_COMMAND) performs these structural checks:
+
+1. **No hardcoded project paths** — agent and skill files must not reference specific projects (other than otherness itself) in executable instruction context. PROVENANCE.md and HTML comment provenance metadata are exempt.
+2. **Skill references resolve** — every `Load skill: read ...` reference in `standalone.md` points to an existing file on disk or in the repo.
+3. **Required files present** — all agent files, skill files, docs, and command files listed in the required set exist.
+4. **Self-update present** — `standalone.md` contains the `git -C ~/.otherness pull` self-update block.
+
+`scripts/test.sh` (TEST_COMMAND) runs all 4 validate checks plus:
+
 5. **Integration test** — verify otherness is running correctly on the reference project (first non-otherness entry in `monitor.projects` in `otherness-config.yaml`) by checking the `_state` branch shows activity within the last 72 hours.
 
-`scripts/validate.sh` (BUILD_COMMAND) runs 1–4 only. `scripts/test.sh` runs all 5. `scripts/lint.sh` runs markdownlint on all agent files.
+`scripts/lint.sh` (LINT_COMMAND) checks agent files for structural correctness using python3 (no external tools required): CRLF line endings, null bytes, required phase headers in `standalone.md`.
 
 ---
 

--- a/docs/aide/definition-of-done.md
+++ b/docs/aide/definition-of-done.md
@@ -124,7 +124,7 @@ cd ~/.otherness
 # 2. Read AGENTS.md successfully
 # 3. Read state.json from _state branch
 # 4. Read docs/aide/vision.md
-# 5. Post a [COORD] startup comment on issue #1
+    # 5. Post a [COORD] startup comment on issue #2
 # 6. Claim or generate a work item
 # 7. NOT crash with "AGENTS.md not found" or "state.json not found"
 ```
@@ -133,7 +133,7 @@ cd ~/.otherness
 
 - [ ] Agent reads AGENTS.md without error
 - [ ] Agent reads state.json from _state branch
-- [ ] Agent posts startup comment on report issue #1
+- [ ] Agent posts startup comment on report issue #2
 - [ ] Agent claims or generates a work item within the first cycle
 - [ ] No `[NEEDS HUMAN]` posted due to missing infrastructure files
 

--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -27,9 +27,9 @@
 - `docs/aide/roadmap.md` — 5 stages of improvement
 - `docs/aide/definition-of-done.md` — 5 journeys
 - `.specify/memory/constitution.md` — 6 behavioral rules
-- `.opencode/command/otherness.*.md` — all 6 commands deployed
+- `.opencode/command/otherness.*.md` — all 8 commands deployed
 - `_state` branch with seeded `state.json`
-- GitHub report issue #1 and all labels
+- GitHub report issue #2 and all labels
 
 ## What the agent must complete in Stage 0
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -58,12 +58,26 @@ print(' '.join(names))
 FOUND=0
 for file in "$AGENTS_DIR"/*.md "$AGENTS_DIR/skills"/*.md; do
   [ -f "$file" ] || continue
+  # PROVENANCE.md is an audit trail log — it legitimately records which project a skill
+  # was extracted from. Skip it for hardcoded-path checks (see issue #78).
+  if [ "$(basename $file)" = "PROVENANCE.md" ]; then
+    continue
+  fi
   # Rule 1: any <owner>/<X> where X is not 'otherness'
+  # Exempt: HTML comment metadata lines (<!-- provenance: ... -->) in skill files.
   if grep -qE "${OWNER}/[a-zA-Z0-9_-]+" "$file" 2>/dev/null; then
-    BAD=$(grep -oE "${OWNER}/[a-zA-Z0-9_-]+" "$file" | grep -v "^${OWNER}/otherness$" | head -3)
+    BAD=$(grep -oE "${OWNER}/[a-zA-Z0-9_-]+" "$file" \
+      | grep -v "^${OWNER}/otherness$" | head -3)
     if [ -n "$BAD" ]; then
-      echo "  ERROR: $(basename $file) contains hardcoded project path(s): $BAD"
-      FOUND=1
+      # Re-check: filter lines that are only in HTML provenance comments
+      BAD_REAL=$(grep -E "${OWNER}/[a-zA-Z0-9_-]+" "$file" \
+        | grep -v "^<!--" \
+        | grep -oE "${OWNER}/[a-zA-Z0-9_-]+" \
+        | grep -v "^${OWNER}/otherness$" | head -3)
+      if [ -n "$BAD_REAL" ]; then
+        echo "  ERROR: $(basename $file) contains hardcoded project path(s): $BAD_REAL"
+        FOUND=1
+      fi
     fi
   fi
   # Rule 2: fleet project names in project-reference context
@@ -121,11 +135,14 @@ REQUIRED=(
   "$(cd "$(dirname "$0")/.." && pwd)/docs/aide/definition-of-done.md"
   "$(cd "$(dirname "$0")/.." && pwd)/docs/aide/metrics.md"
   "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.run.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.run.bounded.md"
   "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.onboard.md"
   "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.setup.md"
   "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.status.md"
   "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.upgrade.md"
   "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.learn.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.arch-audit.md"
+  "$(cd "$(dirname "$0")/.." && pwd)/.opencode/command/otherness.cross-agent-monitor.md"
 )
 MISSING_FILES=0
 for f in "${REQUIRED[@]}"; do


### PR DESCRIPTION
## Summary

Architectural audit 2026-04-15 found 7 findings. This PR fixes all false documentation claims and the CI-breaking bug. Code issues are filed as separate GitHub issues.

**This PR fixes CI immediately.** Main has been red for 3 consecutive runs.

## Changes

### Bug fix — CI broken (issue #78)
`scripts/validate.sh` check 1 was producing false positives on `agents/skills/PROVENANCE.md` and `agents/skills/architectural-audit.md`. Both legitimately contain `pnz1990/kardinal-promoter` as provenance metadata (audit trail header and HTML comment), not as hardcoded agent instructions. The fix:
- Exempt `PROVENANCE.md` from the hardcoded-path check entirely (it's an audit log, not instructions)
- Filter out HTML comment metadata lines (`<!-- provenance: ... -->`) before checking skill files

### Documentation fixes (issues #79, #80, #81, #82, #84)
- **AGENTS.md §Tests**: Replace false check descriptions 1–4 with what `validate.sh` and `lint.sh` actually implement
- **AGENTS.md §Tests**: Fix lint.sh description — it uses python3, not markdownlint
- **AGENTS.md Package Layout**: Add `otherness.arch-audit.md` agent, `architectural-audit.md` skill, and two missing command files
- **definition-of-done.md**: Fix report issue number `#1` → `#2` in Journey 5
- **progress.md**: Fix report issue `#1` → `#2`; fix command count `6` → `8`

### New file
- `.opencode/command/otherness.arch-audit.md` — launcher for the arch-audit agent (the agent existed but had no command file)

## Issues opened by this audit

| # | Priority | Finding |
|---|---|---|
| #78 | HIGH | validate.sh false positive breaks CI |
| #79 | HIGH | AGENTS.md test check descriptions don't match implementation |
| #80 | MEDIUM | AGENTS.md says lint.sh runs markdownlint (it doesn't) |
| #81 | HIGH | definition-of-done + progress.md reference wrong report issue |
| #82 | MEDIUM | 2 command files missing from validate.sh required list |
| #83 | MEDIUM | Learn scheduling execution is commented pseudocode, not implemented |
| #84 | LOW | arch-audit agent not in AGENTS.md Package Layout |

Issues #83 is filed but not addressed in this PR — it describes a structural limitation (learn scheduling requires AI-level sub-task delegation) that needs design discussion, not a doc change.