### PR TITLE
feat(tooling): add validate.sh check 5 — spec files must have ## Design reference

### DIFF
--- a/.specify/specs/10/spec.md
+++ b/.specify/specs/10/spec.md
@@ -106,3 +106,8 @@ atomicity is the correct distributed lock. Rejected.
 
 **Three separate functions**: One function with a retry loop is sufficient. No single-caller
 abstractions needed. Rejected.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/114/spec.md
+++ b/.specify/specs/114/spec.md
@@ -36,3 +36,8 @@ When CI_PROVIDER is unknown, the agent prints a warning that includes the provid
 - Full CircleCI/GitLab CI failure detail reporting (just green/red is enough).
 - Automatic token provision.
 - Other CI providers (Jenkins, Travis, etc.) — unknown → skip is sufficient.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/115/spec.md
+++ b/.specify/specs/115/spec.md
@@ -39,3 +39,8 @@ RECOVERY.md contains a section explaining how to pin to a previous tag when a ba
 - Auto-bumping version on every merge (too noisy; operator-driven).
 - Semantic versioning enforcement tooling.
 - Projects pinned to non-existent tags — they already fall back gracefully per standalone.md.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/119/spec.md
+++ b/.specify/specs/119/spec.md
@@ -39,3 +39,8 @@ If a capability profile specifies `job_family`, it overrides the default `JOB_FA
 - Profile-based rate limiting or resource quotas.
 - Profile validation (schema check of otherness-config.yaml).
 - Deprecating bounded-standalone.md — not changed here.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/121/spec.md
+++ b/.specify/specs/121/spec.md
@@ -35,3 +35,8 @@ grep -c "spec.*conformance" ~/.otherness/agents/standalone.md  # ≥ 1
 - Enforcing three-zone structure quality programmatically (too hard to validate statically).
 - Auto-generating spec.md (that's ENG's job).
 - Enforcing spec on non-otherness projects using otherness (they may not use speckit).
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/126/spec.md
+++ b/.specify/specs/126/spec.md
@@ -47,3 +47,8 @@ grep -c "handoff" ~/.otherness/agents/phases/sm.md       # ≥ 1
 - Mid-thought reasoning capture — too expensive and too noisy.
 - Per-item detailed history — state.json already has that.
 - Handoff for bounded agents — they inherit context from the parent session.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/127-128-129/spec.md
+++ b/.specify/specs/127-128-129/spec.md
@@ -51,3 +51,8 @@ If `git -C ~/.otherness ...` fails (no git, no repo): session ID still generated
 - Backfilling history: old comments don't get the new header format.
 - Weekly/monthly rotation granularity — daily only.
 - Bounded agents: they inherit `$REPORT_ISSUE`, `$MY_SESSION_ID`, `$OTHERNESS_VERSION` from the parent env; no separate changes to bounded-standalone.md needed.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/136/spec.md
+++ b/.specify/specs/136/spec.md
@@ -36,3 +36,8 @@
 - Regression detection for metrics other than `todo_shipped` and `needs_human` (those belong to #137 which is the SM-side feature).
 - Changing the metrics table format or adding new columns.
 - Alerting via any channel other than GitHub issues and issue comments.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/137/spec.md
+++ b/.specify/specs/137/spec.md
@@ -45,3 +45,8 @@ label and follow the CRITICAL tier self-review protocol.
 - ci_red_hours regression detection (not an integer in current table — uses `~0`, `~12` etc.)
 - Alerting via any channel other than GitHub issues.
 - Adding new metrics columns to the table.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/153/spec.md
+++ b/.specify/specs/153/spec.md
@@ -1,0 +1,42 @@
+# Spec: feat(tooling): validate.sh CI lint for ## Design reference
+
+> Item: 153 | Risk: low | Size: xs
+
+## Design reference
+- **Design doc**: `docs/design/01-declarative-design-driven-development.md`
+- **Section**: `§ Future (🔲)`
+- **Implements**: CI lint for `## Design reference` presence in spec files (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: `scripts/validate.sh` must include a new check that verifies every `.specify/specs/*/spec.md` file contains a `## Design reference` section.
+- **Falsified by**: validate.sh exits 0 when a spec.md is missing `## Design reference`.
+
+**O2**: The check must exit non-zero (failing validate.sh) if any spec.md lacks the section.
+- **Falsified by**: validate.sh exits 0 even when a spec is missing the design reference.
+
+**O3**: The check must be graceful when `.specify/specs/` does not exist (new projects without specs yet should not fail).
+- **Falsified by**: validate.sh fails when `.specify/specs/` directory is absent.
+
+**O4**: The check counter must be added as step 5 to validate.sh (keeping the existing step numbering consistent).
+- **Falsified by**: Existing checks renumbered or removed.
+
+**O5**: `docs/design/01-DDDD.md` `## Future` must be updated: `🔲 CI lint for ## Design reference` → `✅ Present`.
+- **Falsified by**: Item still in Future after merge.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Bash pattern for finding spec files: `find .specify/specs -name "spec.md"` or glob.
+- Error message should name the failing spec file.
+
+---
+
+## Zone 3 — Scoped out
+
+- Does NOT check spec content quality (prose quality is not machine-checkable).
+- Does NOT check `## Design reference` content, only presence.
+- Does NOT modify `scripts/test.sh` or `scripts/lint.sh`.

