### PR TITLE
fix(setup): wire command deployment + remove speckit prerequisite

### DIFF
--- a/.opencode/command/otherness.setup.md
+++ b/.opencode/command/otherness.setup.md
@@ -29,6 +29,7 @@ maqa:
   agents_path: ~/.otherness/agents
   status_update_cycles: 5
   product_validation_cycles: 3
+  autonomous_mode: true
 
 ci:
   provider: github-actions
@@ -36,6 +37,9 @@ ci:
     workflow: ci.yml
   wait_timeout_seconds: 1200
   block_on_red: true
+
+monitor:
+  projects: []
 
 github_projects:
   project_id: ""
@@ -77,7 +81,32 @@ if [ ! -d ~/.otherness ]; then
 fi
 ```
 
-## Step 4 — Migrate .maqa/ → .otherness/ (upgrade from older otherness versions)
+## Step 4 — Deploy otherness command files into this project
+
+OpenCode reads slash commands from `.opencode/command/` in the current project directory.
+Copy the command files from `~/.otherness` so `/otherness.run`, `/otherness.onboard`, etc. work.
+
+```bash
+if [ -d ~/.otherness/.opencode/command ]; then
+  mkdir -p .opencode/command
+  # Copy all otherness.*.md commands — skip any that already exist (don't overwrite customisations)
+  for src in ~/.otherness/.opencode/command/otherness.*.md; do
+    fname=$(basename "$src")
+    dest=".opencode/command/$fname"
+    if [ ! -f "$dest" ]; then
+      cp "$src" "$dest"
+      echo "  Deployed: $fname"
+    else
+      echo "  Already present (skipped): $fname"
+    fi
+  done
+  echo "Commands deployed to .opencode/command/"
+else
+  echo "WARNING: ~/.otherness/.opencode/command not found. Clone otherness first (Step 3)."
+fi
+```
+
+## Step 4b — Migrate .maqa/ → .otherness/ (upgrade from older otherness versions)
 
 ```bash
 if [ -d ".maqa" ] && [ ! -d ".otherness" ]; then
@@ -165,6 +194,6 @@ fi
 
 ## Done
 
-Edit `otherness-config.yaml` to configure your CI, GitHub Projects board, and agent settings. If your project has a UI, add `project.job_family: FEE`; for platform/infrastructure projects use `SysDE`; backend-only projects can omit the field (defaults to `SDE`).
+Edit `otherness-config.yaml` to set your `BUILD_COMMAND`, `TEST_COMMAND`, `LINT_COMMAND`, and other project-specific values. If your project has a UI, add `project.job_family: FEE`; for platform/infrastructure projects use `SysDE`; backend-only projects can omit the field (defaults to `SDE`).
 
 Then run `/otherness.run` to start the autonomous team.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ otherness runs on itself. Every improvement it makes to its own agent logic depl
 npm install -g @opencode-ai/cli
 brew install gh && gh auth login
 git clone git@github.com:pnz1990/otherness.git ~/.otherness
-uv tool install specify-cli && specify extension add maqa
 
 # New project — from your project directory
 /otherness.setup   # creates otherness-config.yaml, deploys commands
@@ -63,8 +62,6 @@ That's it. The agent reads `AGENTS.md` and `docs/aide/`, generates a queue from 
 
 ```bash
 # 1. Once per machine
-uv tool install specify-cli
-specify extension add maqa
 gh auth login
 git clone git@github.com:<your-username>/otherness.git ~/.otherness
 
@@ -105,15 +102,7 @@ brew install gh && gh auth login
 
 ### Internal dependencies (managed by otherness, not you)
 
-**[speckit](https://github.com/github/spec-kit)** — deploys `.opencode/command/*.md` files into your project. Called once by `/otherness.setup`, never at runtime.
-
-```bash
-uv tool install specify-cli
-```
-
-**[MAQA](https://github.com/GenieRobot/spec-kit-maqa-ext)** — entry-point shells and `state.json` conventions that otherness reads and writes.
-
-**[aide](https://github.com/mnriem/spec-kit-extensions)** — work item generation from the roadmap. Called internally when the queue is empty.
+**[speckit](https://github.com/github/spec-kit)** — optional: if you already use speckit in your project, it can manage `.opencode/command/` deployment. Not required — `/otherness.setup` deploys command files directly via `cp`.
 
 ### Optional
 

--- a/onboarding-existing-project.md
+++ b/onboarding-existing-project.md
@@ -10,8 +10,6 @@ If your project already has `AGENTS.md` and a git history, skip the manual steps
 
 ```bash
 # 1. Prerequisites (once per machine)
-uv tool install specify-cli
-specify extension add maqa
 gh auth login
 git clone git@github.com:<your-username>/otherness.git ~/.otherness
 
@@ -42,8 +40,6 @@ Review the PR, correct anything that's wrong, merge, then:
 ## Prerequisites (install once per machine)
 
 ```bash
-uv tool install specify-cli
-specify extension add maqa
 gh auth login
 git clone git@github.com:<your-username>/otherness.git ~/.otherness
 ```

--- a/onboarding-new-project.md
+++ b/onboarding-new-project.md
@@ -7,16 +7,10 @@ This guide walks through setting up otherness on a **brand new project** — one
 ## Prerequisites (install once per machine)
 
 ```bash
-# 1. speckit CLI
-uv tool install specify-cli
-
-# 2. MAQA extension
-specify extension add maqa
-
-# 3. GitHub CLI
+# 1. GitHub CLI
 brew install gh && gh auth login
 
-# 4. otherness agent files
+# 2. otherness agent files
 git clone git@github.com:<your-username>/otherness.git ~/.otherness
 ```
 
@@ -31,18 +25,7 @@ cd my-project
 
 ---
 
-## Step 2 — Initialize speckit
-
-```bash
-specify init
-# Choose: opencode integration
-```
-
-This creates `.specify/`, `.opencode/`, and scaffolding files.
-
----
-
-## Step 3 — Run otherness setup
+## Step 2 — Run otherness setup
 
 ```bash
 /otherness.setup


### PR DESCRIPTION
Fixes #98 and #100.

**#98**: `otherness.setup.md` now has explicit Step 4 that copies `~/.otherness/.opencode/command/otherness.*.md` into `.opencode/command/` via `cp`. This was the #1 first-day blocker — without it all slash commands were 'command not found'.

**#100**: speckit/MAQA removed from required prerequisites. New prerequisites: OpenCode, gh CLI, git, python3. speckit moved to optional note in README dependencies section. Both onboarding guides updated.