### PR TITLE
feat(reports): daily rotation, agent identity, otherness version (#127 #128 #129)

### DIFF
--- a/.specify/specs/127-128-129/spec.md
+++ b/.specify/specs/127-128-129/spec.md
@@ -1,0 +1,53 @@
+# Spec: Report Improvements — Daily Rotation + Agent Identity + Version (Issues #127, #128, #129)
+
+## Zone 1 — Obligations (falsifiable)
+
+### O1: Session ID
+Every session generates a short, unique, session-scoped ID at startup.
+- **Violation**: Two concurrent sessions have the same ID, or the ID changes mid-session, or no ID is generated.
+- Format: `sess-<8hex>` (e.g. `sess-a3f24b1c`) derived from `os.urandom(4).hex()`.
+
+### O2: Otherness version
+Every session captures the otherness agent version at startup.
+- **Violation**: A session posts a comment without the version string, or the version is not captured.
+- Captured via: `git -C ~/.otherness describe --tags --always 2>/dev/null || git -C ~/.otherness rev-parse --short HEAD 2>/dev/null || echo "unknown"`.
+
+### O3: Comment header format
+Every comment posted to the report issue by standalone.md or any phase file includes the header:
+`[<BADGE> | <SESSION_ID> | otherness@<VERSION>]`
+- **Violation**: A comment to `$REPORT_ISSUE` is posted without session ID or version.
+- Existing startup comment: `[STANDALONE | sess-a3f2 | otherness@7ebbe14] Session started.`
+
+### O4: Daily report rotation
+At session startup (COORD phase 1a), check if the current report issue (`$REPORT_ISSUE`) was created on a previous UTC calendar day.
+- If it was: close it with a linking comment, create a new issue, update `$REPORT_ISSUE` in `state.json` and the running env.
+- **Violation**: A session starts on a new UTC day and continues posting to the old report issue instead of rotating.
+- **Violation**: The old issue is deleted or loses its history.
+- The new issue title follows the pattern: `📊 Autonomous Team Reports — YYYY-MM-DD`.
+
+### O5: State.json persists report_issue
+After daily rotation, the new `report_issue` number is written to `state.json` as `report_issue`.
+- **Violation**: After rotation, a second session in the same day reads state.json and creates another new issue.
+
+### O6: Graceful fallback
+If `git -C ~/.otherness ...` fails (no git, no repo): session ID still generated (random), version falls back to `"unknown"`. Report rotation is skipped on error, not crashed.
+- **Violation**: Agent crashes on startup when otherness dir is missing or git is unavailable.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Exact length of session ID (recommended: 8 hex chars from 4 random bytes).
+- Whether to put session ID + version in a single env var or two separate ones.
+- Whether daily rotation check happens before or after the rate-limit check (before is fine, it's cheap).
+- Label(s) on the newly created daily report issue (copy from old, or hardcode `otherness`).
+- Whether to update `AGENTS.md` `REPORT_ISSUE:` field on rotation (do NOT — that file must not be auto-modified per AGENTS.md §Files Agents Must Not Modify).
+
+---
+
+## Zone 3 — Scoped out
+
+- Updating `otherness-config.yaml` `report_issue:` field — not a source of truth at runtime; state.json + env var are enough.
+- Backfilling history: old comments don't get the new header format.
+- Weekly/monthly rotation granularity — daily only.
+- Bounded agents: they inherit `$REPORT_ISSUE`, `$MY_SESSION_ID`, `$OTHERNESS_VERSION` from the parent env; no separate changes to bounded-standalone.md needed.

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -52,7 +52,7 @@ with open('.otherness/state.json', 'w') as f: json.dump(s, f, indent=2)
   rm -f .otherness/stop-after-current
   export STATE_MSG="graceful stop"
   # run STATE MANAGEMENT write block
-  gh issue comment $REPORT_ISSUE --repo $REPO --body "[STANDALONE] Stopped cleanly." 2>/dev/null
+  gh issue comment $REPORT_ISSUE --repo $REPO --body "[STANDALONE | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] Stopped cleanly." 2>/dev/null
   exit 0
 fi
 
@@ -97,7 +97,7 @@ except: print(0)
 " 2>/dev/null || echo "0")
   if [ "${HOURS_RED:-0}" -ge 24 ]; then
     gh issue comment $REPORT_ISSUE --repo $REPO \
-      --body "[STANDALONE] [NEEDS HUMAN] CI has been red on main for ${HOURS_RED}h. Failing job: $FAILED." 2>/dev/null
+      --body "[STANDALONE | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] [NEEDS HUMAN] CI has been red on main for ${HOURS_RED}h. Failing job: $FAILED." 2>/dev/null
   fi
 fi
 ```
@@ -208,7 +208,7 @@ PYEOF
 
     git push origin --delete "$QUEUE_LOCK_BRANCH" 2>/dev/null || true
     gh issue comment $REPORT_ISSUE --repo $REPO \
-      --body "[COORD] Queue generated." 2>/dev/null
+      --body "[🎯 COORD | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] Queue generated." 2>/dev/null
   fi
 fi
 ```
@@ -356,7 +356,7 @@ except: print(999)
       [ -d "$LEARN_WT" ] && git worktree remove "$LEARN_WT" --force 2>/dev/null
       git worktree add "$LEARN_WT" "$LEARN_BRANCH"
       gh issue comment $REPORT_ISSUE --repo $REPO \
-        --body "[STANDALONE] Autonomous learn session triggered (${DAYS_SINCE_LEARN}d since last)." 2>/dev/null
+        --body "[STANDALONE | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] Autonomous learn session triggered (${DAYS_SINCE_LEARN}d since last)." 2>/dev/null
       # [AI-STEP] Navigate to $LEARN_WT, read and follow ~/.otherness/agents/otherness.learn.md
       # After learn PR open and CI green: merge and clean up
       gh pr merge "$LEARN_BRANCH" --repo "$REPO" --squash --delete-branch 2>/dev/null || true
@@ -372,11 +372,11 @@ fi
 MY_BRANCH="feat/$ITEM_ID"
 REPO_NAME=$(basename $(git rev-parse --show-toplevel))
 MY_WORKTREE="../${REPO_NAME}.${ITEM_ID}"
-MY_SESSION_ID="STANDALONE-${ITEM_ID}"
+# MY_SESSION_ID is set at startup (sess-XXXX) — preserve it; don't overwrite with item-scoped ID
 
 if git push origin "HEAD:refs/heads/$MY_BRANCH" 2>/dev/null; then
   echo "[COORD] ✅ Claimed $ITEM_ID"
-  export ITEM_ID MY_BRANCH MY_WORKTREE MY_SESSION_ID
+  export ITEM_ID MY_BRANCH MY_WORKTREE
 
   [ -d "$MY_WORKTREE" ] && git worktree remove "$MY_WORKTREE" --force 2>/dev/null
   git worktree add "$MY_WORKTREE" "$MY_BRANCH"
@@ -405,7 +405,7 @@ PYEOF
 
   ISSUE_NUM=$(echo $ITEM_ID | grep -oE '[0-9]+' | head -1)
   gh issue comment $ISSUE_NUM --repo $REPO \
-    --body "[$MY_SESSION_ID] Starting implementation. Branch: \`$MY_BRANCH\`" 2>/dev/null
+    --body "[$MY_SESSION_ID | otherness@${OTHERNESS_VERSION:-unknown}] Starting implementation. Branch: \`$MY_BRANCH\`" 2>/dev/null
 
 else
   echo "[COORD] ⚡ $ITEM_ID already claimed — picking another."

--- a/agents/phases/pm.md
+++ b/agents/phases/pm.md
@@ -73,5 +73,5 @@ fi
 
 ```bash
 gh issue comment $REPORT_ISSUE --repo $REPO \
-  --body "[📋 PM] Product review complete." 2>/dev/null
+  --body "[📋 PM | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] Product review complete." 2>/dev/null
 ```

--- a/agents/phases/qa.md
+++ b/agents/phases/qa.md
@@ -84,7 +84,7 @@ between two design commitments — post `[NEEDS HUMAN]` with the exact conflicti
 # Post review comment on PR
 gh pr review $PR_NUM --repo $REPO \
   --approve \
-  --body "[QA] APPROVED — spec conformance ✓, CI ✓, no blocking findings."
+  --body "[🔍 QA | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] APPROVED — spec conformance ✓, CI ✓, no blocking findings."
 ```
 
 **CRITICAL TIER — AUTONOMOUS MODE SELF-REVIEW PROTOCOL**

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -120,5 +120,5 @@ with open('.otherness/state.json', 'w') as f: json.dump(s, f, indent=2)
 
 ```bash
 gh issue comment $REPORT_ISSUE --repo $REPO \
-  --body "[🔄 SDM] Batch complete. Metrics updated. Triage done." 2>/dev/null
+  --body "[🔄 SDM | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] Batch complete. Metrics updated. Triage done." 2>/dev/null
 ```

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -220,15 +220,99 @@ for line in open('otherness-config.yaml'):
         if m: print(m.group(1)); break
 " 2>/dev/null || echo "true")
 
-export REPO REPO_NAME REPORT_ISSUE PR_LABEL BUILD_COMMAND TEST_COMMAND LINT_COMMAND JOB_FAMILY AUTONOMOUS_MODE
+# Session identity — unique per session, stable for its lifetime
+MY_SESSION_ID="sess-$(python3 -c 'import os; print(os.urandom(4).hex())' 2>/dev/null || echo "$(date +%s | tail -c 9)")"
 
-echo "[STANDALONE] Project: $REPO | Role: $JOB_FAMILY | Autonomous: $AUTONOMOUS_MODE | Report: #$REPORT_ISSUE"
+# Otherness version — for correlating behaviour to agent release
+OTHERNESS_VERSION=$(git -C ~/.otherness describe --tags --always 2>/dev/null \
+  || git -C ~/.otherness rev-parse --short HEAD 2>/dev/null \
+  || echo "unknown")
+
+# Daily report rotation: check if REPORT_ISSUE was created on a previous UTC day;
+# if so, close it and open a fresh one (history preserved).
+REPORT_ISSUE=$(python3 - <<'ROTATE_EOF'
+import subprocess, json, datetime, re, os, sys
+
+# Read base report_issue: state.json > AGENTS.md > otherness-config.yaml
+report_issue = None
+try:
+    r = subprocess.run(['git','show','origin/_state:.otherness/state.json'],
+                       capture_output=True, text=True)
+    if r.returncode == 0:
+        s = json.loads(r.stdout)
+        report_issue = str(s.get('report_issue', '')).strip() or None
+except: pass
+
+if not report_issue:
+    try:
+        for line in open('AGENTS.md'):
+            m = re.match(r'^REPORT_ISSUE:\s*(\S+)', line.strip())
+            if m: report_issue = m.group(1); break
+    except: pass
+
+if not report_issue:
+    try:
+        for line in open('otherness-config.yaml'):
+            m = re.match(r'^\s+report_issue:\s*(\S+)', line)
+            if m: report_issue = m.group(1); break
+    except: pass
+
+if not report_issue:
+    report_issue = '1'
+
+# Check creation date of current report issue
+REPO = os.environ.get('REPO', '')
+PR_LABEL = os.environ.get('PR_LABEL', 'otherness')
+try:
+    r = subprocess.run(['gh','issue','view',report_issue,'--repo',REPO,
+                        '--json','createdAt','--jq','.createdAt'],
+                       capture_output=True, text=True)
+    if r.returncode == 0:
+        created = r.stdout.strip().strip('"')
+        created_date = datetime.datetime.fromisoformat(created.replace('Z','+00:00')).date()
+        today = datetime.datetime.now(datetime.timezone.utc).date()
+        if created_date < today:
+            today_str = today.strftime('%Y-%m-%d')
+            # Create new issue
+            new_title = f'📊 Autonomous Team Reports — {today_str}'
+            cr = subprocess.run(['gh','issue','create','--repo',REPO,
+                                 '--title',new_title,
+                                 '--label',PR_LABEL,
+                                 '--body',f'Daily autonomous team report. Continued from #{report_issue}.'],
+                                capture_output=True, text=True)
+            if cr.returncode == 0:
+                new_url = cr.stdout.strip()
+                new_num = new_url.split('/')[-1]
+                # Close old issue with pointer to new
+                subprocess.run(['gh','issue','comment',report_issue,'--repo',REPO,
+                                '--body',f'[ROTATE] Day boundary reached. Continuing in #{new_num}: {new_url}'],
+                               capture_output=True)
+                subprocess.run(['gh','issue','close',report_issue,'--repo',REPO,
+                                '--comment',f'Daily rotation complete. New report: #{new_num}'],
+                               capture_output=True)
+                # Persist new report_issue to state.json
+                try:
+                    with open('.otherness/state.json') as f: s = json.load(f)
+                    s['report_issue'] = int(new_num)
+                    with open('.otherness/state.json', 'w') as f: json.dump(s, f, indent=2)
+                except: pass
+                print(new_num)
+                sys.exit(0)
+except: pass
+
+print(report_issue)
+ROTATE_EOF
+)
+
+export REPO REPO_NAME REPORT_ISSUE PR_LABEL BUILD_COMMAND TEST_COMMAND LINT_COMMAND JOB_FAMILY AUTONOMOUS_MODE MY_SESSION_ID OTHERNESS_VERSION
+
+echo "[STANDALONE | $MY_SESSION_ID | otherness@$OTHERNESS_VERSION] Project: $REPO | Role: $JOB_FAMILY | Autonomous: $AUTONOMOUS_MODE | Report: #$REPORT_ISSUE"
 ```
 
 Post startup comment:
 ```bash
 gh issue comment $REPORT_ISSUE --repo $REPO \
-  --body "[STANDALONE] Session started. Repo: \`$REPO\`. Role: $JOB_FAMILY." 2>/dev/null
+  --body "[STANDALONE | $MY_SESSION_ID | otherness@$OTHERNESS_VERSION] Session started. Repo: \`$REPO\`. Role: $JOB_FAMILY." 2>/dev/null
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **#127** Daily rotation: at COORD startup, report issue created on a prior UTC day is closed with a history link and a new dated issue is opened. New number persisted to `state.json` + env.
- **#128** Agent identity: every session generates `sess-XXXX` (4 random bytes hex) at startup, stable for the session lifetime.
- **#129** Otherness version: captured via `git -C ~/.otherness describe --tags --always` at startup.

All three values appear in every report issue comment as:
`[🎯 COORD | sess-a3f24b1c | otherness@v1.2.0] ...`

## Files changed

- `agents/standalone.md` — session ID generation, version capture, daily rotation block, updated export + startup comment
- `agents/phases/coord.md` — all `[STANDALONE]` / `[COORD]` comments updated; item claim no longer overwrites session ID
- `agents/phases/sm.md`, `pm.md`, `qa.md` — report comments updated with session header

## Risk

CRITICAL tier (touches standalone.md + phase files). AUTONOMOUS_MODE=true — self-review follows.

## Validation

`scripts/validate.sh`: ✅ PASSED
`scripts/lint.sh`: ✅ PASSED

Closes #127. Closes #128. Closes #129.