### PR TITLE
feat(pinning): complete version pinning — v0.1.0 tag, /otherness.upgrade rewrite, rollback docs (#115)

### DIFF
--- a/.opencode/command/otherness.upgrade.md
+++ b/.opencode/command/otherness.upgrade.md
@@ -1,164 +1,138 @@
 ---
-description: "DEV: Check for speckit/maqa/aide/extension updates, show changelog, and apply with confirmation. Run by the otherness maintainer, not customers."
+description: "Show available otherness versions, changelog preview, and guide pinning/unpinning agent_version."
 ---
 
-You are the otherness dependency upgrade agent. You check for new versions of speckit, maqa, aide, and other extensions that otherness depends on, show what changed, and apply updates.
+You are the otherness version manager. You show available releases, what changed, and help the operator pin or unpin their agent version.
 
-## Step 1 — Current installed versions
-
-```bash
-echo "=== Installed versions ==="
-echo "speckit (opencode integration):"
-python3 -c "import json; d=json.load(open('.specify/integrations/speckit.manifest.json')); print(f'  v{d[\"version\"]} installed {d[\"installed_at\"][:10]}')" 2>/dev/null || echo "  not found"
-
-echo "opencode integration:"
-python3 -c "import json; d=json.load(open('.specify/integrations/opencode.manifest.json')); print(f'  v{d[\"version\"]} installed {d[\"installed_at\"][:10]}')" 2>/dev/null || echo "  not found"
-
-echo "otherness agent files:"
-git -C ~/.otherness log --oneline -5 2>/dev/null | sed 's/^/  /' || echo "  not a git repo"
-
-echo "Extensions:"
-ls .specify/extensions/ 2>/dev/null | grep -v '^\.' | sed 's/^/  /'
-```
-
-## Step 2 — Check community catalog for updates
+## Step 1 — Current pinned version
 
 ```bash
-echo ""
-echo "=== Checking community catalog ==="
-CATALOG_URL=$(python3 -c "
+CURRENT_PIN=$(python3 -c "
 import re
-for line in open('.specify/extension-catalogs.yml'):
-    m = re.match(r'^\s+url:\s*(.+)', line)
-    if m: print(m.group(1).strip()); break
-" 2>/dev/null || echo "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json")
+for line in open('otherness-config.yaml'):
+    m = re.match(r'^\s+agent_version:\s*[\"\'']?([^\"\'#\n]+)[\"\'']?', line)
+    if m:
+        v = m.group(1).strip()
+        if v not in ('', 'null'):
+            print(v); break
+" 2>/dev/null || echo "")
 
-curl -sL "$CATALOG_URL" 2>/dev/null | python3 - << 'EOF'
-import sys, re
-content = sys.stdin.read()
-# Extract extension names and versions from the catalog YAML
-extensions = re.findall(r'^\s+name:\s+(\S+).*?version:\s+(\S+)', content, re.MULTILINE | re.DOTALL)
-for ext in ['maqa', 'aide', 'maqa-ci', 'maqa-github-projects', 'verify', 'verify-tasks', 'review', 'ship', 'worktree', 'git']:
-    for name, version in extensions:
-        if name == ext:
-            print(f"  {name}: {version}")
-            break
-EOF
-```
-
-## Step 3 — Check otherness upstream for new commits
-
-```bash
-echo ""
-echo "=== otherness upstream (pnz1990/otherness) ==="
-git -C ~/.otherness fetch --quiet 2>/dev/null
-
-LOCAL=$(git -C ~/.otherness rev-parse HEAD 2>/dev/null)
-REMOTE=$(git -C ~/.otherness rev-parse origin/main 2>/dev/null)
-
-if [ "$LOCAL" = "$REMOTE" ]; then
-  echo "  Up to date."
+if [ -z "$CURRENT_PIN" ]; then
+  echo "Current: unpinned (running latest — git pull on every startup)"
 else
-  echo "  New commits available:"
-  git -C ~/.otherness log --oneline "$LOCAL..$REMOTE" 2>/dev/null | sed 's/^/    /'
+  echo "Current: pinned to $CURRENT_PIN"
+  RUNNING=$(git -C ~/.otherness describe --tags --always 2>/dev/null || echo "unknown")
+  echo "Running: $RUNNING"
+  if [ "$RUNNING" != "$CURRENT_PIN" ]; then
+    echo "⚠️  WARNING: running version differs from pin — may be behind or ahead"
+  fi
 fi
 ```
 
-## Step 4 — Check speckit CLI version
+## Step 2 — Available releases (changelog preview)
 
 ```bash
 echo ""
-echo "=== speckit CLI ==="
-specify --version 2>/dev/null || echo "  specify not installed (uv tool install specify-cli)"
+echo "=== Available releases ==="
+gh release list --repo pnz1990/otherness --limit 10 \
+  --json tagName,name,publishedAt \
+  --jq '.[] | "\(.tagName)  \(.name)  (\(.publishedAt[:10]))"' 2>/dev/null \
+  || echo "(no releases found — repo may be unpinned-only)"
 
-# Check PyPI for latest
-LATEST=$(curl -s https://pypi.org/pypi/specify-cli/json 2>/dev/null | \
-  python3 -c "import json,sys; d=json.load(sys.stdin); print(d['info']['version'])" 2>/dev/null || echo "unknown")
-echo "  Latest on PyPI: $LATEST"
-```
-
-## Step 5 — Present update plan and confirm
-
-Based on the above findings, produce a summary:
-
-```
-=== UPDATE PLAN ===
-
-otherness agent files: <N new commits — titles>
-speckit CLI: <current> → <latest>
-maqa extension: <current> → <latest>
-aide extension: <current> → <latest>
-<any other extensions with available updates>
-
-Apply? (yes/no)
-```
-
-Wait for confirmation before applying any changes.
-
-## Step 6 — Apply updates (on confirmation)
-
-### Update otherness agent files
-```bash
-git -C ~/.otherness pull --quiet
-echo "otherness: updated to $(git -C ~/.otherness rev-parse --short HEAD)"
-```
-
-### Upgrade speckit CLI
-```bash
-uv tool upgrade specify-cli 2>/dev/null || pip install --upgrade specify-cli 2>/dev/null
-specify --version
-```
-
-### Update extensions via speckit
-For each extension with an available update:
-```bash
-# Re-install extension (speckit handles version pinning)
-specify extension update <extension-name>
-```
-
-### Update manifest checksums
-After updating command files, update the manifest:
-```bash
-python3 - << 'EOF'
-import json, hashlib, os
-
-def sha256(path):
-    with open(path, 'rb') as f:
-        return hashlib.sha256(f.read()).hexdigest()
-
-manifest = json.load(open('.specify/integrations/opencode.manifest.json'))
-updated = {}
-for path in manifest['files']:
-    if os.path.exists(path):
-        updated[path] = sha256(path)
-    else:
-        updated[path] = manifest['files'][path]  # keep old if file missing
-
-manifest['files'] = updated
-with open('.specify/integrations/opencode.manifest.json', 'w') as f:
-    json.dump(manifest, f, indent=2)
-print("Updated opencode manifest checksums.")
-EOF
-```
-
-## Step 7 — Verify after update
-
-```bash
 echo ""
-echo "=== Post-update verification ==="
-echo "otherness: $(git -C ~/.otherness log --oneline -1 2>/dev/null)"
-specify --version 2>/dev/null || echo "specify: not installed"
-echo ""
-echo "Run /otherness.run to start the updated agent."
+echo "=== Recent commits on main (unpinned changelog) ==="
+git -C ~/.otherness fetch --quiet 2>/dev/null
+git -C ~/.otherness log --oneline -10 origin/main 2>/dev/null | sed 's/^/  /'
 ```
 
-## What each dependency provides and when to update
+## Step 3 — Show release notes for a specific version (optional)
 
-| Dependency | What it adds | How often to update |
-|---|---|---|
-| **otherness** (`~/.otherness/`) | Agent loops, GitHub PM, roles, PDCA | On every session (auto via git pull) |
-| **speckit CLI** | Internal spec workflow commands | When new queue/item/verify features ship |
-| **maqa extension** | State machine conventions, bounded sessions | When new coordination patterns available |
-| **aide extension** | Queue/roadmap generation improvements | When roadmap-to-items translation improves |
-| **verify/verify-tasks** | Phantom completion detection | When new anti-patterns are caught |
-| **review extensions** | Code review sub-agents | When new review dimensions available |
+If the operator asks about a specific version:
+
+```bash
+# Replace TAG with the version of interest
+gh release view TAG --repo pnz1990/otherness 2>/dev/null
+```
+
+## Step 4 — Pin to a version
+
+To pin `otherness-config.yaml` to a specific release:
+
+```bash
+# Replace vX.Y.Z with the desired tag
+TARGET_VERSION="vX.Y.Z"
+
+python3 - <<PYEOF
+import re
+
+with open('otherness-config.yaml') as f:
+    content = f.read()
+
+# Replace existing agent_version value (or add it under maqa:)
+if re.search(r'^\s+agent_version:', content, re.MULTILINE):
+    content = re.sub(
+        r'(^\s+agent_version:\s*).*',
+        f'\\g<1>"$TARGET_VERSION"',
+        content, flags=re.MULTILINE
+    )
+else:
+    content = re.sub(
+        r'(^maqa:)',
+        f'\\1\n  agent_version: "$TARGET_VERSION"',
+        content, flags=re.MULTILINE
+    )
+
+with open('otherness-config.yaml', 'w') as f:
+    f.write(content)
+print(f"Pinned to $TARGET_VERSION in otherness-config.yaml")
+PYEOF
+```
+
+Then commit:
+```bash
+git add otherness-config.yaml
+git commit -m "chore: pin otherness to $TARGET_VERSION"
+git push origin main
+```
+
+**After pinning**: the next session startup will checkout `$TARGET_VERSION` from `~/.otherness` instead of pulling latest.
+
+## Step 5 — Unpin (return to latest)
+
+```bash
+python3 - <<PYEOF
+import re
+
+with open('otherness-config.yaml') as f:
+    content = f.read()
+
+content = re.sub(
+    r'(^\s+agent_version:\s*).*',
+    '\\g<1>""',
+    content, flags=re.MULTILINE
+)
+
+with open('otherness-config.yaml', 'w') as f:
+    f.write(content)
+print("Unpinned — will pull latest on next startup.")
+PYEOF
+
+git add otherness-config.yaml
+git commit -m "chore: unpin otherness (return to latest)"
+git push origin main
+```
+
+## Step 6 — Verify the pin is active
+
+Start a new otherness session. The startup log will show:
+```
+[STANDALONE] Pinned to vX.Y.Z
+```
+
+If it shows `[STANDALONE] Agent files up to date (latest)` then the pin is not set or the tag doesn't exist.
+
+---
+
+## Rollback after a bad release
+
+See `RECOVERY.md` §Situation 8 for the full rollback procedure (pin to the previous tag).

--- a/.specify/specs/115/spec.md
+++ b/.specify/specs/115/spec.md
@@ -1,0 +1,41 @@
+# Spec: Complete Version Pinning (#115)
+
+## Zone 1 — Obligations (falsifiable)
+
+### O1: First release tag exists
+A git tag `v0.1.0` and corresponding GitHub release exists on `pnz1990/otherness`.
+- **Violation**: `gh release list --repo pnz1990/otherness --limit 1` returns empty.
+
+### O2: /otherness.upgrade rewrites for version pinning
+`.opencode/command/otherness.upgrade.md` is rewritten to:
+- Show the current pinned version (from `otherness-config.yaml` `agent_version`) or "unpinned (latest)"
+- List available tags with their commit subjects (changelog preview)
+- Guide the user to set `agent_version: vX.Y.Z` in `otherness-config.yaml`
+- **Violation**: The file contains only the old speckit/extension content with no mention of `agent_version` or `changelog`.
+
+### O3: Acceptance test passes
+```bash
+grep -c "changelog\|agent_version\|bump" ~/.otherness/.opencode/command/otherness.upgrade.md
+# Must return ≥ 1
+```
+
+### O4: Rollback documented in RECOVERY.md
+RECOVERY.md contains a section explaining how to pin to a previous tag when a bad agent version is deployed.
+- **Violation**: RECOVERY.md has no mention of version pinning or `agent_version` rollback.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Tag message for v0.1.0 (should describe the state at this point in the project).
+- Whether to also update `otherness-config-template.yaml` to show a commented example.
+- Exact prose in the upgrade command.
+
+---
+
+## Zone 3 — Scoped out
+
+- Automated tag creation CI (manual tagging by maintainer is sufficient for now).
+- Auto-bumping version on every merge (too noisy; operator-driven).
+- Semantic versioning enforcement tooling.
+- Projects pinned to non-existent tags — they already fall back gracefully per standalone.md.

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -172,6 +172,47 @@ rm -rf docs/aide/
 
 ---
 
+## Situation 8: A bad otherness release broke my agent — I need to roll back
+
+If a new otherness release caused regressions (e.g. agents get stuck, wrong behavior), you can pin your project to the last known-good version.
+
+```bash
+# 1. List available releases to find the last good one
+gh release list --repo pnz1990/otherness --limit 10
+
+# 2. Pin your project to that version
+# Edit otherness-config.yaml:
+#   maqa:
+#     agent_version: "v0.1.0"   ← replace with the last good tag
+python3 - <<PYEOF
+import re
+TARGET = "v0.1.0"  # replace with desired version
+with open('otherness-config.yaml') as f:
+    content = f.read()
+if re.search(r'^\s+agent_version:', content, re.MULTILINE):
+    content = re.sub(r'(^\s+agent_version:\s*).*', f'\\g<1>"{TARGET}"', content, flags=re.MULTILINE)
+else:
+    content = re.sub(r'(^maqa:)', f'\\1\n  agent_version: "{TARGET}"', content, flags=re.MULTILINE)
+with open('otherness-config.yaml', 'w') as f:
+    f.write(content)
+print(f"Pinned to {TARGET}")
+PYEOF
+
+# 3. Commit the pin
+git add otherness-config.yaml
+git commit -m "fix: pin otherness to last known-good version"
+git push origin main
+
+# 4. Restart your otherness session — startup will show:
+#    [STANDALONE] Pinned to v0.1.0
+```
+
+To report the regression to the otherness team: open an issue on https://github.com/pnz1990/otherness with label `priority/critical` and the exact agent version where the problem appeared.
+
+To unpin once the regression is fixed: run `/otherness.upgrade` → Step 5.
+
+---
+
 ## Quick reference
 
 | What happened | Fix |
@@ -183,3 +224,4 @@ rm -rf docs/aide/
 | Agent stuck on `[NEEDS HUMAN]` | Read the issue, fix the root cause, close it |
 | State JSON corrupt | Delete `_state` branch, re-run `/otherness.setup` |
 | Orphaned worktrees | `git worktree prune` |
+| Bad otherness release | Pin to previous tag in `otherness-config.yaml` (Situation 8) |


### PR DESCRIPTION
## Summary

- **GitHub release `v0.1.0`** created on `pnz1990/otherness` — first stable release
- **`/otherness.upgrade`** rewritten: shows current pin, lists available releases with dates, guides pin/unpin of `agent_version` in `otherness-config.yaml`
- **RECOVERY.md Situation 8** added: how to pin to a previous tag when a bad release is deployed

## Acceptance tests

```bash
gh release list --repo pnz1990/otherness --limit 3  # ✅ v0.1.0 present
grep -c 'changelog\|agent_version\|bump' ~/.otherness/.opencode/command/otherness.upgrade.md  # = 9 ✅
```

## Validation

`scripts/validate.sh`: ✅ PASSED  
`scripts/lint.sh`: ✅ PASSED

Closes #115.