### PR TITLE
fix(dod): mark Journey 2 failing — alibi _state stalled >72h

### DIFF
--- a/.specify/specs/146/spec.md
+++ b/.specify/specs/146/spec.md
@@ -1,0 +1,34 @@
+# Spec: fix(dod): Journey 2 FAILING — alibi _state stalled >72h
+
+> Item: 146 | Risk: low | Size: xs
+
+## Design reference
+- N/A — infrastructure change with no user-visible behavior change (docs-only fix)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: `docs/aide/definition-of-done.md` Journey Status table must accurately reflect the current state of each journey. Journey 2 is currently ❌ Failing (alibi `_state` last commit > 72h ago, no queue activity). The table must be updated to show this.
+- **Falsified by**: Journey Status shows "✅ Passing" when alibi `_state` is >72h stale.
+
+**O2**: A `[NEEDS HUMAN]` comment must be posted on the alibi report issue (pnz1990/alibi#1) explaining that otherness has not run in >3 days and requesting a session restart.
+- **Falsified by**: No such comment exists on alibi#1 after this item ships.
+
+**O3**: The DoD Journey Status table must include the date the check was last performed (ISO date, not "N days ago" or relative).
+- **Falsified by**: The table lacks a current date in the "Last checked" column.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Wording of the [NEEDS HUMAN] comment is up to the engineer. Must be actionable.
+- Journey 1, 3, 4, 5 statuses should be re-verified and updated if stale.
+
+---
+
+## Zone 3 — Scoped out
+
+- Does NOT fix why alibi is stalled — that requires a human to restart a session.
+- Does NOT change any agent instruction files.
+- Does NOT modify scripts or CI.

--- a/docs/aide/definition-of-done.md
+++ b/docs/aide/definition-of-done.md
@@ -144,7 +144,7 @@ cd ~/.otherness
 | Journey | Status | Last checked | Notes |
 |---|---|---|---|
 | 1: Build and validate itself | ✅ Passing | 2026-04-17 | validate.sh, lint.sh, test.sh all exit 0 |
-| 2: Runs correctly on reference project | ✅ Passing | 2026-04-14 | alibi active (state commits <4h ago) |
-| 3: Self-improvement happening | ✅ Passing | 2026-04-17 | 5+ PRs merged to otherness today; 11 skills; PROVENANCE updated |
-| 4: CRITICAL tier protection | ✅ Passing | 2026-04-17 | PR #139 has needs-human label; self-review protocol ran |
-| 5: Starts cleanly on fresh clone | ✅ Passing | 2026-04-14 | All 8 command files present; state seeds correctly |
+| 2: Runs correctly on reference project | ❌ Failing | 2026-04-17 | alibi `_state` last commit 2026-04-14 (>72h). `features: {}` empty — no session has run. [NEEDS HUMAN: restart otherness on alibi] |
+| 3: Self-improvement happening | ✅ Passing | 2026-04-17 | PR merged 2026-04-17; 11 skills; PROVENANCE last entry 2026-04-15 |
+| 4: CRITICAL tier protection | ✅ Passing | 2026-04-17 | No open CRITICAL PRs without needs-human; self-review protocol working |
+| 5: Starts cleanly on fresh clone | ✅ Passing | 2026-04-17 | 9 command files present; state seeds correctly |


### PR DESCRIPTION
## Summary

- Journey 2 (reference project health) was showing ✅ Passing with a stale 2026-04-14 timestamp
- alibi `_state` last commit is >72h old; `features: {}` shows no session has actually run
- Updated DoD Journey Status table to ❌ Failing with accurate reason
- Posted `[NEEDS HUMAN]` on pnz1990/alibi#1 requesting session restart
- Updated Journey 3/4/5 timestamps to current 2026-04-17

## Design doc
N/A — infrastructure docs fix, no agent instruction changes.

## Customer doc
Updated `docs/aide/definition-of-done.md`: Journey Status table corrected.