### PR TITLE
feat(tooling): add --fleet mode to /otherness.status

### DIFF
--- a/.opencode/command/otherness.status.md
+++ b/.opencode/command/otherness.status.md
@@ -1,12 +1,23 @@
 ---
-description: "Show current agent state: what's in progress, queue position, CI status, and board health."
+description: "Show current agent state: what's in progress, queue position, CI status, and board health. Pass --fleet to see all monitored projects."
 ---
 
 You are showing the current status of the autonomous team.
 
-## Step 1 — Read state
+Parse arguments:
+```bash
+ARGS="${ARGUMENTS:-}"
+FLEET_MODE=false
+echo "$ARGS" | grep -q "\-\-fleet" && FLEET_MODE=true
+```
+
+## Step 1 — Read state (single-project mode)
+
+Skip if `FLEET_MODE=true`.
 
 ```bash
+if [ "$FLEET_MODE" != "true" ]; then
+
 python3 - << 'EOF'
 import json, datetime, os
 
@@ -51,28 +62,138 @@ for role, h in s.get('session_heartbeats', {}).items():
         age = (datetime.datetime.utcnow() - ts).seconds // 60
         print(f"Heartbeat {role}: {age}m ago (cycle {h.get('cycle',0)})")
 EOF
+
+fi
 ```
 
-## Step 2 — CI status on main
+## Step 2 — CI status on main (single-project mode)
+
+Skip if `FLEET_MODE=true`.
 
 ```bash
-REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
-echo "CI (main):"
-gh run list --repo "$REPO" --branch main --limit 5 \
-  --json status,conclusion,name,createdAt \
-  --jq '.[] | "\(.conclusion // .status) \(.name) \(.createdAt[:10])"' 2>/dev/null || echo "  (gh not configured)"
+if [ "$FLEET_MODE" != "true" ]; then
+  REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
+  echo "CI (main):"
+  gh run list --repo "$REPO" --branch main --limit 5 \
+    --json status,conclusion,name,createdAt \
+    --jq '.[] | "\(.conclusion // .status) \(.name) \(.createdAt[:10])"' 2>/dev/null || echo "  (gh not configured)"
+fi
 ```
 
