### PR TITLE
fix(onboarding): write REPORT_ISSUE into AGENTS.md during onboard

### DIFF
--- a/agents/onboard.md
+++ b/agents/onboard.md
@@ -547,6 +547,26 @@ content = re.sub(r'(report_issue:\s*)TBD', f'\\g<1>{num}', content)
 content = re.sub(r'(report_issue:\s*)""', f'\\g<1>{num}', content)
 open('otherness-config.yaml', 'w').write(content)
 print(f"Set report_issue = {num} in otherness-config.yaml")
+
+# Also write REPORT_ISSUE into AGENTS.md if it exists but doesn't have the field yet.
+# standalone.md reads REPORT_ISSUE exclusively from AGENTS.md.
+import os, re as _re
+if os.path.exists('AGENTS.md'):
+    agents_content = open('AGENTS.md').read()
+    if not _re.search(r'^REPORT_ISSUE:', agents_content, _re.MULTILINE):
+        # Insert after PR_LABEL line if present, otherwise append
+        if _re.search(r'^PR_LABEL:', agents_content, _re.MULTILINE):
+            agents_content = _re.sub(
+                r'(^PR_LABEL:\s*\S+)',
+                f'\\g<1>\nREPORT_ISSUE:   {num}',
+                agents_content, count=1, flags=_re.MULTILINE
+            )
+        else:
+            agents_content += f'\nREPORT_ISSUE:   {num}\n'
+        open('AGENTS.md', 'w').write(agents_content)
+        print(f"Added REPORT_ISSUE = {num} to AGENTS.md")
+    else:
+        print("AGENTS.md already has REPORT_ISSUE — skipping")
 EOF
     echo "Report issue created: #$REPORT_NUM"
   else
@@ -567,6 +587,7 @@ BRANCH="otherness-onboard"
 
 git checkout -b "$BRANCH"
 git add docs/aide/ .otherness/state.json otherness-config.yaml
+[ -f AGENTS.md ] && git add AGENTS.md 2>/dev/null || true
 git commit -m "chore: otherness onboarding — add docs/aide, state.json, config"
 git push origin "$BRANCH"
 


### PR DESCRIPTION
## Problem

`standalone.md` reads `REPORT_ISSUE` exclusively from `AGENTS.md` at startup. After #95 fixed the report issue creation, the number was written to `otherness-config.yaml` but not `AGENTS.md`. The agent loop would still default to issue `#1` and post all reports to the wrong (or nonexistent) issue.

## Fix

In STEP 6c (after creating the report issue), write `REPORT_ISSUE: <N>` into `AGENTS.md` if:
- The file exists, AND
- It doesn't already have a `REPORT_ISSUE:` line

Insertion point: after the `PR_LABEL:` line (maintains Project Config block structure). Falls back to appending if no `PR_LABEL:` line found.

Also adds `AGENTS.md` to the `git add` in STEP 7 so the change is committed with the onboarding PR.