### PR TITLE
feat(pm): expand §5c cross-project improvement proposals (Idea 5)

### DIFF
--- a/.specify/specs/175/spec.md
+++ b/.specify/specs/175/spec.md
@@ -1,0 +1,37 @@
+# Spec: feat(pm): cross-project improvement proposals
+
+> Item: 175 | Risk: medium | Size: m | Tier: CRITICAL (pm.md — phases file)
+
+## Design reference
+- N/A — enhancement to pm.md §5c stub (docs/future-ideas.md Idea 5)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: pm.md §5c must be expanded with a [AI-STEP] that looks across all monitored projects for common blockers, not just competitive analysis.
+- **Falsified by**: §5c still only mentions competitive analysis without cross-project blocker detection.
+
+**O2**: When ≥2 projects share the same blocker (needs_human open, CI red, 0 velocity), PM must open an issue on the otherness repo proposing an improvement.
+- **Falsified by**: PM runs the check but opens no issue even when ≥2 projects share a blocker.
+
+**O3**: The issue proposal must not contain project-specific information (project names must be abstracted).
+- **Falsified by**: Issue body contains a specific project repo slug.
+
+**O4**: Change confined to §5c stub replacement — no new sections in pm.md.
+- **Falsified by**: New section added or existing sections outside §5c modified.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Frequency: keeps current "every 10 PM cycles" trigger
+- What "common blocker" means: same category of needs-human issue, both CI red, or both 0 velocity
+- Issue title format: "improvement(loop): <abstract pattern> affecting ≥2 managed projects"
+
+---
+
+## Zone 3 — Scoped out
+
+- Does NOT implement competitive analysis against external tools (that's separate)
+- Does NOT aggregate metric data across projects (only needs-human + CI status)

--- a/agents/phases/pm.md
+++ b/agents/phases/pm.md
@@ -92,11 +92,25 @@ with open('.otherness/state.json', 'w') as f: json.dump(s, f, indent=2)
 
 ```bash
 if [ $((${PM_CYCLE:-0} % 10)) -eq 0 ] && [ "${PM_CYCLE:-0}" -gt 0 ]; then
-  echo "[PM] Running competitive analysis..."
-  # [AI-STEP] Check otherness against the category it belongs to.
-  # Read docs/future-ideas.md for potential improvements.
-  # Check speckit release notes for new patterns worth adopting.
-  # If a gap is found that would make otherness measurably better: open an issue.
+  echo "[PM] Running cross-project improvement check..."
+  # [AI-STEP] Cross-project improvement proposals (Idea 5 from docs/future-ideas.md):
+  # 1. Read monitor.projects from otherness-config.yaml
+  # 2. For each project:
+  #    - Check open [needs-human] issues: gh issue list --repo <proj> --label needs-human --state open
+  #    - Check CI status: gh run list --repo <proj> --branch main --limit 1 --json conclusion
+  #    - Check recent metrics (if accessible): look for todo_shipped = 0 in _state metrics
+  # 3. Find common blockers across ≥2 projects:
+  #    - Both have needs-human open → pattern: "unresolved escalation backlog"
+  #    - Both have CI red → pattern: "CI reliability gap"
+  #    - Both have 0 velocity → pattern: "queue generation or claiming issue"
+  # 4. For each common blocker: open an issue on $REPO proposing the improvement.
+  #    Title: "improvement(loop): <abstract pattern> affecting ≥2 managed projects"
+  #    Body: abstract description (no project names) + suggested fix direction
+  #    Labels: otherness,kind/enhancement,area/agent-loop
+  # 5. Also check docs/future-ideas.md for ideas ready to implement.
+  #    If an idea has a complexity tag of 'small' or 'xs' and hasn't been opened as an issue:
+  #    open it now with a [PM proposal] prefix.
+  # If only 1 project in monitor: log "[PM] Need ≥2 projects for cross-project analysis."
 fi
 ```
 


### PR DESCRIPTION
## Summary

Replaces §5c minimal stub with cross-project improvement detector. PM now looks across monitored projects for common blockers and opens improvement issues on the otherness repo.

**Risk**: MEDIUM — CRITICAL tier (pm.md). +15 lines AI-STEP.

## [NEEDS HUMAN: critical-tier-change]

Self-review below.