### PR TITLE
feat(sm): skill confidence check — flag unreferenced/stale skills (§4c-skill)

### DIFF
--- a/.specify/specs/179/spec.md
+++ b/.specify/specs/179/spec.md
@@ -1,0 +1,41 @@
+# Spec: feat(sm): skill confidence scoring
+
+> Item: 179 | Risk: medium | Size: m | Tier: CRITICAL (sm.md — phases file)
+
+## Design reference
+- N/A — new SM subsection for skill quality maintenance (docs/future-ideas.md Idea 6)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: sm.md must include a new subsection (between §4c and §4d) that checks each skill file for:
+- Not loaded recently (no reference in phases/*.md or standalone.md within last 6 months)
+- Content appears contradicted by a newer skill file
+- Older than 90 days with no updates
+- **Falsified by**: No skill confidence check in SM phase after PR.
+
+**O2**: The check is AI-STEP only — it produces a comment/warning, never modifies skill files autonomously.
+- **Falsified by**: SM phase deletes or modifies a skill file.
+
+**O3**: Results are posted as a comment on REPORT_ISSUE (not as a [NEEDS HUMAN] escalation — just informational).
+- **Falsified by**: A [NEEDS HUMAN] is posted when skill confidence is low.
+
+**O4**: Change is a new section insertion between §4c and §4d — no existing sections modified.
+- **Falsified by**: Any existing sm.md section content changed.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Frequency: once per 10 SM cycles (same as PM competitive check)
+- What "not loaded recently" means: skill filename doesn't appear in any grep of phases/*.md or standalone.md
+- Whether to check for contradictions: basic overlap detection (same topic name in 2 skill files)
+
+---
+
+## Zone 3 — Scoped out
+
+- Does NOT auto-deprecate skills
+- Does NOT merge skill files
+- Does NOT change any skill content

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -224,6 +224,28 @@ with open('.otherness/state.json', 'w') as f: json.dump(s, f, indent=2)
 
 ---
 
+## 4c-skill. Skill confidence check (every 10 SM cycles)
+
+```bash
+if [ $((${BATCH_COUNT:-0} % 10)) -eq 0 ] && [ "${BATCH_COUNT:-0}" -gt 0 ]; then
+  echo "[SM] Running skill confidence check..."
+  # [AI-STEP] Check each skill file in ~/.otherness/agents/skills/ (excluding PROVENANCE, README):
+  # For each skill:
+  # 1. Check if it is referenced in phases/*.md or standalone.md:
+  #    grep -r "<skill-basename>" ~/.otherness/agents/phases/ ~/.otherness/agents/standalone.md
+  #    If not found: note as "unreferenced"
+  # 2. Check age: git -C ~/.otherness log --format='%ar' -1 -- agents/skills/<skill>.md
+  #    If last modified >180 days ago: note as "stale"
+  # 3. Check for obvious contradictions: if 2 skill files have the same topic heading:
+  #    note both as "possibly overlapping"
+  # Compile a report. Post it as a comment on $REPORT_ISSUE (informational only).
+  # Do NOT modify any skill file. Do NOT post [NEEDS HUMAN].
+  # Example comment: "[SM] Skill confidence: 12 skills checked. unreferenced: [X]. stale: [Y]."
+fi
+```
+
+---
+
 ## 4d. Write session handoff
 
 ```bash


### PR DESCRIPTION
## Summary

New SM subsection §4c-skill: every 10 cycles, checks each skill file for unreferenced, stale, or overlapping content. Posts informational comment on report issue. No file modifications.

**Risk**: MEDIUM — CRITICAL tier (sm.md). +17 lines AI-STEP. No restructuring.

## [NEEDS HUMAN: critical-tier-change]

Self-review below.