### PR TITLE
docs(README): add all 9 commands to reference table

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ That's it. The agent reads `AGENTS.md` and `docs/aide/`, generates a queue from 
 |---|---|
 | `/otherness.setup` | One-time project init — creates config, deploys all commands |
 | `/otherness.onboard` | Existing project — reads the codebase, generates `docs/aide/` drafts, seeds state |
-| `/otherness.status` | What the agent is working on, CI state, open blockers |
+| `/otherness.run` | Start the autonomous team loop (coordinator → engineer → QA → SM → PM → repeat) |
+| `/otherness.run.bounded` | Scoped agent with declared boundaries — run multiple concurrently |
+| `/otherness.status [--fleet]` | What the agent is working on, CI state, open blockers; `--fleet` for all monitored projects |
 | `/otherness.learn [repo ...]` | Study open-source projects and internalize patterns into skills |
 | `/otherness.upgrade` | Check for updates to internal dependencies |
+| `/otherness.arch-audit` | Architectural audit — checks docs vs source, finds drift and structural issues |
+| `/otherness.cross-agent-monitor` | Cross-project health monitor — heartbeat, velocity, blockers across all monitored repos |
 
 ---
 


### PR DESCRIPTION
Fixes #91. Adds /otherness.run, /otherness.run.bounded, /otherness.arch-audit, /otherness.cross-agent-monitor to the commands table. Updates /otherness.status entry with --fleet flag documentation.