### PR TITLE
fix(ci): CI provider abstraction — CircleCI/GitLab/unknown (#114)

### DIFF
--- a/.specify/specs/114/spec.md
+++ b/.specify/specs/114/spec.md
@@ -1,0 +1,38 @@
+# Spec: CI Provider Abstraction (#114)
+
+## Zone 1 — Obligations (falsifiable)
+
+### O1: CI_PROVIDER dispatched in coord.md
+The CI check in `coord.md` §1a reads `CI_PROVIDER` from `otherness-config.yaml` and dispatches:
+- `github-actions` → existing `gh run list` path
+- `circleci` → CircleCI v2 API call (warns if token not set, skips gate rather than silently passing)
+- `gitlab` → GitLab pipelines API call (warns if token not set, skips gate)
+- Unknown → warn and skip CI gate explicitly (log the skip, don't silently pass)
+- **Violation**: A non-GitHub project proceeds to claim work without any CI check or warning.
+
+### O2: Acceptance test passes
+```bash
+grep -c "CI_PROVIDER\|circleci\|gitlab" ~/.otherness/agents/phases/coord.md  # ≥ 1
+```
+Note: acceptance test in issue says `standalone.md` but the CI check lives in `coord.md`. Satisfying `coord.md` is correct; `standalone.md` reads `CI_PROVIDER` in startup so both can satisfy.
+
+### O3: Unknown provider is logged, not silently skipped
+When CI_PROVIDER is unknown, the agent prints a warning that includes the provider name.
+- **Violation**: Agent proceeds without any output when provider is unrecognized.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to also update `standalone.md` startup to export `CI_PROVIDER` (recommended — cleaner dispatch).
+- Exact CircleCI API endpoint and token env var name (`CIRCLE_TOKEN`).
+- Exact GitLab API endpoint and token env var name (`GITLAB_TOKEN`).
+- Whether to support `bitbucket` (low-demand — skip for now, log as unknown).
+
+---
+
+## Zone 3 — Scoped out
+
+- Full CircleCI/GitLab CI failure detail reporting (just green/red is enough).
+- Automatic token provision.
+- Other CI providers (Jenkins, Travis, etc.) — unknown → skip is sufficient.

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -56,12 +56,17 @@ with open('.otherness/state.json', 'w') as f: json.dump(s, f, indent=2)
   exit 0
 fi
 
-# CI check
-CI_STATUS=$(gh run list --repo $REPO --branch main --limit 5 \
-  --json conclusion,status,name,createdAt \
-  --jq '[.[] | {conclusion,status,name,createdAt}]' 2>/dev/null || echo "[]")
+# CI check — dispatched by CI_PROVIDER
+_CI_PROVIDER="${CI_PROVIDER:-github-actions}"
+FAILED=""
 
-FAILED=$(echo "$CI_STATUS" | python3 -c "
+case "$_CI_PROVIDER" in
+  github-actions)
+    CI_STATUS=$(gh run list --repo $REPO --branch main --limit 5 \
+      --json conclusion,status,name,createdAt \
+      --jq '[.[] | {conclusion,status,name,createdAt}]' 2>/dev/null || echo "[]")
+
+    FAILED=$(echo "$CI_STATUS" | python3 -c "
 import json, sys, datetime
 runs = json.load(sys.stdin)
 for r in runs:
@@ -75,6 +80,49 @@ for r in runs:
             if mins > 30: print(f'HUNG: {r[\"name\"]} ({mins:.0f}m)'); exit()
         except: pass
 " 2>/dev/null)
+    ;;
+
+  circleci)
+    # Requires CIRCLE_TOKEN env var; warns and skips gate if unset
+    if [ -z "$CIRCLE_TOKEN" ]; then
+      echo "[COORD] ⚠️  CI_PROVIDER=circleci but CIRCLE_TOKEN not set — skipping CI gate"
+    else
+      CI_JSON=$(curl -s -H "Circle-Token: $CIRCLE_TOKEN" \
+        "https://circleci.com/api/v2/project/gh/${REPO}/pipeline?branch=main" 2>/dev/null \
+        || echo '{}')
+      FAILED=$(echo "$CI_JSON" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for p in d.get('items', []):
+    state = p.get('state', '')
+    if state == 'errored': print(f'CircleCI pipeline {p.get(\"id\",\"\")} errored'); exit()
+" 2>/dev/null)
+    fi
+    ;;
+
+  gitlab)
+    # Requires GITLAB_TOKEN and GITLAB_URL env vars; warns and skips gate if unset
+    if [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_URL" ]; then
+      echo "[COORD] ⚠️  CI_PROVIDER=gitlab but GITLAB_TOKEN/GITLAB_URL not set — skipping CI gate"
+    else
+      ENCODED_REPO=$(python3 -c "import urllib.parse,os; print(urllib.parse.quote_plus(os.environ.get('REPO','')))")
+      CI_JSON=$(curl -s -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        "${GITLAB_URL}/api/v4/projects/${ENCODED_REPO}/pipelines?ref=main&per_page=5" 2>/dev/null \
+        || echo '[]')
+      FAILED=$(echo "$CI_JSON" | python3 -c "
+import json, sys
+pipelines = json.load(sys.stdin)
+for p in pipelines:
+    if p.get('status') in ('failed', 'canceled'):
+        print(f'GitLab pipeline {p.get(\"id\",\"\")} {p.get(\"status\",\"\")}'); exit()
+" 2>/dev/null)
+    fi
+    ;;
+
+  *)
+    echo "[COORD] ⚠️  Unknown CI_PROVIDER='$_CI_PROVIDER' — skipping CI gate (known: github-actions, circleci, gitlab)"
+    ;;
+esac
 
 if [ -n "$FAILED" ]; then
   echo "[COORD] 🔴 CI BLOCKING: $FAILED — fix before new work"

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -220,6 +220,17 @@ for line in open('otherness-config.yaml'):
         if m: print(m.group(1)); break
 " 2>/dev/null || echo "true")
 
+CI_PROVIDER=$(python3 -c "
+import re
+section = None
+for line in open('otherness-config.yaml'):
+    s = re.match(r'^(\w[\w_]*):', line)
+    if s: section = s.group(1)
+    if section == 'ci':
+        m = re.match(r'^\s+provider:\s*(\S+)', line)
+        if m: print(m.group(1)); break
+" 2>/dev/null || echo "github-actions")
+
 # Session identity — unique per session, stable for its lifetime
 MY_SESSION_ID="sess-$(python3 -c 'import os; print(os.urandom(4).hex())' 2>/dev/null || echo "$(date +%s | tail -c 9)")"
 
@@ -304,7 +315,7 @@ print(report_issue)
 ROTATE_EOF
 )
 
-export REPO REPO_NAME REPORT_ISSUE PR_LABEL BUILD_COMMAND TEST_COMMAND LINT_COMMAND JOB_FAMILY AUTONOMOUS_MODE MY_SESSION_ID OTHERNESS_VERSION
+export REPO REPO_NAME REPORT_ISSUE PR_LABEL BUILD_COMMAND TEST_COMMAND LINT_COMMAND JOB_FAMILY AUTONOMOUS_MODE MY_SESSION_ID OTHERNESS_VERSION CI_PROVIDER
 
 echo "[STANDALONE | $MY_SESSION_ID | otherness@$OTHERNESS_VERSION] Project: $REPO | Role: $JOB_FAMILY | Autonomous: $AUTONOMOUS_MODE | Report: #$REPORT_ISSUE"
 ```


### PR DESCRIPTION
## Summary

CI check in coord.md §1a now dispatches on `CI_PROVIDER` from `otherness-config.yaml`:

| Provider | Behavior |
|---|---|
| `github-actions` | Unchanged (`gh run list`) |
| `circleci` | CircleCI v2 API — warns + skips if `CIRCLE_TOKEN` not set |
| `gitlab` | GitLab pipelines API — warns + skips if `GITLAB_TOKEN`/`GITLAB_URL` not set |
| unknown | Warns explicitly, skips gate (never silent) |

`CI_PROVIDER` is now read at startup in standalone.md and exported.

## Acceptance tests
```bash
grep -c 'CI_PROVIDER\|circleci\|gitlab' agents/phases/coord.md  # = 9 ✅
grep -c 'CI_PROVIDER\|circleci\|gitlab' agents/standalone.md    # = 2 ✅
```

## Validation
`scripts/validate.sh`: ✅ PASSED
`scripts/lint.sh`: ✅ PASSED

Closes #114.