### PR TITLE
docs(design): populate Present/Future sections in design docs

### DIFF
--- a/.specify/specs/148/spec.md
+++ b/.specify/specs/148/spec.md
@@ -1,0 +1,40 @@
+# Spec: docs(design): populate 🔲 Future sections in design docs
+
+> Item: 148 | Risk: low | Size: s
+
+## Design reference
+- **Design doc**: `docs/design/01-declarative-design-driven-development.md`
+- **Section**: `§ Interfaces → Machine-readable Present/Future markers`
+- **Implements**: adding real `🔲 Future` items to both design docs so COORD queue generator can read them (O4 compliance)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: Both `docs/design/01-declarative-design-driven-development.md` and `docs/design/02-human-instruction-interpretation.md` must have parseable `## Present (✅)` and `## Future (🔲)` sections after this PR merges.
+- **Falsified by**: COORD queue generator finds 0 `🔲 Future` items in docs/design/ after this PR.
+
+**O2**: Each `🔲 Future` item in both design docs must represent real, actionable future work — not template placeholders.
+- **Falsified by**: Any `🔲 Future` item contains template text like `<item description>` or `<why deferred>`.
+
+**O3**: The `## Present (✅)` sections must accurately list what is currently implemented and shipped.
+- **Falsified by**: A feature that is shipped is listed as `🔲 Future`, or a feature that is NOT shipped is listed as `✅ Present`.
+
+**O4**: After this PR, the COORD queue generator must produce at least 1 actionable queue item from design docs (not fall back to roadmap).
+- **Falsified by**: Running the queue generation script returns `SOURCE: roadmap` after this PR.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Number of `🔲 Future` items per doc: 2-4 is appropriate. More than 5 is too speculative.
+- Which future items to include: drawn from Zone 3 (deferred items), future-ideas.md where applicable, and known enforcement gaps.
+- Exact wording of Present/Future items is up to engineer.
+
+---
+
+## Zone 3 — Scoped out
+
+- Does NOT implement any of the Future items (just declares them).
+- Does NOT change any agent instruction files (agents/*, .opencode/*).
+- Does NOT add new roadmap stages.

--- a/docs/design/01-declarative-design-driven-development.md
+++ b/docs/design/01-declarative-design-driven-development.md
@@ -28,6 +28,23 @@ mark what is present vs future.
 
 ---
 
+## Present (✅)
+
+- ✅ Design doc required before spec — ENG creates `docs/design/` file before writing spec.md (PR #144, 2026-04-17)
+- ✅ Spec `## Design reference` section required — QA blocks PR if absent (PR #144, 2026-04-17)
+- ✅ Design doc updated in same PR as feature — `🔲 → ✅` markers move on merge (PR #144, 2026-04-17)
+- ✅ COORD reads design doc Future items as primary queue source — roadmap is fallback (PR #144, 2026-04-17)
+- ✅ PM validates design-doc coverage each cycle — opens kind/docs issues for gaps (PR #145, 2026-04-17)
+
+## Future (🔲)
+
+- 🔲 `/otherness.onboard` generates design doc drafts inferred from codebase — marked ⚠️ Inferred (O7 — deferred: requires onboarding agent update)
+- 🔲 Customer doc requirement enforced by QA — QA blocks PR if `docs/<feature>.md` missing for user-visible features (O6 — deferred: "user-visible" is hard to determine programmatically)
+- 🔲 CI lint for `## Design reference` presence in spec files — static check catches missing design reference before review (deferred: lint is structural; prose quality is not machine-checkable)
+- 🔲 Design doc for Stage 5 (Versioned Release Model) — create `docs/design/03-versioned-release.md` when Stage 5 triggers
+
+---
+
 ## Zone 1 — Obligations
 
 **O1 — Design doc must exist before spec.**

--- a/docs/design/02-human-instruction-interpretation.md
+++ b/docs/design/02-human-instruction-interpretation.md
@@ -17,6 +17,21 @@ input signals, not execution commands.
 
 ---
 
+## Present (✅)
+
+- ✅ D4 classification at session start — IMPERATIVE/DECLARATIVE/INFRA classification before acting (PR #145, 2026-04-17)
+- ✅ Translation format posted before implementation — `[📋 D4 TRANSLATION]` block with Heard/Intent/D4 layer/Artifact (PR #145, 2026-04-17)
+- ✅ 60s wait before acting on translation — human can correct before agent proceeds (PR #145, 2026-04-17)
+- ✅ Infra exception — pure maintenance tasks skip translation, go directly to spec (PR #145, 2026-04-17)
+
+## Future (🔲)
+
+- 🔲 Translation artifact persisted in spec — the D4 translation is saved as part of `.specify/specs/ITEM_ID/translation.md` for traceability (deferred: low priority until translation quality becomes a recurring issue)
+- 🔲 GitHub issue instructions intercepted — instructions posted as comments on GitHub issues are classified and translated before the agent acts on them (deferred: complex; issues go through queue currently)
+- 🔲 Translation confidence score — agent rates its own translation confidence; low confidence triggers the clarifying question even for non-ambiguous instructions (deferred: speculative, may increase friction)
+
+---
+
 ## Zone 1 — Obligations
 
 **O1 — Classify before acting.**


### PR DESCRIPTION
## Summary

Adds real ✅ Present and 🔲 Future sections to both design docs, enabling the COORD queue generator to read 7 actionable future items from `docs/design/` rather than falling back to roadmap.

**Before**: both design docs had empty `## Future (🔲)` template sections (0 items)
**After**: 7 parseable `🔲 Future` items across 2 design docs

## Design doc
Updated `docs/design/01-declarative-design-driven-development.md`:
- Added `## Present (✅)` — 5 shipped obligations
- Added `## Future (🔲)` — 4 real items (onboarding, QA enforcement, CI lint, Stage 5)

Updated `docs/design/02-human-instruction-interpretation.md`:
- Added `## Present (✅)` — 4 shipped obligations
- Added `## Future (🔲)` — 3 real items (persistence, GitHub issues, confidence)

## Verification
```
SOURCE: design docs (7 future items)
ITEM: /otherness.onboard generates design doc drafts inferred from codebase
ITEM: Customer doc requirement enforced by QA
ITEM: CI lint for ## Design reference presence in spec files
ITEM: Design doc for Stage 5 (Versioned Release Model)
ITEM: Translation artifact persisted in spec
ITEM: GitHub issue instructions intercepted
ITEM: Translation confidence score
```