### PR TITLE
feat(sm): auto-open kind/chore on 2-batch metric regression (#137)

### DIFF
--- a/.specify/specs/137/spec.md
+++ b/.specify/specs/137/spec.md
@@ -1,0 +1,47 @@
+# Spec: SM Metric Regression Auto-Open (Issue #137)
+
+**Version**: 1.0 | **Date**: 2026-04-17 | **Risk tier**: CRITICAL (agents/phases/sm.md)
+
+Note: Issue #137 incorrectly states "Not CRITICAL tier". agents/phases/sm.md is CRITICAL
+per the AGENTS.md change risk table (agents/phases/*.md). This PR will carry needs-human
+label and follow the CRITICAL tier self-review protocol.
+
+---
+
+## Zone 1 — Obligations (must satisfy)
+
+1. **O1**: `agents/phases/sm.md` §4b contains a regression check that reads `docs/aide/metrics.md`
+   batch log after writing the new row and parses the last 3 rows.
+
+2. **O2**: If `needs_human` increased for 2 consecutive batches (rows N-1 and N both > row N-2,
+   OR both > 0 when N-2 was 0): opens a `kind/chore` issue titled
+   `[METRIC REGRESSION] needs_human increasing — investigate`. Deduped (no open issue with same title).
+
+3. **O3**: If `todo_shipped` was 0 for 2 consecutive batches (rows N-1 and N both = 0): opens a
+   `kind/chore` issue titled `[METRIC REGRESSION] no items shipped in 2 batches`. Deduped.
+
+4. **O4**: Regression check only fires when there are at least 3 rows (compares N, N-1, N-2).
+   Gracefully skips when < 3 rows.
+
+5. **O5**: CI (`bash scripts/validate.sh && bash scripts/lint.sh`) passes after the change.
+
+6. **O6**: The change is additive — no existing §4b behavior is removed or modified.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Location: append the regression block after the existing `git push origin main` in §4b.
+- Regression definition for needs_human: last 2 batches both have needs_human > baseline
+  (baseline = N-2 row value). Simple: both N-1 and N > N-2.
+- Parser reuses the same approach as §5e in pm.md (copy+adapt for DRY-ness is acceptable
+  since the files are separate markdown instruction files, not shared code).
+- The `gh issue list --search` dedup pattern matches pm.md §5e for consistency.
+
+---
+
+## Zone 3 — Scoped out
+
+- ci_red_hours regression detection (not an integer in current table — uses `~0`, `~12` etc.)
+- Alerting via any channel other than GitHub issues.
+- Adding new metrics columns to the table.

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -79,6 +79,92 @@ for i in 1 2 3; do
   git pull --rebase origin main --quiet 2>/dev/null && \
   git push origin main && break || sleep $((i * 2))
 done
+
+# Regression detection: read back last 3 rows and auto-open issues on 2-batch regressions
+python3 - <<'REGEOF'
+import re, subprocess, os
+
+REPO = os.environ.get('REPO', '')
+REPORT_ISSUE = os.environ.get('REPORT_ISSUE', '')
+
+def parse_rows(content):
+    rows = []
+    for line in content.splitlines():
+        m = re.match(r'^\|\s*\d{4}-\d{2}-\d{2}\s*\|(.+)', line)
+        if m:
+            cells = [c.strip() for c in line.split('|')[1:-1]]
+            if len(cells) >= 7:
+                try:
+                    rows.append({
+                        'batch': cells[1],
+                        'needs_human': int(cells[3]) if cells[3].isdigit() else -1,
+                        'todo_shipped': int(cells[6]) if cells[6].isdigit() else -1,
+                    })
+                except (ValueError, IndexError):
+                    pass
+    return rows
+
+def open_if_absent(title, body):
+    """Open a kind/chore issue only if none with the same title is currently open."""
+    existing = subprocess.run(
+        ['gh', 'issue', 'list', '--repo', REPO, '--state', 'open',
+         '--search', title, '--json', 'number', '--jq', 'length'],
+        capture_output=True, text=True)
+    count = int(existing.stdout.strip() or '0')
+    if count == 0:
+        r = subprocess.run(
+            ['gh', 'issue', 'create', '--repo', REPO,
+             '--title', title, '--label', 'kind/chore,otherness', '--body', body],
+            capture_output=True, text=True)
+        if r.returncode == 0:
+            print(f'[SM] Opened regression issue: {r.stdout.strip()}')
+        else:
+            print(f'[SM] Failed to open regression issue: {r.stderr.strip()}')
+    else:
+        print(f'[SM] Regression issue already open — skipping duplicate for: {title}')
+
+try:
+    content = open('docs/aide/metrics.md').read()
+    rows = parse_rows(content)
+except Exception:
+    rows = []
+
+if len(rows) < 3:
+    print(f'[SM] Regression check: only {len(rows)} rows — need ≥ 3, skipping.')
+else:
+    n2, n1, n0 = rows[-3], rows[-2], rows[-1]
+
+    # needs_human regression: last 2 batches both higher than N-2
+    if n2['needs_human'] >= 0 and n1['needs_human'] >= 0 and n0['needs_human'] >= 0:
+        if n1['needs_human'] > n2['needs_human'] and n0['needs_human'] > n2['needs_human']:
+            open_if_absent(
+                '[METRIC REGRESSION] needs_human increasing — investigate',
+                f'SM regression check triggered.\n\n'
+                f'`needs_human` increased for 2 consecutive batches vs baseline:\n'
+                f'- Batch {n2["batch"]}: {n2["needs_human"]}\n'
+                f'- Batch {n1["batch"]}: {n1["needs_human"]}\n'
+                f'- Batch {n0["batch"]}: {n0["needs_human"]}\n\n'
+                f'Review open needs-human issues and identify the root cause.'
+            )
+        else:
+            print(f'[SM] needs_human: no regression '
+                  f'({n2["needs_human"]} → {n1["needs_human"]} → {n0["needs_human"]})')
+
+    # todo_shipped regression: last 2 batches both = 0
+    if n1['todo_shipped'] >= 0 and n0['todo_shipped'] >= 0:
+        if n1['todo_shipped'] == 0 and n0['todo_shipped'] == 0:
+            open_if_absent(
+                '[METRIC REGRESSION] no items shipped in 2 batches',
+                f'SM regression check triggered.\n\n'
+                f'`todo_shipped` = 0 for 2 consecutive batches:\n'
+                f'- Batch {n1["batch"]}: shipped={n1["todo_shipped"]}\n'
+                f'- Batch {n0["batch"]}: shipped={n0["todo_shipped"]}\n\n'
+                f'Check the queue: is it empty? Are items blocked? See docs/aide/roadmap.md.'
+            )
+        else:
+            print(f'[SM] todo_shipped: no regression '
+                  f'({n1["todo_shipped"]} → {n0["todo_shipped"]})')
+REGEOF
 ```
 
 ---


### PR DESCRIPTION
## Summary

Stage 4 deliverable: SM auto-opens a `kind/chore` issue when any metric regresses for 2 consecutive batches.

Adds regression detection block to `agents/phases/sm.md` §4b. After the existing metrics push, reads back last 3 rows and fires when:
- `needs_human` increases for 2 consecutive batches vs N-2 baseline
- `todo_shipped` = 0 for 2 consecutive batches

Dedup check: only opens issue if no open issue with the same title already exists.

## Files changed
- `agents/phases/sm.md` — regression check after §4b metrics push (CRITICAL tier)
- `.specify/specs/137/spec.md` — spec

## Risk tier: CRITICAL (agents/phases/sm.md)

[NEEDS HUMAN: critical-tier-change]

Note: Issue #137 incorrectly stated 'Not CRITICAL tier' — agents/phases/sm.md is explicitly CRITICAL per AGENTS.md change risk table.

## Spec conformance
- O1: §4b reads metrics.md batch log after push ✅
- O2: Opens needs_human regression issue with dedup ✅
- O3: Opens todo_shipped regression issue with dedup ✅
- O4: Graceful skip when < 3 rows ✅
- O5: CI passes ✅
- O6: Additive — no existing §4b behavior removed ✅