### PR TITLE
feat(qa): check for customer doc in spec conformance — MISS finding if absent

### DIFF
--- a/.specify/specs/159/spec.md
+++ b/.specify/specs/159/spec.md
@@ -1,0 +1,42 @@
+# Spec: feat(qa): enforce customer doc existence for user-visible features
+
+> Item: 159 | Risk: medium | Size: s | Tier: CRITICAL (qa.md)
+
+## Design reference
+- **Design doc**: `docs/design/01-declarative-design-driven-development.md`
+- **Section**: `§ Future (🔲)`
+- **Implements**: Customer doc requirement enforced by QA (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: The QA spec conformance check (§3b) must include a step that checks for a customer doc when the spec has a non-N/A `## Design reference`.
+- **Falsified by**: QA approves a PR with a non-N/A design reference without checking for a customer doc.
+
+**O2**: The check must be a **MISS** finding (open a follow-up issue, do NOT block merge). Since "user-visible" is ambiguous, blocking would cause false positives.
+- **Falsified by**: The check blocks merge for any PR with a non-N/A design reference.
+
+**O3**: The check must only fire when the design reference points to an actual `docs/design/` file (not N/A). Infra-only items must be skipped.
+- **Falsified by**: The check fires for specs with `## Design reference: - N/A`.
+
+**O4**: The change must be a 3-5 line addition to qa.md §3b — no restructuring.
+- **Falsified by**: More than 8 lines of qa.md changed.
+
+**O5**: `docs/design/01-DDDD.md` `## Future` must be updated: `🔲 Customer doc requirement enforced by QA` → `✅ Present`.
+- **Falsified by**: Item still in Future after merge.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- What constitutes a "customer doc": `docs/<feature-area>.md` where feature-area is derived from the design doc filename or referenced section.
+- Since this is a MISS (not WRONG), wording should be informational: "Consider adding a customer doc..."
+
+---
+
+## Zone 3 — Scoped out
+
+- Does NOT enforce customer doc content quality
+- Does NOT check whether the customer doc is up-to-date
+- Does NOT block merge — MISS only

--- a/agents/phases/qa.md
+++ b/agents/phases/qa.md
@@ -61,6 +61,8 @@ else
   # Three valid outcomes:
   #   A) Section present with a docs/design/ file named → verify that file exists and
   #      check that the PR diff updates it (🔲 → ✅). If design doc not updated: WRONG.
+  #      Also: check if a docs/<feature>.md customer doc exists. If not: MISS finding —
+  #      open a follow-up issue "docs: add customer doc for <feature-area>". Do NOT block merge.
   #   B) Section present with "N/A — infrastructure change" → acceptable for chore/fix/refactor.
   #   C) Section absent → WRONG. Post:
   #      "[QA] WRONG — spec.md missing ## Design reference section.

--- a/docs/design/01-declarative-design-driven-development.md
+++ b/docs/design/01-declarative-design-driven-development.md
@@ -37,11 +37,11 @@ mark what is present vs future.
 - ✅ PM validates design-doc coverage each cycle — opens kind/docs issues for gaps (PR #145, 2026-04-17)
 - ✅ Design doc for Stage 5 (Versioned Release Model) — created `docs/design/03-versioned-release.md` (PR #152, 2026-04-17)
 - ✅ CI lint for `## Design reference` presence in spec files — validate.sh check 5 (PR #153, 2026-04-17)
+- ✅ Customer doc requirement checked by QA — MISS finding (follow-up issue) when non-N/A design ref has no customer doc (PR #159, 2026-04-17)
 
 ## Future (🔲)
 
 - 🔲 `/otherness.onboard` generates design doc drafts inferred from codebase — marked ⚠️ Inferred (O7 — deferred: requires onboarding agent update)
-- 🔲 Customer doc requirement enforced by QA — QA blocks PR if `docs/<feature>.md` missing for user-visible features (O6 — deferred: "user-visible" is hard to determine programmatically)
 
 ---
 


### PR DESCRIPTION
## Summary

When a spec has a non-N/A `## Design reference`, QA now checks for a customer doc (`docs/<feature>.md`). If absent: **MISS** finding (follow-up issue), does NOT block merge.

This is a conservative implementation of DDDD O6 — enforcing customer doc existence without false-positive blocking.

**Risk**: MEDIUM — CRITICAL tier (qa.md). +3 lines. No restructuring.

## [NEEDS HUMAN: critical-tier-change]

Per AGENTS.md CRITICAL tier rules. AUTONOMOUS_MODE=true self-review below.

## Design doc
Updated `docs/design/01-DDDD.md`: `🔲 Customer doc requirement enforced by QA` → `✅ Present`