### PR TITLE
fix(agent-loop): add git fetch --prune at session startup

### DIFF
--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -353,7 +353,8 @@ fi
 git config pull.rebase false 2>/dev/null || true
 git pull origin main --quiet
 
-# Pull latest state from dedicated _state branch
+# Prune stale remote-tracking refs for deleted branches, then fetch state
+git fetch --prune --quiet 2>/dev/null || true
 git fetch origin _state --quiet
 git show origin/_state:.otherness/state.json > .otherness/state.json 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

Fixes #76. Stale remote-tracking refs for deleted feature branches accumulated in the local git view without explicit pruning.

## Change

Added `git fetch --prune --quiet` before the `_state` branch fetch in the startup block. This prunes stale refs for deleted branches on every session startup.

## Risk tier

**CRITICAL** — touches `agents/standalone.md`. Deploys globally on next session startup.

## Self-review

Change is minimal (2 lines modified: comment replaced + one new line). Graceful fallback with `|| true` — if prune fails (e.g. no remote), startup continues. No behavioral change to any phase logic.

Failure modes:
- Project with no remote: `|| true` prevents crash ✓
- Project on a machine without network: same ✓
- Parallel sessions: each session prunes independently — idempotent ✓

[NEEDS HUMAN: critical-tier-change]