### PR TITLE
fix(test): use REPO_ROOT env var for config path in test.sh heredoc

### DIFF
--- a/.specify/specs/178/spec.md
+++ b/.specify/specs/178/spec.md
@@ -1,0 +1,26 @@
+# Spec: fix(test): test.sh integration check __file__ bug
+
+> Item: 178 | Risk: low | Size: xs
+
+## Design reference
+- N/A — infrastructure bug fix, no user-visible behavior change
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: test.sh must use a correct path to resolve otherness-config.yaml — not os.path.abspath(__file__) in a heredoc.
+- **Falsified by**: REFERENCE_PROJECT remains empty after fix.
+
+**O2**: After fix, test.sh integration check actually runs on the reference project (pnz1990/alibi).
+- **Falsified by**: Integration check still skipped when otherness-config.yaml has monitor.projects.
+
+---
+
+## Zone 2 — Implementer's judgment
+- Use SCRIPT_DIR (already defined in the shell) to construct the config path.
+- Or use pure bash to parse the YAML.
+
+## Zone 3 — Scoped out
+- Does not fix the alibi stall (Journey 2 failure) — that's a separate [NEEDS HUMAN].
+- Does not modify validate.sh or lint.sh.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,10 +14,11 @@ echo "=== otherness integration test ==="
 
 # Resolve the reference project from otherness-config.yaml (first entry under monitor.projects)
 # Falls back gracefully if not configured — integration check is skipped, not failed.
-REFERENCE_PROJECT=$(python3 - << 'EOF'
+REFERENCE_PROJECT=$(REPO_ROOT="$REPO_ROOT" python3 - << 'EOF'
 import re, os, sys
 
-config_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'otherness-config.yaml')
+# Use REPO_ROOT from shell env — __file__ is undefined in heredocs
+config_path = os.path.join(os.environ.get('REPO_ROOT', '.'), 'otherness-config.yaml')
 try:
     content = open(config_path).read()
     in_monitor = in_projects = False
@@ -28,7 +29,8 @@ try:
             m = re.match(r'\s+- (.+)', line)
             if m:
                 repo = m.group(1).strip()
-                repo = repo.strip('"').strip("'")  # strip quotes — avoid backslash in heredoc                # Skip the otherness repo itself as reference — pick a managed project
+                repo = repo.strip('"').strip("'")
+                # Skip the otherness repo itself — pick a managed project
                 if not repo.endswith('/otherness'):
                     print(repo)
                     sys.exit(0)


### PR DESCRIPTION
## Summary

`__file__` is undefined in Python heredocs. The reference project extraction in test.sh always returned empty, silently skipping the integration check.

**Fix**: Pass REPO_ROOT from shell as env var; Python reads it via `os.environ.get('REPO_ROOT', '.')`.

**After fix**: Integration check correctly runs, shows warning when alibi is stale (current state).

**Risk**: LOW — scripts/test.sh only, no agent instruction files changed.