--- a/.specify/specs/41/spec.md
+++ b/.specify/specs/41/spec.md
@@ -115,3 +115,8 @@ git push origin --delete _state
 # trigger state write → it should bootstrap and write
 git ls-remote --heads origin _state  # branch recreated
 ```
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/42/spec.md
+++ b/.specify/specs/42/spec.md
@@ -64,3 +64,8 @@ grep -n "push origin main" agents/standalone.md agents/bounded-standalone.md
 # Only allowed output: lines containing the string in a comment explaining what NOT to do
 # Zero matches = PASS
 ```
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/43/spec.md
+++ b/.specify/specs/43/spec.md
@@ -92,3 +92,8 @@ After this PR merges, trigger a queue generation and verify:
 3. No generated item is labeled `size/m` or larger.
 4. No generated item duplicates an open issue or recent merged PR title.
 5. Queue has ≤ 5 items.
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/44/spec.md
+++ b/.specify/specs/44/spec.md
@@ -122,3 +122,8 @@ EOF
 python3 -c "import json; s=json.load(open('.otherness/state.json')); print(s.get('version'), s.get('repo'), 'engineer_slots' in s)"
 # Must print: 1.3 pnz1990/test True
 ```
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/45/spec.md
+++ b/.specify/specs/45/spec.md
@@ -114,3 +114,8 @@ fi
 # Verify output contains a table with all 4 projects
 # Verify a stale project shows ⚠️ STALE
 ```
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/.specify/specs/47/spec.md
+++ b/.specify/specs/47/spec.md
@@ -71,3 +71,8 @@ bash scripts/validate.sh  # must still pass
 # Test 3: current passing state still passes
 bash scripts/validate.sh && echo "PASS" || echo "FAIL"
 ```
+
+---
+
+## Design reference
+- N/A — pre-DDDD item (written before design doc system, PR #144)

--- a/docs/design/01-declarative-design-driven-development.md
+++ b/docs/design/01-declarative-design-driven-development.md
@@ -36,12 +36,12 @@ mark what is present vs future.
 - ✅ COORD reads design doc Future items as primary queue source — roadmap is fallback (PR #144, 2026-04-17)
 - ✅ PM validates design-doc coverage each cycle — opens kind/docs issues for gaps (PR #145, 2026-04-17)
 - ✅ Design doc for Stage 5 (Versioned Release Model) — created `docs/design/03-versioned-release.md` (PR #152, 2026-04-17)
+- ✅ CI lint for `## Design reference` presence in spec files — validate.sh check 5 (PR #153, 2026-04-17)
 
 ## Future (🔲)
 
 - 🔲 `/otherness.onboard` generates design doc drafts inferred from codebase — marked ⚠️ Inferred (O7 — deferred: requires onboarding agent update)
 - 🔲 Customer doc requirement enforced by QA — QA blocks PR if `docs/<feature>.md` missing for user-visible features (O6 — deferred: "user-visible" is hard to determine programmatically)
-- 🔲 CI lint for `## Design reference` presence in spec files — static check catches missing design reference before review (deferred: lint is structural; prose quality is not machine-checkable)
 
 ---
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -159,12 +159,29 @@ done
 [ $MISSING_FILES -eq 0 ] && echo "  OK: all required files present" || exit 1
 
 # 4. Check self-update is present in standalone.md
-echo "[4/4] Checking self-update mechanism..."
+echo "[4/5] Checking self-update mechanism..."
 if ! grep -q "git -C ~/.otherness pull" "$AGENTS_DIR/standalone.md"; then
   echo "  ERROR: standalone.md missing self-update (git pull) mechanism"
   exit 1
 fi
 echo "  OK: self-update present"
+
+# 5. Check all spec.md files contain ## Design reference
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SPECS_DIR="$ROOT_DIR/.specify/specs"
+echo "[5/5] Checking spec files for ## Design reference..."
+if [ ! -d "$SPECS_DIR" ]; then
+  echo "  OK: no .specify/specs/ directory — skipping spec lint"
+else
+  MISSING_REF=0
+  while IFS= read -r spec_file; do
+    if ! grep -q "^## Design reference" "$spec_file" 2>/dev/null; then
+      echo "  ERROR: spec missing ## Design reference: $spec_file"
+      MISSING_REF=1
+    fi
+  done < <(find "$SPECS_DIR" -name "spec.md" 2>/dev/null)
+  [ $MISSING_REF -eq 0 ] && echo "  OK: all spec files have ## Design reference" || exit 1
+fi
 
 echo ""
 echo "=== validate: PASSED ==="


### PR DESCRIPTION
## Summary

Adds validate.sh check [5/5]: every `.specify/specs/*/spec.md` must contain `## Design reference`. This makes DDDD O2 machine-enforceable at CI time.

- 15 pre-DDDD spec files backfilled with `N/A — pre-DDDD item`
- validate.sh now has 5 checks (was 4)
- All specs pass the new check

## Design doc
Updated `docs/design/01-DDDD.md`: `🔲 CI lint for ## Design reference` → `✅ Present`

## Verification
```
[5/5] Checking spec files for ## Design reference...
  OK: all spec files have ## Design reference
=== validate: PASSED ===
```