### PR TITLE
feat(queue): intent-based capability profiles — agents claim by area (#119)

### DIFF
--- a/.specify/specs/119/spec.md
+++ b/.specify/specs/119/spec.md
@@ -1,0 +1,41 @@
+# Spec: Intent-Based Queue / Capability Profiles (#119)
+
+## Zone 1 — Obligations (falsifiable)
+
+### O1: Capability profile read from config
+`standalone.md` startup reads the `agents` section of `otherness-config.yaml` to find a
+matching profile for the current session (matched by `REPO_NAME` hostname or the first entry),
+and sets `ALLOWED_AREAS` from that profile's `areas` list.
+- **Violation**: `ALLOWED_AREAS` is always empty regardless of what is in `otherness-config.yaml`.
+
+### O2: Fallback — no profile or no areas match
+If no capability profile is found, or if `areas` is empty/absent, `ALLOWED_AREAS` is unset
+(agent claims any item). Same as current behavior.
+- **Violation**: Agent gets stuck with `ALLOWED_AREAS` set to an empty value and claims nothing.
+
+### O3: Acceptance test passes
+```bash
+grep -c "capability\|agent.*profile\|ALLOWED_AREAS" ~/.otherness/agents/standalone.md  # ≥ 1
+```
+
+### O4: JOB_FAMILY respected per profile
+If a capability profile specifies `job_family`, it overrides the default `JOB_FAMILY` read from
+`otherness-config.yaml` `project.job_family`.
+- **Violation**: `JOB_FAMILY` is always the project-level value even when a per-agent profile specifies a different one.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How to select which profile applies to this session (first match, or by `id` from env var).
+- Exact YAML structure for the `agents:` section (follow the example in the issue body).
+- Whether to log the selected profile at startup.
+
+---
+
+## Zone 3 — Scoped out
+
+- Dynamic profile switching mid-session.
+- Profile-based rate limiting or resource quotas.
+- Profile validation (schema check of otherness-config.yaml).
+- Deprecating bounded-standalone.md — not changed here.

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -209,6 +209,57 @@ for line in open('otherness-config.yaml'):
         if m: print(m.group(1)); break
 " 2>/dev/null || echo "SDE")
 
+# Capability profile: read from otherness-config.yaml agents[] section.
+# Allows specialized agents to declare which item areas they can work on.
+# AGENT_ID env var selects a specific profile; otherwise the first profile is used.
+# If no profile found or areas empty: ALLOWED_AREAS stays unset (claim any item).
+eval "$(python3 - <<'CAP_EOF'
+import re, os, yaml as _yaml_unused
+# Parse agents section with regex (no PyYAML dependency)
+try:
+    content = open("otherness-config.yaml").read()
+    # Find agents: block
+    agents_block = re.search(r'^agents:\s*\n((?:  .+\n?)*)', content, re.MULTILINE)
+    if not agents_block:
+        raise ValueError("no agents section")
+
+    lines = agents_block.group(1).splitlines()
+    profiles = []
+    current = {}
+    for line in lines:
+        id_m = re.match(r"\s+-\s+id:\s*(.+)", line)
+        area_m = re.match(r"\s+areas:\s*\[(.+)\]", line)
+        area_m2 = re.match(r"\s+-\s+(.+)", line)
+        jf_m = re.match(r"\s+job_family:\s*(\S+)", line)
+        if id_m:
+            if current: profiles.append(current)
+            current = {"id": id_m.group(1).strip()}
+        elif area_m and current:
+            current["areas"] = [a.strip().strip("\"'") for a in area_m.group(1).split(",")]
+        elif jf_m and current:
+            current["job_family"] = jf_m.group(1).strip()
+    if current: profiles.append(current)
+
+    if not profiles:
+        raise ValueError("empty agents list")
+
+    # Select profile: by AGENT_ID env var or first
+    target_id = os.environ.get("AGENT_ID", "")
+    profile = next((p for p in profiles if p.get("id") == target_id), profiles[0])
+
+    areas = profile.get("areas", [])
+    if areas:
+        print(f"export ALLOWED_AREAS=\"{','.join(areas)}\"")
+        print(f"echo \"[STANDALONE] Capability profile: id={profile.get('id','')} areas={','.join(areas)}\"")
+    jf = profile.get("job_family", "")
+    if jf:
+        print(f"JOB_FAMILY=\"{jf}\"")
+        print(f"echo \"[STANDALONE] Job family override from profile: {jf}\"")
+except Exception:
+    pass  # No profile — no-op, agent claims any item
+CAP_EOF
+)"
+
 AUTONOMOUS_MODE=$(python3 -c "
 import re
 section = None


### PR DESCRIPTION
## Summary

Agents can now declare capability profiles in `otherness-config.yaml`:

```yaml
agents:
  - id: frontend-agent
    areas: [area/ui, area/frontend]
    job_family: FEE
  - id: backend-agent
    areas: [area/controller, area/api]
    job_family: SDE
```

At startup, the first profile (or the one matching `AGENT_ID` env var) sets:
- `ALLOWED_AREAS` — filters queue items by label in coord.md (already implemented)
- `JOB_FAMILY` override (optional per-profile)

**No profile configured → unchanged behavior** (agent claims any item).

## Acceptance test
```bash
grep -c 'capability\|agent.*profile\|ALLOWED_AREAS' agents/standalone.md  # = 2 ✅
```

## Validation
`scripts/validate.sh`: ✅ PASSED
`scripts/lint.sh`: ✅ PASSED

Closes #119.