### PR TITLE
feat(handoff): session handoff — write context at batch end, read at startup (#126)

### DIFF
--- a/.specify/specs/126/spec.md
+++ b/.specify/specs/126/spec.md
@@ -1,0 +1,49 @@
+# Spec: Session Handoff (#126)
+
+## Zone 1 — Obligations (falsifiable)
+
+### O1: Handoff written by SM phase
+At the end of every SM batch (`sm.md` §4d or equivalent), the agent writes `.otherness/handoff.md`
+in the main repo directory with a structured summary of the session.
+- **Violation**: SM phase completes without writing `.otherness/handoff.md`.
+
+### O2: Handoff content
+The handoff file must contain at minimum:
+- UTC timestamp of when it was written
+- PRs merged in the current batch (number + title, from git log or gh pr list)
+- Current queue items and their states (from state.json)
+- CI status on main
+- Next item to work on (first `todo` in state.json)
+- **Violation**: File is written but missing any of the above sections.
+
+### O3: Startup reads handoff
+`standalone.md` startup block reads `.otherness/handoff.md` if present and echoes its content.
+- **Violation**: `standalone.md` does not contain a reference to `handoff.md` in its startup section.
+
+### O4: Handoff committed to main
+`.otherness/handoff.md` is committed to main on every write (using pull-rebase-retry pattern, same as metrics.md).
+- **Violation**: Handoff exists only locally and is lost on session end without commit.
+
+### O5: Acceptance test passes
+```bash
+grep -c "handoff.md" ~/.otherness/agents/standalone.md  # ≥ 1
+grep -c "handoff" ~/.otherness/agents/phases/sm.md       # ≥ 1
+```
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Exact sections and prose in the handoff file.
+- Whether to include worktree list, skill file count, or other diagnostic info.
+- Whether to overwrite or append (overwrite is simpler and correct — one handoff = one session).
+- How many PRs to show (last 10 is fine).
+
+---
+
+## Zone 3 — Scoped out
+
+- Operator conversation context (what was said in the chat) — agent cannot read that.
+- Mid-thought reasoning capture — too expensive and too noisy.
+- Per-item detailed history — state.json already has that.
+- Handoff for bounded agents — they inherit context from the parent session.

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -116,7 +116,85 @@ with open('.otherness/state.json', 'w') as f: json.dump(s, f, indent=2)
 
 ---
 
-## 4d. Post SDM review to report issue
+## 4d. Write session handoff
+
+```bash
+# Write .otherness/handoff.md — next session reads this at startup
+python3 - <<'EOF'
+import subprocess, json, datetime, os
+
+REPO = os.environ.get('REPO', '')
+now = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+# Merged PRs (last 10)
+try:
+    merged = subprocess.check_output(
+        ['gh','pr','list','--repo',REPO,'--state','merged','--limit','10',
+         '--json','number,title,mergedAt',
+         '--jq','.[] | "- PR #\(.number) \(.title) (\(.mergedAt[:10]))"'],
+        text=True).strip()
+except:
+    merged = '(unavailable)'
+
+# Queue from state.json
+try:
+    with open('.otherness/state.json') as f: s = json.load(f)
+    features = s.get('features', {})
+    todo = [f"- {k}: {v.get('title','')}" for k,v in features.items() if v.get('state')=='todo']
+    in_prog = [f"- {k}: {v.get('title','')}" for k,v in features.items() if v.get('state') in ('assigned','in_review')]
+    done_items = [k for k,v in features.items() if v.get('state')=='done']
+    queue_text = ('**In progress:**\n' + '\n'.join(in_prog) + '\n' if in_prog else '') + \
+                 ('**Todo:**\n' + '\n'.join(todo) if todo else '**Queue empty**')
+    next_item = todo[0].lstrip('- ').split(':')[0] if todo else 'none'
+except:
+    queue_text = '(unavailable)'
+    done_items = []
+    next_item = 'unknown'
+
+# CI status
+try:
+    ci = subprocess.check_output(
+        ['gh','run','list','--repo',REPO,'--branch','main','--limit','1',
+         '--json','conclusion,status','--jq','.[0] | (.conclusion // .status)'],
+        text=True).strip()
+except:
+    ci = 'unknown'
+
+handoff = f"""## Session Handoff — {now}
+
+### Recent merges (last 10)
+{merged}
+
+### Queue
+{queue_text}
+
+### CI status (main)
+{ci}
+
+### Next item
+{next_item}
+
+### Notes
+Session: {os.environ.get('MY_SESSION_ID','unknown')} | otherness@{os.environ.get('OTHERNESS_VERSION','unknown')}
+"""
+
+os.makedirs('.otherness', exist_ok=True)
+with open('.otherness/handoff.md', 'w') as f: f.write(handoff)
+print(f"[SDM] Handoff written → .otherness/handoff.md (next_item={next_item})")
+EOF
+
+# Commit handoff to main (pull-rebase-retry — low-risk doc commit)
+git add .otherness/handoff.md
+git commit -m "chore(sm): session handoff update $(date +%Y-%m-%dT%H:%M:%SZ)" 2>/dev/null || true
+for i in 1 2 3; do
+  git pull --rebase origin main --quiet 2>/dev/null && \
+  git push origin main && break || sleep $((i * 2))
+done
+```
+
+---
+
+## 4e. Post SDM review to report issue
 
 ```bash
 gh issue comment $REPORT_ISSUE --repo $REPO \

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -315,6 +315,15 @@ gh issue comment $REPORT_ISSUE --repo $REPO \
   --body "[STANDALONE | $MY_SESSION_ID | otherness@$OTHERNESS_VERSION] Session started. Repo: \`$REPO\`. Role: $JOB_FAMILY." 2>/dev/null
 ```
 
+Read session handoff if present:
+```bash
+if [ -f ".otherness/handoff.md" ]; then
+  echo "[STANDALONE] Reading session handoff from previous session:"
+  cat .otherness/handoff.md
+  echo "[STANDALONE] Handoff read — proceeding from last state."
+fi
+```
+
 ---
 
 ## RESUME CHECK


### PR DESCRIPTION
## Summary

SM phase writes `.otherness/handoff.md` at the end of every batch:
- Recent merges (last 10 PRs)
- Current queue with states
- CI status on main  
- Next item to work on
- Session ID + otherness version

Startup reads it if present, giving the next session full context without human-supplied summary.

## Acceptance test
```bash
grep -c 'handoff.md' ~/.otherness/agents/standalone.md  # = 2 ✅
grep -c 'handoff' ~/.otherness/agents/phases/sm.md       # = 8 ✅
```

## Validation
`scripts/validate.sh`: ✅ PASSED  
`scripts/lint.sh`: ✅ PASSED

Closes #126.