### PR TITLE
chore(design): remove speculative D4 item from COORD queue source

### DIFF
--- a/.specify/specs/196/spec.md
+++ b/.specify/specs/196/spec.md
@@ -1,0 +1,23 @@
+# Spec: chore(design): move deferred D4 item out of COORD queue
+
+> Item: 196 | Risk: low | Size: xs
+
+## Design reference
+- **Design doc**: `docs/design/02-human-instruction-interpretation.md`
+- **Section**: `§ Future (🔲)`
+- **Implements**: removing speculative/deferred item from COORD queue source
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: The "Translation confidence score" item must no longer appear in COORD queue generation output.
+**O2**: The item must be preserved in the design doc (not deleted) — just in a section that COORD won't match.
+
+---
+
+## Zone 2 — Implementer's judgment
+- Use same pattern as Stage 5 guard: rename ## Future → ## Deferred or ## Speculative.
+
+## Zone 3 — Scoped out
+- Does not implement the feature.

--- a/docs/design/02-human-instruction-interpretation.md
+++ b/docs/design/02-human-instruction-interpretation.md
@@ -26,7 +26,9 @@ input signals, not execution commands.
 - ✅ Translation artifact persisted in spec — D4 translation saved to `.specify/d4/translation.md` before proceeding (PR #154, 2026-04-17)
 - ✅ GitHub issue instructions intercepted — coord.md checks last 5 comments on claimed issue for imperative instructions, posts D4 translation (PR #167, 2026-04-17)
 
-## Future (🔲)
+## Speculative (🔲 — not a queue input, deferred until needed)
+
+> ⚠️ Items in this section are explicitly deferred as speculative. COORD does NOT generate queue items from this section.
 
 - 🔲 Translation confidence score — agent rates its own translation confidence; low confidence triggers the clarifying question even for non-ambiguous instructions (deferred: speculative, may increase friction)
 


### PR DESCRIPTION
Design docs now have 0 non-deferred queue-visible Future items. COORD will generate from roadmap as fallback until new design doc items are added.