### PR TITLE
feat(d4): translate imperative human instructions to declarative artifacts

### DIFF
--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -389,6 +389,91 @@ fi
 
 ---
 
+## D4 INSTRUCTION INTERPRETATION
+
+**Before entering the loop, check whether the human has sent a direct instruction in
+this conversation.** If they have, apply the D4 translation protocol before acting.
+
+This fires once at session start, not on every loop iteration.
+
+### Classification
+
+Classify the instruction into one of three categories:
+
+**DECLARATIVE** — the human expressed an intent in design terms ("the vision should say X",
+"add this to the roadmap", "update the design doc for Y"). Proceed directly — it is already
+in the right form. Create or update the D4 artifact they described, then enter the loop.
+
+**IMPERATIVE** — the human expressed a direct action ("add X", "fix Y", "make Z do W",
+"update the readme"). Translate to D4 first. Post the translation. Wait 60s. Then act on
+the translation, not the original instruction.
+
+**INFRA** — pure maintenance with no user-visible behavior change (fix broken CI, clean
+stale branches, update a pinned dependency). No translation needed. Proceed directly.
+
+### Translation format (for IMPERATIVE instructions)
+
+Post this before doing any implementation work:
+
+```
+[📋 D4 TRANSLATION]
+Heard:     "<instruction verbatim>"
+Intent:    <one sentence — what the human actually wants, stated as an outcome>
+D4 layer:  <vision | roadmap | design doc | spec>
+Artifact:  <what would be written — exact text of the design doc entry, vision update, etc.>
+Question:  <one question if genuinely ambiguous — omit if clear>
+Proceeding in 60s unless you correct the translation.
+```
+
+Then wait 60 seconds. If the human corrects the translation, update it and repost. If not,
+proceed using the D4 artifact as the work order — not the original instruction.
+
+### Rules
+
+- **Never silently infer and act.** The translation is always posted for IMPERATIVE instructions.
+- **Act on the artifact, not the instruction.** After translation: create/update the design doc
+  `🔲 Future` item, write the spec referencing it (per eng.md §2b), then implement.
+- **One clarifying question maximum.** Only ask if the translation would be materially different
+  depending on the answer. Do not interrogate the human.
+- **Surface missing design docs.** If the instruction implies a feature area with no
+  `docs/design/` file, create that file first (per eng.md §2b O1). The design doc is part
+  of the work.
+- **Surface scope.** If the instruction implies work outside the current roadmap stage, say so
+  before proceeding. Do not silently expand scope.
+
+### Examples
+
+Imperative: "add a --verbose flag to the CLI"
+```
+[📋 D4 TRANSLATION]
+Heard:     "add a --verbose flag to the CLI"
+Intent:    Improve debuggability by exposing internal state on request
+D4 layer:  design doc → spec
+Artifact:  docs/design/03-cli.md §Future:
+           🔲 --verbose: emit reconciler decisions to stderr. Useful for stuck promotions.
+Proceeding in 60s unless you correct the translation.
+```
+
+Imperative: "update the readme with the D4 logo"
+```
+[📋 D4 TRANSLATION]
+Heard:     "update the readme with the D4 logo"
+Intent:    Brand the project with the D4 identity in the primary entry point
+D4 layer:  vision (README is the customer-facing expression of vision.md)
+Artifact:  README.md: add D4 logo image, update tagline to lead with D4 motto
+Proceeding in 60s unless you correct the translation.
+```
+
+Ambiguous: "we need better error messages"
+```
+[📋 D4 TRANSLATION]
+Heard:     "we need better error messages"
+Intent:    unclear
+Question:  Which surface — CLI output, web UI error states, or controller logs?
+```
+
+---
+
 ## RESUME CHECK
 
 ```bash

--- a/docs/design/02-human-instruction-interpretation.md
+++ b/docs/design/02-human-instruction-interpretation.md
@@ -1,0 +1,140 @@
+# 02: Human instruction interpretation — declarative translation
+
+> Status: Active | Created: 2026-04-17
+
+---
+
+## What this does
+
+When a human issues an instruction during a session — in the conversation, in an issue,
+or in the config — the agent does not execute it literally. It translates the intent
+into a declarative artifact (a vision update, a design doc entry, or a roadmap item)
+and then works from that artifact. The human sees what was understood before anything
+is built.
+
+This is the D4 model applied to human communication. Imperative instructions are
+input signals, not execution commands.
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Classify before acting.**
+When a human instruction arrives, the agent first classifies it:
+- **Declarative** — already expressed as a design intent, vision update, or roadmap item. Proceed.
+- **Imperative** — expressed as a direct action ("add X", "fix Y", "update Z"). Translate first.
+- **Ambiguous** — could be either. Ask one question to disambiguate, then translate.
+
+**O2 — Translate imperative instructions to declarative artifacts.**
+For imperative instructions, the agent proposes what the equivalent declarative artifact
+would be — which layer of the D4 hierarchy it belongs to and what it would say. It posts
+this translation before doing any implementation work.
+
+Translation output format:
+```
+[📋 D4 TRANSLATION]
+Heard:     "<the instruction verbatim>"
+Intent:    <one sentence — what the human actually wants, not what they said>
+D4 layer:  <vision / roadmap / design doc / spec>
+Artifact:  <what would be written — a vision update, a 🔲 Future item, a roadmap stage, etc.>
+Question:  <one question if anything is ambiguous — otherwise omit>
+Proceeding in 60s unless you correct the translation.
+```
+
+**O3 — Act on the translation, not the original instruction.**
+After posting the translation, the agent proceeds using the D4 hierarchy. It creates or
+updates the design doc `🔲 Future` item, writes the spec referencing that design doc,
+then implements. The original imperative instruction is not the work order — the design
+artifact is.
+
+**O4 — Surface scope creep and missing design docs.**
+If an imperative instruction implies work that has no corresponding design doc, the agent
+creates the design doc first (per eng.md §2b O1). If the instruction implies work outside
+the current roadmap stage, it says so before proceeding.
+
+**O5 — Never silently interpret.**
+The agent never silently infers what the human meant and acts on that inference. The
+translation is always posted. Silent inference is how design intent diverges from
+implementation.
+
+**O6 — Infra and ops exceptions.**
+Pure maintenance tasks with no user-visible behavior change (fix a broken test, clean up
+a stale branch, update a dependency version) do not require translation. These are
+classified as infra-only and proceed directly to spec with `## Design reference: N/A`.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How long to wait before acting on the translation: 60 seconds is the default. For
+  urgent ops tasks (CI is red, broken deploy) the agent may act immediately and note
+  the exception.
+- Whether to ask a clarifying question: only if the translation would be materially
+  different depending on the answer. One question maximum. Do not interrogate.
+- How verbose the translation output is: keep it short. The intent line is the most
+  important. Everything else is confirmation.
+
+---
+
+## Zone 3 — Scoped out
+
+- Intercepting instructions that arrive via GitHub issues (those go through the normal
+  queue; this applies to direct conversation messages)
+- Refusing to act on instructions that are out of scope (the agent translates and flags,
+  but does not refuse)
+- Natural language parsing of complex multi-part instructions (treat them as one intent,
+  ask if genuinely ambiguous)
+
+---
+
+## Examples
+
+**Imperative → declarative translation:**
+
+```
+Human:  "add a --verbose flag to the CLI"
+
+[📋 D4 TRANSLATION]
+Heard:     "add a --verbose flag to the CLI"
+Intent:    Improve CLI debuggability by exposing internal state on request
+D4 layer:  design doc → spec
+Artifact:  In docs/design/03-cli.md §Present/Future:
+           🔲 --verbose flag: emit controller events and reconciler decisions
+           to stderr when set. Useful for debugging stuck promotions.
+Proceeding in 60s unless you correct the translation.
+```
+
+**Imperative that implies a missing design doc:**
+
+```
+Human:  "make the dashboard show blocked pipelines first"
+
+[📋 D4 TRANSLATION]
+Heard:     "make the dashboard show blocked pipelines first"
+Intent:    Prioritize operator attention by surfacing actionable items at the top
+D4 layer:  design doc (new section)
+Artifact:  docs/design/06-kardinal-ui.md currently has no section on sort order.
+           Will add to Future (🔲):
+           🔲 Pipeline list default sort: blocked (needs_human > 0 or ci_red) first,
+              then by blockage_duration desc.
+           Then spec → implement.
+Proceeding in 60s unless you correct the translation.
+```
+
+**Ambiguous instruction:**
+
+```
+Human:  "we need better error messages"
+
+[📋 D4 TRANSLATION]
+Heard:     "we need better error messages"
+Intent:    Unclear — could mean CLI error output, UI error states, or controller logs
+Question:  Which surface? CLI commands, the web UI, or controller/reconciler logs?
+```
+
+**Pure infra — no translation needed:**
+
+```
+Human:  "the lint step is broken, fix it"
+→ Classified as infra-only. Proceeding directly to fix.
+```


### PR DESCRIPTION
## Problem

When a human says "add a flag" or "fix this", the agent executes literally. Nothing intercepts the instruction and asks: what is the declarative artifact this should be expressed as first?

## What this changes

New D4 INSTRUCTION INTERPRETATION block in standalone.md. Three categories: DECLARATIVE (proceed), IMPERATIVE (translate first), INFRA (proceed). For IMPERATIVE, posts a structured translation and waits 60s before acting on the artifact through the full D4 chain.

## Design reference
- `docs/design/02-human-instruction-interpretation.md` (written before this implementation)
- Implements O1-O6

## Risk tier: CRITICAL (standalone.md)
[NEEDS HUMAN: critical-tier-change]

## Self-review
1. SPEC COMPLETENESS: O1-O6 all implemented.
2. FAILURE MODES: No response in 60s → proceeds. Ambiguous → one question then best-effort. No docs/design/ → surfaces the gap.
3. GLOBAL DEPLOYMENT: No project-specific references.
4. SIMPLICITY: Additive section only, no loop changes.
5. VISION: D4 applied to the human-agent interface.