### PR TITLE
docs(design): create 03-versioned-release.md for Stage 5

### DIFF
--- a/.specify/specs/152/spec.md
+++ b/.specify/specs/152/spec.md
@@ -1,0 +1,37 @@
+# Spec: docs(design): create design doc 03 for Stage 5
+
+> Item: 152 | Risk: low | Size: xs
+
+## Design reference
+- N/A — this item IS creating the design doc; no prior design doc exists for this area
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: `docs/design/03-versioned-release.md` must exist after this PR merges.
+- **Falsified by**: File does not exist after PR.
+
+**O2**: The new design doc must have parseable `## Present (✅)` and `## Future (🔲)` sections, with `🔲 Future` items matching the Stage 5 roadmap deliverables.
+- **Falsified by**: COORD queue generator finds 0 items in the new doc.
+
+**O3**: The doc must accurately reflect that Stage 5 has NOT started (no deliverables are ✅ Present yet).
+- **Falsified by**: Any Stage 5 deliverable is marked as ✅ Present.
+
+**O4**: `docs/design/01-DDDD.md` `## Future` section must be updated: the item `🔲 Design doc for Stage 5` moves to `## Present (✅)` with this PR reference.
+- **Falsified by**: Doc 01 still has `🔲 Design doc for Stage 5` in Future section after merge.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Doc structure: follow the template from doc 01.
+- Number of Future items: match the Stage 5 roadmap deliverables (5 items).
+- Zone 1/2/3 in the design doc: keep concise since Stage 5 is not yet active.
+
+---
+
+## Zone 3 — Scoped out
+
+- Does NOT implement any Stage 5 deliverables.
+- Does NOT change agent instruction files.

--- a/docs/design/01-declarative-design-driven-development.md
+++ b/docs/design/01-declarative-design-driven-development.md
@@ -35,13 +35,13 @@ mark what is present vs future.
 - ✅ Design doc updated in same PR as feature — `🔲 → ✅` markers move on merge (PR #144, 2026-04-17)
 - ✅ COORD reads design doc Future items as primary queue source — roadmap is fallback (PR #144, 2026-04-17)
 - ✅ PM validates design-doc coverage each cycle — opens kind/docs issues for gaps (PR #145, 2026-04-17)
+- ✅ Design doc for Stage 5 (Versioned Release Model) — created `docs/design/03-versioned-release.md` (PR #152, 2026-04-17)
 
 ## Future (🔲)
 
 - 🔲 `/otherness.onboard` generates design doc drafts inferred from codebase — marked ⚠️ Inferred (O7 — deferred: requires onboarding agent update)
 - 🔲 Customer doc requirement enforced by QA — QA blocks PR if `docs/<feature>.md` missing for user-visible features (O6 — deferred: "user-visible" is hard to determine programmatically)
 - 🔲 CI lint for `## Design reference` presence in spec files — static check catches missing design reference before review (deferred: lint is structural; prose quality is not machine-checkable)
-- 🔲 Design doc for Stage 5 (Versioned Release Model) — create `docs/design/03-versioned-release.md` when Stage 5 triggers
 
 ---
 

--- a/docs/design/03-versioned-release.md
+++ b/docs/design/03-versioned-release.md
@@ -1,0 +1,89 @@
+# 03: Versioned Release Model
+
+> Status: Planned — not yet started
+> Applies to: otherness itself (not the projects it manages)
+> Trigger: >10 repos using otherness, OR CRITICAL tier regression in production, OR community request
+
+---
+
+## What this does
+
+Projects can pin to a stable otherness version and upgrade explicitly, rather than
+always auto-updating to `main`. This prevents a bad agent instruction change from
+immediately affecting all users.
+
+Currently, every session runs `git -C ~/.otherness pull` at startup, taking the
+latest `main`. This is the fast, zero-overhead default. Stage 5 adds an opt-in
+stability layer on top of this default without removing it.
+
+The versioning model:
+- `main` remains the bleeding edge (current behavior, no change)
+- Tags (`v1.0.0`, `v1.1.0`) mark stable release points
+- Projects pin via `agent_version: v1.0.0` in `otherness-config.yaml`
+- `/otherness.upgrade` shows changelog and upgrades the pin
+
+---
+
+## Present (✅)
+
+*(Stage 5 has not started. Nothing is Present yet.)*
+
+## Future (🔲)
+
+- 🔲 Git tags as releases — each stable release is tagged `vMAJOR.MINOR.PATCH` on the otherness repo
+- 🔲 `agent_version` field in otherness-config.yaml — semver string; empty/absent = `main` (current behavior preserved)
+- 🔲 Self-update respects version pin — `git -C ~/.otherness checkout <version>` instead of `pull` when `agent_version` is set
+- 🔲 `/otherness.upgrade` command — shows changelog diff between current and latest tag, asks confirmation before updating the pin
+- 🔲 CHANGELOG.md maintained automatically — each merged PR to main appends an entry (SM phase responsibility)
+
+---
+
+## Zone 1 — Obligations (when Stage 5 is implemented)
+
+**O1 — Default behavior unchanged.**
+Projects without `agent_version` set continue to auto-update to `main`. Adding a
+version pin must be an explicit opt-in, not a change to the default.
+
+**O2 — Upgrade is always explicit.**
+No session silently upgrades the pinned version. `/otherness.upgrade` is the only
+mechanism. It shows the diff and waits for confirmation.
+
+**O3 — Pin is per-project, not global.**
+`agent_version` lives in `otherness-config.yaml`, not in the agent files. Different
+projects can pin to different versions.
+
+**O4 — Rollback is documented.**
+RECOVERY.md must include instructions for rolling back to a previous pin after a
+bad upgrade.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Version numbering scheme: `v1.MINOR.PATCH`. Major version bump for breaking changes
+  to CRITICAL tier files (standalone.md interface).
+- Whether to backfill past releases with tags: at Stage 5 trigger, the first release
+  is the current `main` HEAD tagged as `v1.0.0`.
+- CHANGELOG format: minimal — one line per PR with type/scope and PR number.
+
+---
+
+## Zone 3 — Scoped out
+
+- Automatic version discovery for projects (they must explicitly set `agent_version`)
+- Multi-project version dashboard
+- Pre-release tags (alpha, beta) — not needed at current scale
+- Yanking / patching a released version (just release a new patch tag)
+
+---
+
+## Rejected alternatives
+
+**"Always auto-update (current behavior, no versioning)."**
+This is the current state and it works well at small scale. Stage 5 exists as a
+future option, not a current need. See AGENTS.md §Future Risk: Global Deployment Model
+for the full analysis of when to switch.
+
+**"Each project forks the agent files."**
+Defeats the network effect: improvements don't propagate. The whole point of otherness
+is that a fix anywhere benefits everyone.


### PR DESCRIPTION
## Summary

Creates the design doc for Stage 5 (Versioned Release Model), fulfilling DDDD O5 (all roadmap stages should have design docs).

Stage 5 is NOT started — all deliverables are in `🔲 Future`.

## Design doc
Created `docs/design/03-versioned-release.md`:
- Present: empty (Stage 5 not yet triggered)
- Future: 5 items (git tags, agent_version field, version-pinned self-update, /otherness.upgrade, CHANGELOG.md)

Updated `docs/design/01-DDDD.md`: moved `🔲 Design doc for Stage 5` to `✅ Present`.