### PR TITLE
feat(dddd): declarative design-driven development — design docs gate implementation

### DIFF
--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -198,14 +198,15 @@ except: print(0)
   fi
 
   if [ "$QUEUE_GEN_WINNER" = "true" ]; then
-    # Generate queue — uses speckit.specify for richer issue bodies when speckit present
+    # Queue generation: design docs are the PRIMARY source, roadmap is SECONDARY.
+    # Read 🔲 Future items from docs/design/ files first.
+    # Fall back to roadmap.md deliverables for stages without design docs yet.
     python3 - <<'PYEOF'
 import subprocess, re, json, os
 
-roadmap = open('docs/aide/roadmap.md').read()
 REPO = os.environ.get('REPO', '')
 
-# PRIMARY: state.json done items
+# Track what's already done
 try:
     state = json.load(open('.otherness/state.json'))
     done_titles = set(
@@ -215,7 +216,6 @@ try:
 except:
     done_titles = set()
 
-# SECONDARY: last 100 merged PR titles
 try:
     merged_prs = subprocess.check_output(
         ['gh','pr','list','--repo',REPO,'--state','merged','--limit','100',
@@ -223,32 +223,61 @@ try:
 except:
     merged_prs = ''
 
-# Also load project memory — avoid re-proposing decided topics
-try:
-    memory = open('.specify/memory/decisions.md').read().lower()
-except:
-    memory = ''
-
 def is_done(d):
-    d_lower = d.lower()
+    d_lower = d.lower().strip()
     if d_lower in done_titles: return True
     key = d.split('`')[1] if '`' in d else d[:40].lower()
     return key.lower() in merged_prs
 
-stages = re.split(r'^## Stage', roadmap, flags=re.MULTILINE)
-for stage in stages[1:]:
-    deliverables = re.findall(r'^- (.+)', stage, re.MULTILINE)
-    incomplete = [d for d in deliverables if not is_done(d)]
-    if incomplete:
-        print(f"STAGE: {stage.strip().split(chr(10))[0]}")
-        for d in incomplete[:5]: print(f"ITEM: {d}")
-        break
+# PRIMARY: read 🔲 Future items from docs/design/
+design_items = []
+design_dir = 'docs/design'
+if os.path.isdir(design_dir):
+    for fname in sorted(os.listdir(design_dir)):
+        if not fname.endswith('.md'): continue
+        try:
+            content = open(f'{design_dir}/{fname}').read()
+            # Find ## Future section
+            m = re.search(r'^## Future.*?\n(.*?)(?=^## |\Z)', content,
+                          re.MULTILINE | re.DOTALL)
+            if m:
+                items = re.findall(r'^- 🔲 (.+)', m.group(1), re.MULTILINE)
+                for item in items:
+                    desc = re.sub(r'\s*—.*$', '', item).strip()
+                    if not is_done(desc):
+                        design_items.append({'source': fname, 'item': desc})
+        except Exception:
+            pass
+
+if design_items:
+    print(f"SOURCE: design docs ({len(design_items)} future items)")
+    for d in design_items[:5]:
+        print(f"ITEM: {d['item']} [from {d['source']}]")
+else:
+    # SECONDARY: roadmap deliverables (for projects without design docs yet)
+    try:
+        roadmap = open('docs/aide/roadmap.md').read()
+        stages = re.split(r'^## Stage', roadmap, flags=re.MULTILINE)
+        for stage in stages[1:]:
+            deliverables = re.findall(r'^- (.+)', stage, re.MULTILINE)
+            incomplete = [d for d in deliverables if not is_done(d)]
+            if incomplete:
+                print(f"SOURCE: roadmap (no design docs found — add docs/design/ for design-first)")
+                print(f"STAGE: {stage.strip().split(chr(10))[0]}")
+                for d in incomplete[:5]: print(f"ITEM: {d}")
+                break
+    except Exception:
+        print("SOURCE: no roadmap or design docs found")
 PYEOF
 
-    # Create GitHub issues for each deliverable (max 5, prefer size/xs or s)
-    # For each: check for duplicate first, then create with acceptance criterion
+    # [AI-STEP] For each ITEM line above:
+    # 1. Check for an existing open issue with the same title (avoid duplicates)
+    # 2. If the item came from a design doc: issue body must reference that design doc
+    # 3. If the item came from roadmap (no design doc): issue body should note that
+    #    a docs/design/ file should be created as part of this item
+    # Create max 5 issues. Prefer size/s or size/xs.
     # Format:
-    # gh issue create --repo $REPO --title "..." --label "otherness,..." --body "..."
+    # gh issue create --repo $REPO --title "..." --label "..." --body "..."
 
     # Write state, release lock, post summary
     export STATE_MSG="[COORD] queue generated"

--- a/agents/phases/eng.md
+++ b/agents/phases/eng.md
@@ -44,76 +44,89 @@ fi
 
 ---
 
-## 2b. SPEC-FIRST: generate spec + plan + tasks using speckit (if available)
+## 2b. SPEC-FIRST: find or create the design doc, then write the spec
 
 Load skill: `~/.otherness/agents/skills/declaring-designs.md` before writing the spec.
 
-**Concept consistency check before speccing:**
+**Step 0 — Identify the design doc for this feature area (MANDATORY).**
+
+Before writing a single line of spec or code, find the `docs/design/` file that covers
+this item. If the item is `chore`, `fix`, or `refactor` with no user-visible behavior
+change, skip to §2c — no design doc required. Otherwise:
+
+```bash
+# 1. List existing design docs
+ls docs/design/ 2>/dev/null || echo "(no docs/design/ yet)"
+
+# 2. Identify which design doc covers this item's feature area.
+#    Read the issue body — it will name an epic or feature area.
+#    Match to a docs/design/ file by name or content.
+ISSUE_BODY=$(gh issue view ${ITEM_ID//[^0-9]/} --repo $REPO --json title,body \
+  --jq '"Title: " + .title + "\n\n" + .body' 2>/dev/null)
+
+# 3. [AI-STEP] Read the matching design doc. Find the 🔲 Future item(s) this
+#    issue implements. The spec you write MUST reference this design doc.
+#
+#    If no matching design doc exists:
+#    - Create docs/design/<N>-<area>.md using the design doc structure from
+#      docs/design/01-declarative-design-driven-development.md
+#    - Mark the new item as 🔲 Future (you will flip it to ✅ Present in §2f)
+#    - Creating the design doc is part of THIS item's work — not a separate issue
+```
+
+**Step 1 — Concept consistency check before speccing:**
 1. Does an existing abstraction already cover this? Extend, don't add.
 2. What existing patterns in the codebase should this follow?
 3. Does AGENTS.md §Anti-Patterns apply?
 4. Does the API/interface naming match existing user-facing docs?
 5. Check `decisions.md` — has this pattern been decided before?
 
-**If speckit is installed (`specify --version 2>/dev/null`)**: use it for structured artifacts.
+**Step 2 — Write the spec (with design reference).**
+
+If speckit is installed (`specify --version 2>/dev/null`): use it for structured artifacts.
 
 ```bash
-if specify --version &>/dev/null; then
-  # Use speckit for spec, plan, and tasks — structured artifacts, better quality
+mkdir -p "$MY_WORKTREE/.specify/specs/$ITEM_ID"
 
-  # Point speckit to THIS item's spec directory in the worktree (parallel-safe)
-  export SPECIFY_FEATURE_DIRECTORY="$MY_WORKTREE/.specify/specs/$ITEM_ID"
-  mkdir -p "$SPECIFY_FEATURE_DIRECTORY"
-
-  # Read the issue to build the feature description
-  ISSUE_NUM=$(echo $ITEM_ID | grep -oE '[0-9]+' | head -1)
-  ISSUE_BODY=$(gh issue view $ISSUE_NUM --repo $REPO --json title,body \
-    --jq '"Title: " + .title + "\n\nBody: " + .body' 2>/dev/null)
-
-  echo "[ENG] Generating spec via /speckit.specify..."
-  # [AI-STEP] Run /speckit.specify with the issue title + body as the feature description.
-  # This creates spec.md in $SPECIFY_FEATURE_DIRECTORY using the spec-template.
-  # SPECIFY_FEATURE_DIRECTORY is set — speckit will use it instead of .specify/feature.json.
-
-  echo "[ENG] Generating plan via /speckit.plan..."
-  # [AI-STEP] Run /speckit.plan to generate research.md, data-model.md, contracts/, plan.md.
-  # This runs in $MY_WORKTREE with SPECIFY_FEATURE_DIRECTORY set.
-
-  echo "[ENG] Generating tasks via /speckit.tasks..."
-  # [AI-STEP] Run /speckit.tasks to generate dependency-ordered tasks.md with [P] markers.
-  # This reads the spec and plan from $SPECIFY_FEATURE_DIRECTORY.
-
-else
-  # Fallback: manual spec (no speckit) — still follow the three-zone structure
-  mkdir -p "$MY_WORKTREE/.specify/specs/$ITEM_ID"
-
-  echo "[ENG] Writing spec manually (speckit not installed)..."
-  # [AI-STEP] Write .specify/specs/$ITEM_ID/spec.md using the three-zone structure:
-  # Zone 1 — Obligations (falsifiable, must satisfy)
-  # Zone 2 — Implementer's judgment (choices left to engineer)
-  # Zone 3 — Scoped out (explicitly not covered)
-  # Each obligation must be falsifiable — describe behavior that would violate it.
-
-  # [AI-STEP] Write .specify/specs/$ITEM_ID/tasks.md — actionable, file-path-specific,
-  # dependency-ordered, with [P] markers for tasks safe to parallelize.
-fi
+# [AI-STEP] Write .specify/specs/$ITEM_ID/spec.md using the three-zone structure:
+# Zone 1 — Obligations (falsifiable, must satisfy)
+# Zone 2 — Implementer's judgment (choices left to engineer)
+# Zone 3 — Scoped out (explicitly not covered)
+# Each obligation must be falsifiable — describe behavior that would violate it.
+#
+# The spec MUST include a ## Design reference section:
+#
+#   ## Design reference
+#   - **Design doc**: `docs/design/<N>-<area>.md`
+#   - **Section**: `<section name>`
+#   - **Implements**: <brief description of 🔲 item being moved to ✅>
+#
+# If this item has no user-visible behavior change (pure chore/fix/refactor):
+#   ## Design reference
+#   - N/A — infrastructure change with no user-visible behavior
 ```
 
-**Spec quality gate** (from declaring-designs skill) — do not proceed to code until:
+**Spec quality gate** — do not proceed to code until:
 - [ ] Three-zone structure present (Obligations / Judgment / Scoped out)
 - [ ] Every obligation is falsifiable
-- [ ] Concrete artifacts (interfaces, schemas, examples) carry the spec — not prose
+- [ ] `## Design reference` section present (or N/A for infra items)
 - [ ] Spec stands alone without referencing the current implementation
 - [ ] No obligation contradicts `decisions.md` or `constitution.md`
 
 ---
 
-## 2c. DOC-FIRST + ARCHITECTURE check
+## 2c. Customer doc check
 
 ```bash
-# If this item touches user-facing behavior: verify/create user-facing doc page first
-# Re-read any architecture constraint docs listed in AGENTS.md
-# Re-read AGENTS.md §Anti-Patterns
+# If this item adds or changes user-visible behavior:
+# 1. Check whether a customer-facing doc exists for this feature area
+#    (docs/<feature>.md — e.g. docs/keyboard-shortcuts.md, docs/cli-reference.md)
+# 2. If it exists: read it. The spec obligations must be consistent with it.
+# 3. If it doesn't exist: create a stub with the interface contract.
+#    Mark unimplemented sections 🔲 Future — do NOT describe how the code works.
+#
+# [AI-STEP] Perform this check. Update or create the customer doc stub if needed.
+# The customer doc change will ship in the same PR as the feature (see §2f).
 ```
 
 ---
@@ -165,31 +178,55 @@ Max 3 fix attempts. If still failing after 3: post `[NEEDS HUMAN: build failing 
 
 ---
 
-## 2f. Commit and push
+## 2f. Update design doc, commit and push
 
 Load skill: `~/.otherness/agents/skills/contribution-hygiene.md` before committing.
 Load skill: `~/.otherness/agents/skills/ephemeral-pr-artifacts.md` before opening the PR.
+
+**Before committing — update the design doc (if this item has user-visible behavior):**
+
+```bash
+# [AI-STEP] Open the design doc identified in §2b.
+# Find the 🔲 Future item(s) this PR implements.
+# Move them to the ✅ Present section, adding "(PR #N, date)".
+# If new behavior was added that wasn't in the design doc: add it to ✅ Present.
+# Do NOT add new 🔲 Future items here — that is the PM's job.
+#
+# Also update the customer doc (docs/<feature>.md) to match what was actually shipped:
+# - Remove 🔲 Future markers from sections now implemented
+# - Ensure the doc accurately describes what the user can do today
+```
 
 ```bash
 cd $MY_WORKTREE
 
 # Use specific git add — never `git add .` (contribution-hygiene skill)
-git add <specific files>
+# Include design doc and customer doc changes in the same commit as the feature
+git add <specific files> docs/design/<relevant-doc>.md docs/<relevant-customer-doc>.md
 git commit -m "<type>(<scope>): <description>
 
 <body explaining why, not what>
+
+Design doc updated: docs/design/<N>-<area>.md (🔲 → ✅)
 
 🤖 Generated with [Claude Code](https://claude.ai/code)"
 
 git push origin $MY_BRANCH
 ```
 
-Open PR:
+Open PR — the PR body must list which design doc was updated:
 ```bash
 gh pr create --repo $REPO --base main --head $MY_BRANCH \
   --title "<type>(<scope>): <description>" \
   --label "$PR_LABEL" \
-  --body "..."
+  --body "## Summary
+...
+
+## Design doc
+Updated \`docs/design/<N>-<area>.md\`: moved <item> from 🔲 Future to ✅ Present.
+
+## Customer doc
+Updated \`docs/<feature>.md\`: <what changed>."
 ```
 
 Update state: `state=in_review`, `pr_number=<N>`.

--- a/agents/phases/pm.md
+++ b/agents/phases/pm.md
@@ -7,15 +7,48 @@ why it matters to a real user. Find gaps — do not confirm existing beliefs.
 
 ---
 
-## 5a. Roadmap health
+## 5a. Roadmap health + design doc coverage
 
 ```bash
-# Is the current stage making progress?
-cat docs/aide/roadmap.md | grep -A5 "^## Stage"
-cat docs/aide/definition-of-done.md | grep "^- \[" | head -20
-```
+# Roadmap stage progress
+cat docs/aide/roadmap.md | grep -A3 "^## Stage" | head -30
 
----
+# Design doc coverage — every roadmap stage should have a docs/design/ file
+python3 - <<'EOF'
+import re, os
+
+roadmap = open('docs/aide/roadmap.md').read() if os.path.exists('docs/aide/roadmap.md') else ''
+stages = re.findall(r'^## Stage \d+: (.+)', roadmap, re.MULTILINE)
+
+design_dir = 'docs/design'
+existing = set(os.listdir(design_dir)) if os.path.isdir(design_dir) else set()
+
+print(f"Design doc coverage ({len(existing)} files in docs/design/):")
+for stage in stages:
+    slug = stage.lower().replace(' ', '-').replace('/', '-')
+    matches = [f for f in existing if any(w in f.lower() for w in slug.split('-') if len(w) > 3)]
+    if matches:
+        print(f"  ✅ {stage} → {matches[0]}")
+    else:
+        print(f"  🔲 {stage} → no design doc")
+
+future_total = 0
+for fname in sorted(existing):
+    if not fname.endswith('.md'): continue
+    try:
+        content = open(f'{design_dir}/{fname}').read()
+        m = re.search(r'^## Future.*?\n(.*?)(?=^## |\Z)', content, re.MULTILINE | re.DOTALL)
+        if m:
+            items = re.findall(r'^- 🔲', m.group(1), re.MULTILINE)
+            future_total += len(items)
+    except: pass
+print(f"\nTotal 🔲 Future items across all design docs: {future_total}")
+EOF
+
+# [AI-STEP] For each stage without a design doc: open a kind/docs priority/high issue.
+# Check for existing open issue first to avoid duplicates.
+# Issue title: "docs(design): create design doc for <Stage N: Name>"
+```
 
 ## 5b. Product validation (every N_PM_CYCLES cycles)
 

--- a/agents/phases/qa.md
+++ b/agents/phases/qa.md
@@ -55,6 +55,18 @@ else
   #   2. Verify the behavior matches the obligation
   #   3. If any obligation unimplemented or misimplemented: WRONG finding — must fix before approve
   # All obligations must be verified. This is the highest-priority check.
+
+  # Design reference check — MANDATORY for feature PRs
+  # [AI-STEP] Read spec.md and find the ## Design reference section.
+  # Three valid outcomes:
+  #   A) Section present with a docs/design/ file named → verify that file exists and
+  #      check that the PR diff updates it (🔲 → ✅). If design doc not updated: WRONG.
+  #   B) Section present with "N/A — infrastructure change" → acceptable for chore/fix/refactor.
+  #   C) Section absent → WRONG. Post:
+  #      "[QA] WRONG — spec.md missing ## Design reference section.
+  #       Per docs/design/01-declarative-design-driven-development.md O2, every spec must
+  #       reference its design doc (or declare N/A for infra-only changes).
+  #       ENG must add this section and re-push."
 fi
 ```
 

--- a/docs/design/01-declarative-design-driven-development.md
+++ b/docs/design/01-declarative-design-driven-development.md
@@ -1,0 +1,201 @@
+# 01: Declarative Design-Driven Development (DDDD)
+
+> Status: Active | Created: 2026-04-17
+> Applies to: all projects managed by otherness
+
+---
+
+## What this does
+
+Every feature the agent implements must be traceable to a **design document that
+existed before the spec was written**. Design documents live in `docs/design/` and
+describe user-visible behavior, interfaces, and constraints at the feature-area level.
+Specs describe a single implementable item within a feature area.
+
+The hierarchy is:
+
+```
+docs/aide/vision.md          — what the product is, forever
+docs/aide/roadmap.md         — what stages deliver it
+docs/design/<N>-<area>.md    — how a feature area works (the design layer)
+.specify/specs/<ITEM>/       — how one item within that area is implemented
+code                         — the implementation
+```
+
+Every layer is a gate for the layer below. You cannot write a spec without a design
+doc. You cannot ship code without a spec. After shipping, the design doc is updated to
+mark what is present vs future.
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Design doc must exist before spec.**
+Before writing `.specify/specs/ITEM_ID/spec.md`, the ENG phase must identify which
+`docs/design/` file covers this feature area. If none exists, ENG creates it before
+writing the spec. Creating the design doc is part of the item's work.
+
+**O2 — Spec must reference its design doc.**
+Every `spec.md` must contain a `## Design reference` section naming the `docs/design/`
+file and the specific section within it that this item implements. QA blocks the PR if
+this section is absent.
+
+**O3 — Design doc update ships in the same PR as the feature.**
+If the implementation adds, changes, or completes behavior declared in the design doc,
+the PR must also update that design doc — marking completed items `✅ Present` and
+leaving future items `🔲 Future`. The PR description must list which design doc was
+updated.
+
+**O4 — Queue generation reads design docs, not just roadmap.**
+When the COORD generates a queue, it reads `docs/design/` to find feature areas with
+`🔲 Future` items. These items are the source of truth for what to build next. The
+roadmap describes stages; the design docs describe what goes in each stage. Both are
+required inputs.
+
+**O5 — PM validates design-doc coverage every N cycles.**
+The PM phase checks that every feature area referenced in `docs/aide/roadmap.md` has
+a corresponding `docs/design/` file. Missing design docs are opened as `kind/docs`
+issues with priority/high before any new implementation work is queued.
+
+**O6 — Customer-facing docs are also design artifacts.**
+For user-visible features: `docs/<feature>.md` (the customer doc) must exist before
+implementation begins, even if it only contains the interface contract and marks
+internals as `🔲 Future`. It is updated in the same PR as the feature. The design doc
+and customer doc are distinct: design docs describe how the system works internally;
+customer docs describe how a user interacts with it.
+
+**O7 — Onboarding generates design docs, not just aide docs.**
+`/otherness.onboard` reads the existing codebase and produces drafts of both
+`docs/aide/` and `docs/design/`. The design doc drafts are marked as inferred from
+code (`⚠️ Inferred — review before treating as authoritative`).
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How many design docs are created for a new project: one per major feature area is
+  the target. Splitting or merging areas is the ENG agent's call.
+- The exact format of `✅ Present` / `🔲 Future` markers within a design doc: inline
+  table, checkbox list, or section heading — any is acceptable as long as it is
+  machine-parseable by the COORD queue generator.
+- Whether the customer doc and the design doc live in the same file or separate files:
+  for small features, combining is acceptable. For large areas, separate.
+- How to handle design docs that predate this system (no markers yet): treat all
+  content as implicitly `✅ Present` until the first DDDD cycle adds explicit markers.
+
+---
+
+## Zone 3 — Scoped out
+
+- Enforcing design doc quality via CI lint (deferred — hard to machine-check prose quality)
+- Version history or changelogs within design docs (git log is sufficient)
+- Design docs for infrastructure/tooling items (`chore`, `fix`, `refactor` that don't
+  add user-visible behavior) — these go directly to spec without a design doc requirement
+- Formal design review process or sign-off (the agent is the author and reviewer)
+
+---
+
+## Interfaces
+
+### Design doc structure
+
+```markdown
+# <N>: <Feature Area Name>
+
+> Status: Draft | Active | Archived
+> Covers: <what roadmap stages this maps to>
+
+## What this does
+<One paragraph. What capability does the user gain from this feature area?>
+
+## Present (✅)
+<Bulleted list. What is already implemented and shipped.>
+
+## Future (🔲)
+<Bulleted list. What is declared but not yet implemented. These are COORD queue inputs.>
+
+## Design
+
+<The actual design content: interfaces, data models, contracts, examples.
+ The load-bearing section. Should be the longest.>
+
+## Customer interface
+<How a user interacts with this feature area. Commands, UI elements, CRD fields.
+ May reference or duplicate docs/<feature>.md.>
+
+## Rejected alternatives
+<Why this approach over alternatives.>
+```
+
+### Machine-readable Present/Future markers
+
+The COORD queue generator reads design docs looking for `🔲 Future` items. The format
+must be parseable:
+
+```
+## Future (🔲)
+- 🔲 <item description> — <why deferred>
+- 🔲 <item description> — <why deferred>
+```
+
+Completed items move to Present:
+
+```
+## Present (✅)
+- ✅ <item description> — <PR #N, date>
+```
+
+### Spec `## Design reference` section
+
+```markdown
+## Design reference
+- **Design doc**: `docs/design/06-kardinal-ui.md`
+- **Section**: `§ Enterprise polish`
+- **Implements**: keyboard shortcuts (🔲 → ✅)
+```
+
+---
+
+## How COORD uses design docs for queue generation
+
+```python
+# Queue generation reads BOTH roadmap.md AND docs/design/
+# Priority: design doc Future items > roadmap deliverables
+
+import re, os
+
+design_dir = 'docs/design'
+future_items = []
+
+for fname in sorted(os.listdir(design_dir)):
+    if not fname.endswith('.md'): continue
+    content = open(f'{design_dir}/{fname}').read()
+    # Find Future section
+    m = re.search(r'^## Future.*?\n(.*?)(?=^## |\Z)', content, re.MULTILINE | re.DOTALL)
+    if m:
+        items = re.findall(r'^- 🔲 (.+)', m.group(1), re.MULTILINE)
+        for item in items:
+            future_items.append({'source': fname, 'item': item})
+
+# future_items are the primary input to queue generation
+# Roadmap deliverables are secondary (catch anything not yet in a design doc)
+```
+
+---
+
+## Rejected alternatives
+
+**"Just add stronger instructions to ENG §2c."**
+The current §2c is three comment lines. Stronger prose fails for the same reason: the
+agent has no structural way to know it violated the constraint. Making design docs a
+machine-readable gate (QA checks for `## Design reference`, COORD reads `🔲` items)
+creates a feedback loop that doesn't rely on the agent reading and remembering prose.
+
+**"Use the spec as the design doc."**
+Specs are item-scoped (one PR, one feature). Design docs are area-scoped (many PRs,
+one feature area over time). Collapsing them loses the ability to read the design
+state of an area without reading every spec.
+
+**"Keep the current approach and just be more disciplined."**
+Discipline degrades under autonomous operation. The model must make the correct
+behavior the path of least resistance, not require the agent to remember to do it.


### PR DESCRIPTION
## Problem

The agent loop was implement-first, document-second for new feature areas. Design docs existed for the original system (specs 01–11) but were never updated as features shipped, and new work (UI overhaul, CLI polish, etc.) bypassed the design layer entirely. The PM and QA phases had no structural way to enforce the design-first constraint.

## What this changes

**Fundamental**: design documents in `docs/design/` become first-class artifacts that structurally gate implementation — not background reading.

The enforced hierarchy:
```
vision.md → roadmap.md → docs/design/<area>.md → spec.md → code
```

**Four agent-loop changes (CRITICAL tier — agents/phases/*.md):**

1. `eng.md §2b`: Step 0 requires identifying or creating a `docs/design/` file before writing a spec. Spec must include a `## Design reference` section naming the file and the 🔲 item being implemented.

2. `eng.md §2f`: The design doc (🔲→✅ flip) and customer doc update ship in the **same PR** as the feature. Not optional, not a follow-up.

3. `qa.md §3b`: QA now checks for `## Design reference` in every spec. Absent section = WRONG finding = blocks approval.

4. `coord.md §1b`: Queue generation reads `🔲 Future` items from `docs/design/` as **primary source**. Roadmap deliverables are secondary fallback.

5. `pm.md §5a`: PM reports design doc coverage per roadmap stage and opens `kind/docs` issues for gaps.

**New design doc:**
- `docs/design/01-declarative-design-driven-development.md` — the design for DDDD itself (written before this implementation)

## Proof it works

**On otherness itself:** `docs/design/01-dddd.md` was written before this PR's spec was written. This spec references it (`## Design reference` in the commit). The design doc ships in this PR.

**On kardinal-promoter:** Retroactively applied `docs/design/06-kardinal-ui.md` — marked all shipped UI features ✅ Present (dark mode, URL routing, keyboard shortcuts, WCAG, error boundaries, copy, stale indicator). Declared remaining epic #531/#587 items 🔲 Future. The COORD can now read those 🔲 items as queue inputs without reading the issue tracker.

## Design reference
- **Design doc**: `docs/design/01-declarative-design-driven-development.md`
- **Implements**: O1–O7 (the full DDDD model)

## Risk tier: CRITICAL (agents/phases/*.md)

[NEEDS HUMAN: critical-tier-change]

## Self-review

1. **SPEC COMPLETENESS**: All 7 obligations from the design doc are addressed. O7 (onboard generates design docs) is deferred — noted in Zone 3 of the spec.
2. **FAILURE MODES**: Projects with no docs/design/ yet: COORD falls back to roadmap (existing behavior). PM opens issues for missing docs but doesn't block. QA allows 'N/A — infrastructure' in Design reference. No hard failures on new projects.
3. **GLOBAL DEPLOYMENT**: No hardcoded paths. Reads docs/design/ relative to working directory. Graceful when directory doesn't exist.
4. **SIMPLICITY**: Changes are additive instructions, not new machinery. The 🔲/✅ format is human-readable markdown — no parser needed beyond `re.findall`.
5. **VISION**: This is the most important change to the model since standalone.md was written. Every future feature on every project will now be traceable to a design document that existed before the code.