-## Step 3 — Open needs-human and blocked issues
+## Step 3 — Open needs-human and blocked issues (single-project mode)
+
+Skip if `FLEET_MODE=true`.
 
 ```bash
-echo ""
-echo "Needs human:"
-gh issue list --repo "$REPO" --label "needs-human" --state open \
-  --json number,title --jq '.[] | "  #\(.number) \(.title[:70])"' 2>/dev/null || echo "  none"
+if [ "$FLEET_MODE" != "true" ]; then
+  echo ""
+  echo "Needs human:"
+  gh issue list --repo "$REPO" --label "needs-human" --state open \
+    --json number,title --jq '.[] | "  #\(.number) \(.title[:70])"' 2>/dev/null || echo "  none"
 
-echo ""
-echo "Blocked:"
-gh issue list --repo "$REPO" --label "blocked" --state open \
-  --json number,title --jq '.[] | "  #\(.number) \(.title[:70])"' 2>/dev/null || echo "  none"
+  echo ""
+  echo "Blocked:"
+  gh issue list --repo "$REPO" --label "blocked" --state open \
+    --json number,title --jq '.[] | "  #\(.number) \(.title[:70])"' 2>/dev/null || echo "  none"
+fi
+```
+
+## Step 4 — Fleet health table (--fleet mode)
+
+Only run if `FLEET_MODE=true`. Reads project list from `otherness-config.yaml` under `monitor.projects`.
+
+```bash
+if [ "$FLEET_MODE" = "true" ]; then
+
+python3 - << 'EOF'
+import subprocess, json, datetime, re, os, base64
+
+# Resolve config path: prefer project root, fall back to ~/.otherness
+config_path = 'otherness-config.yaml'
+if not os.path.exists(config_path):
+    config_path = os.path.expanduser('~/.otherness/otherness-config.yaml')
+
+repos = []
+in_monitor = in_projects = False
+try:
+    for line in open(config_path):
+        if re.match(r'^monitor:', line): in_monitor = True
+        if in_monitor and re.match(r'\s+projects:', line): in_projects = True
+        if in_projects:
+            m = re.match(r'\s+- (.+)', line)
+            if m: repos.append(m.group(1).strip().strip('"\''))
+except Exception as e:
+    print(f"Could not parse monitor.projects from {config_path}: {e}")
+    exit(1)
+
+if not repos:
+    print("No projects configured under monitor.projects in otherness-config.yaml")
+    exit(0)
+
+print(f"{'PROJECT':<28} {'_STATE':<14} {'CI':<10} {'OPEN_PRS':<10} {'NEEDS_HUMAN':<13} {'TODO'}")
+print("-" * 85)
+
+flags = []
+for repo in repos:
+    name = repo.split('/')[-1]
+
+    # _state last commit
+    r = subprocess.run(['gh','api',f'repos/{repo}/branches/_state',
+                        '--jq','.commit.commit.committer.date'],
+                       capture_output=True, text=True)
+    if r.returncode == 0 and r.stdout.strip():
+        ts = datetime.datetime.fromisoformat(r.stdout.strip().replace('Z','+00:00'))
+        hours = (datetime.datetime.now(datetime.timezone.utc) - ts).total_seconds() / 3600
+        state_str = f"{hours:.0f}h ago" if hours < 72 else f"⚠ STALE {hours:.0f}h"
+    else:
+        state_str = "NO _STATE"
+
+    # CI status
+    ci = subprocess.run(['gh','run','list','--repo',repo,'--branch','main','--limit','1',
+                         '--json','conclusion','--jq','.[0].conclusion'],
+                        capture_output=True, text=True)
+    ci_raw = (ci.stdout.strip() or "?")
+    ci_str = ("🔴 " if ci_raw == "failure" else "✅ " if ci_raw == "success" else "") + ci_raw[:7]
+
+    # Open PRs
+    prs = subprocess.run(['gh','pr','list','--repo',repo,'--state','open',
+                          '--json','number','--jq','length'],
+                         capture_output=True, text=True)
+    pr_count = prs.stdout.strip() or "0"
+
+    # Needs-human
+    nh = subprocess.run(['gh','issue','list','--repo',repo,'--state','open',
+                         '--label','needs-human','--json','number','--jq','length'],
+                        capture_output=True, text=True)
+    nh_count = nh.stdout.strip() or "0"
+    nh_flag = "⚠ " + nh_count if int(nh_count or 0) > 0 else nh_count
+
+    # TODO items in state.json
+    sr = subprocess.run(['gh','api',
+                         f'repos/{repo}/contents/.otherness%2Fstate.json?ref=_state',
+                         '--jq','.content'],
+                        capture_output=True, text=True)
+    todo_count = "?"
+    if sr.returncode == 0:
+        try:
+            s = json.loads(base64.b64decode(sr.stdout.strip()))
+            todo_count = str(len([d for d in s.get('features',{}).values()
+                                  if d.get('state') == 'todo']))
+        except: pass
+
+    print(f"{name:<28} {state_str:<14} {ci_str:<10} {pr_count:<10} {nh_flag:<13} {todo_count}")
+
+    if "STALE" in state_str or "failure" in ci_str or int(nh_count or 0) > 0:
+        flags.append(repo)
+
+if flags:
+    print()
+    print(f"⚠  Flagged ({len(flags)}): {', '.join(f.split('/')[-1] for f in flags)}")
+    print("   Run /otherness.cross-agent-monitor for details.")
+else:
+    print()
+    print("✅ All projects healthy.")
+EOF
+
+fi
 ```


### PR DESCRIPTION
## Summary

Fixes #45. `/otherness.status` now accepts `--fleet` to show a cross-project health dashboard without needing to open each project separately.

## What it does

```
/otherness.status --fleet
```

Outputs a table:
```
PROJECT                      _STATE         CI         OPEN_PRS   NEEDS_HUMAN   TODO
-----------------------------------------------------------------------------------------
otherness                    1h ago         ✅ success  2          0             3
alibi                        4h ago         ✅ success  0          0             1
kro-ui                       2h ago         🔴 failure  1          ⚠ 2           0
kardinal-promoter             ⚠ STALE 80h   ✅ success  0          0             0

⚠  Flagged (2): kro-ui, kardinal-promoter
   Run /otherness.cross-agent-monitor for details.
```

Reads project list from `monitor.projects` in `otherness-config.yaml` (project root or `~/.otherness`).

## Design

- Runs from any project directory (falls back to `~/.otherness/otherness-config.yaml` if no local config found)
- Single-project mode (no flag) is completely unchanged — no regression risk
- Flags projects with STALE _state, CI failure, or needs-human items
- Points to `/otherness.cross-agent-monitor` for detailed investigation