### PR TITLE
feat(qa): mandatory spec conformance check — blocks PR if spec missing (#121)

### DIFF
--- a/.specify/specs/121/spec.md
+++ b/.specify/specs/121/spec.md
@@ -1,0 +1,37 @@
+# Spec: Mandatory Spec Conformance Check (#121)
+
+## Zone 1 — Obligations (falsifiable)
+
+### O1: Missing spec is a WRONG finding
+If `spec.md` does not exist at `$MY_WORKTREE/.specify/specs/$ITEM_ID/spec.md`, QA must emit a
+WRONG finding and not approve the PR.
+- **Violation**: QA approves a PR that has no spec.md.
+
+### O2: Spec conformance check before code review
+QA must complete the spec conformance check (verify every Zone 1 obligation) before reading
+the code diff for quality issues.
+- **Violation**: QA approves with code quality checks but no conformance check.
+
+### O3: Hard rule in standalone.md
+`standalone.md` HARD RULES must explicitly state that spec conformance check is mandatory.
+- **Violation**: `grep -c "spec.*conformance|conformance.*check|zone.*1.*obligation" agents/standalone.md` returns 0.
+
+### O4: Acceptance test passes
+```bash
+grep -c "spec.*conformance" ~/.otherness/agents/standalone.md  # ≥ 1
+```
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Exact wording of the WRONG message when spec is missing.
+- Whether to also check `bounded-standalone.md` (not needed — it delegates to standalone.md).
+
+---
+
+## Zone 3 — Scoped out
+
+- Enforcing three-zone structure quality programmatically (too hard to validate statically).
+- Auto-generating spec.md (that's ENG's job).
+- Enforcing spec on non-otherness projects using otherness (they may not use speckit).

--- a/agents/phases/qa.md
+++ b/agents/phases/qa.md
@@ -37,17 +37,24 @@ fi
 
 ---
 
-## 3b. Spec conformance check (step 0 — mandatory before code review)
+## 3b. Spec conformance check (step 0 — **MANDATORY**, blocks approval)
+
+**This check is not optional. QA cannot approve without completing it.**
 
 ```bash
 SPEC_FILE="$MY_WORKTREE/.specify/specs/$ITEM_ID/spec.md"
-if [ -f "$SPEC_FILE" ]; then
+if [ ! -f "$SPEC_FILE" ]; then
+  echo "[QA] WRONG — spec.md missing at $SPEC_FILE"
+  echo "[QA] ENG must write spec.md (three-zone structure) before PR can be approved."
+  echo "[QA] Returning to ENG phase — write spec first, then re-push."
+  # [AI-STEP] Go back to ENG phase 2b, write the spec, commit it, re-enter QA
+else
   echo "[QA] Running spec conformance check..."
   # [AI-STEP] For each Zone 1 obligation in spec.md:
   #   1. Find the corresponding code in the diff
   #   2. Verify the behavior matches the obligation
-  #   3. If any obligation unimplemented or misimplemented: WRONG finding — must fix
-  # This is the highest-priority check. Cannot approve without completing it.
+  #   3. If any obligation unimplemented or misimplemented: WRONG finding — must fix before approve
+  # All obligations must be verified. This is the highest-priority check.
 fi
 ```
 

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -437,4 +437,5 @@ Loser picks a different item. See coord.md §1c.
 - **Rate limit guard**: check `gh api rate_limit` before API-heavy operations. Sleep until reset if <300 remaining.
 - **`[NEEDS HUMAN]` + `AUTONOMOUS_MODE=true`**: attempt autonomous resolution first. Escalate with concrete recommendation if judgment call needed.
 - **Adversarial QA. TDD always. Max 3 QA cycles.**
+- **Spec conformance check is mandatory.** QA cannot approve a PR without verifying every Zone 1 obligation in spec.md is satisfied. No spec file = WRONG finding (ENG must write one). See qa.md §3b.
 - **Perfection is the direction, not the destination.**


### PR DESCRIPTION
## Summary

QA phase 3b was conditionally skipped if `spec.md` was missing. Now it's a hard gate:
- **No spec.md → WRONG finding**, QA sends ENG back to write it
- **Hard rule added to `standalone.md`**: _"Spec conformance check is mandatory. QA cannot approve a PR without verifying every Zone 1 obligation in spec.md is satisfied. No spec file = WRONG finding (ENG must write one)."_

## Why
Root cause of most QA cycles across observed projects: implementation drift from spec. Making spec conformance the first and mandatory QA step creates a hard feedback loop.

## Acceptance test
```bash
grep -c 'spec.*conformance' ~/.otherness/agents/standalone.md  # = 1 ✅
```

## Validation
`scripts/validate.sh`: ✅ PASSED  
`scripts/lint.sh`: ✅ PASSED

Closes #121.