### PR TITLE
feat(onboard): add Step 4b — generate docs/design/ stubs inferred from codebase

### DIFF
--- a/.specify/specs/163/spec.md
+++ b/.specify/specs/163/spec.md
@@ -1,0 +1,43 @@
+# Spec: feat(onboard): generate design doc stubs
+
+> Item: 163 | Risk: high | Size: l | Tier: HIGH (onboard.md)
+
+## Design reference
+- **Design doc**: `docs/design/01-declarative-design-driven-development.md`
+- **Section**: `§ Future (🔲)`
+- **Implements**: `/otherness.onboard` generates design doc drafts inferred from codebase (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: `/otherness.onboard` must create draft `docs/design/` files for 2-4 major feature areas inferred from the codebase.
+- **Falsified by**: Onboarding completes without creating any `docs/design/` files.
+
+**O2**: Each generated design doc must include `⚠️ Inferred — review before treating as authoritative` in the status line.
+- **Falsified by**: Generated design doc has no inferred warning.
+
+**O3**: Each generated design doc must have `## Present (✅)` and `## Future (🔲)` sections, populated with inferred content.
+- **Falsified by**: Generated design doc has neither section.
+
+**O4**: The step must be graceful when the codebase has no identifiable feature areas (new empty project). In that case, create a single `docs/design/01-overview.md` stub.
+- **Falsified by**: Onboarding crashes or creates 0 docs for an empty project.
+
+**O5**: `docs/design/01-DDDD.md` `## Future` must be updated: `/otherness.onboard generates design doc drafts` → `✅ Present`.
+- **Falsified by**: Item still in Future after merge.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How to infer feature areas: look at directory structure, package.json/pom.xml/go.mod, and README.md headings
+- Number of design docs to generate: 2-4 (too many overwhelms; too few is useless)
+- Depth of generated content: stubs are acceptable — Present section can say "inferred from code" and Future can say "TODO: review and add items"
+
+---
+
+## Zone 3 — Scoped out
+
+- Does NOT enforce the inferred design docs are accurate
+- Does NOT update them after initial onboarding
+- Does NOT run validate.sh on the generated docs (they're marked as drafts)

--- a/agents/onboard.md
+++ b/agents/onboard.md
@@ -294,6 +294,42 @@ Required by `scripts/validate.sh`. Seed with the header and empty batch log:
 
 ---
 
+## STEP 4b — Create docs/design/ stubs
+
+Create design doc stubs inferred from the codebase. These are drafts — they will be refined
+by the agent loop over time. Mark every generated doc as `⚠️ Inferred`.
+
+```bash
+mkdir -p docs/design
+```
+
+```bash
+# [AI-STEP] Infer 2-4 major feature areas from the codebase.
+#
+# Sources to read (in order):
+# 1. Repository top-level directory structure (ls .)
+# 2. README.md sections and headings
+# 3. Package manifest (package.json, pom.xml, go.mod, Cargo.toml, requirements.txt)
+# 4. Any existing docs/ files
+#
+# For each inferred feature area:
+# 1. Create docs/design/0N-<area-slug>.md
+# 2. Include: Status: Draft | ⚠️ Inferred — review before treating as authoritative
+# 3. Include: ## What this does (one paragraph from README or inferred)
+# 4. Include: ## Present (✅) — list major existing capabilities (inferred from code)
+# 5. Include: ## Future (🔲) — leave empty or add obvious TODOs
+# 6. Include: ## Zone 1 — Obligations (stub: "To be defined")
+#
+# If no feature areas can be identified: create docs/design/01-overview.md
+# with status: ⚠️ Inferred — project structure not yet identifiable.
+#
+# Example output for a web app with auth and API:
+#   docs/design/01-authentication.md
+#   docs/design/02-api-endpoints.md
+```
+
+---
+
 ## STEP 5 — Seed `.otherness/state.json`
 
 ```bash

--- a/docs/design/01-declarative-design-driven-development.md
+++ b/docs/design/01-declarative-design-driven-development.md
@@ -38,10 +38,11 @@ mark what is present vs future.
 - ✅ Design doc for Stage 5 (Versioned Release Model) — created `docs/design/03-versioned-release.md` (PR #152, 2026-04-17)
 - ✅ CI lint for `## Design reference` presence in spec files — validate.sh check 5 (PR #153, 2026-04-17)
 - ✅ Customer doc requirement checked by QA — MISS finding (follow-up issue) when non-N/A design ref has no customer doc (PR #159, 2026-04-17)
+- ✅ `/otherness.onboard` generates design doc stubs — Step 4b creates 2-4 inferred docs, marked ⚠️ Inferred (PR #163, 2026-04-17)
 
 ## Future (🔲)
 
-- 🔲 `/otherness.onboard` generates design doc drafts inferred from codebase — marked ⚠️ Inferred (O7 — deferred: requires onboarding agent update)
+*(No remaining Future items — all DDDD obligations are now Present or explicitly deferred in Zone 3.)*
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `## STEP 4b — Create docs/design/ stubs` to onboard.md. During onboarding, the agent now infers 2-4 major feature areas from the project and creates draft design docs marked `⚠️ Inferred`.

Every new project onboarded by otherness immediately has a `docs/design/` directory. The COORD queue uses these stubs as queue source from day 1.

**Risk**: HIGH — onboard.md is a HIGH tier file. The step is entirely an AI-STEP (agent judgment), no mandatory shell commands that could fail.

## Design doc
Updated `docs/design/01-DDDD.md`: `🔲 /otherness.onboard generates design doc stubs` → `✅ Present`
**DDDD design doc now has 0 remaining Future items** — all obligations shipped.