### PR TITLE
docs: arch-audit 2026-04-17 — fix false claims in README and future-ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ Session 1: /otherness.run.bounded
            AGENT_ID=STANDALONE-REFACTOR
            SCOPE=Fix logic leaks in the health and auth packages
            ALLOWED_AREAS=area/health,area/auth
-           ALLOWED_MILESTONES=v1.1.0
            ALLOWED_PACKAGES=pkg/health,pkg/auth
            DENY_PACKAGES=cmd/myapp,api/v1
 
@@ -197,12 +196,13 @@ Session 2: /otherness.run.bounded
            AGENT_ID=STANDALONE-CLI
            SCOPE=CLI commands and output formatting
            ALLOWED_AREAS=area/cli
-           ALLOWED_MILESTONES=v1.1.0
            ALLOWED_PACKAGES=cmd/myapp
            DENY_PACKAGES=pkg/core
 ```
 
-Each session posts hourly updates to its own `[AGENT_NAME] Progress Log` GitHub issue.
+Supported BOUNDARY parameters: `AGENT_NAME` (required), `AGENT_ID`, `SCOPE` (required), `ALLOWED_AREAS`, `ALLOWED_PACKAGES`, `DENY_PACKAGES`.
+
+Each session uses `$AGENT_NAME` as its badge on all issue comments and PRs.
 
 ---
 
@@ -210,13 +210,15 @@ Each session posts hourly updates to its own `[AGENT_NAME] Progress Log` GitHub 
 
 | What you want | Where |
 |---|---|
-| What's being worked on | Projects → Sprint board |
-| Full backlog | Projects → Backlog |
-| Release progress | GitHub Milestones |
-| What shipped | GitHub Releases |
-| Agent reports | Issue #REPORT_ISSUE |
-| Per-agent progress | Each agent's Progress Log issue |
+| What's being worked on | `_state` branch → `state.json` features (in_progress items) |
+| Full backlog | GitHub issues (open, labeled `otherness`) |
+| Agent reports | Issue #REPORT_ISSUE (comment stream from all phases) |
 | Blocking decisions | Issues labeled `needs-human` |
+| CI status | GitHub Actions (main branch runs) |
+
+> **Note**: GitHub Projects board, Milestones, and Releases integration are not enabled by default.
+> `github_projects` fields in `otherness-config.yaml` must be configured to activate Projects board sync.
+> Milestones and Releases are not currently written by any agent phase.
 
 ---
 

--- a/docs/future-ideas.md
+++ b/docs/future-ideas.md
@@ -109,7 +109,7 @@ Higher-quality skills → better ENG/QA decisions.
 1. ✅ **Idea 1** (learn from `[NEEDS HUMAN]`) — COVERED by SM §4c (PR #173)
 2. ✅ **Idea 3** (difficulty ledger) — DONE (PR #172)
 3. ✅ **Idea 2** (cross-project SM mining) — COVERED by SM §4c (PR #173)
-4. **Idea 4** (internal portfolio learn) — NEXT UP: triggers at sm_cycle_count=30 (currently 14)
+4. **Idea 4** (internal portfolio learn) — NEXT UP: triggers at sm_cycle_count=30 (currently 16)
 5. ✅ **Idea 5** (PM cross-project proposals) — DONE (PR #177)
 6. ✅ **Idea 6** (skill confidence) — DONE (PR #181)
 7. **Idea 8** ✅ — COVERED by SM §4c (PR #173)


### PR DESCRIPTION
## Summary

Architecture audit found 8 findings. This PR corrects the documentation issues that can be fixed immediately (pure doc fixes, no behavior change).

## Documentation fixes

- **README bounded sessions**: Removed unsupported `ALLOWED_MILESTONES` parameter from example (fixes #201). Added list of supported BOUNDARY parameters.
- **README bounded sessions**: Removed false 'hourly Progress Log' claim — no such mechanism exists in bounded-standalone.md
- **README observability table**: Replaced false entries (Projects Sprint board, Backlog, Milestones, Releases — all unconfigured) with accurate observability channels (fixes #203). Added note about GitHub Projects requiring manual configuration.
- **future-ideas.md**: Updated sm_cycle_count inline counter from 14→16 to match actual state.

## Issues opened (code fixes required separately)

| Issue | Title | Priority |
|---|---|---|
| #198 | stale watchdog uses REPO slug not 'origin' — item locks never released | HIGH |
| #199 | duplicate §1c section labels in coord.md | HIGH |
| #200 | validate.sh check count in AGENTS.md is 4, actual is 5 | MEDIUM |
| #201 | ALLOWED_MILESTONES bounded parameter is unsupported | MEDIUM |
| #202 | lint.sh misses agents/phases/*.md — CRITICAL tier files not covered | MEDIUM |
| #203 | README observability claims GitHub Projects/Milestones/Releases as active | MEDIUM |
| #204 | difficulty-ledger.md never loaded in eng.md despite skills README saying it should | MEDIUM |
| #205 | AGENTS.md PM competitive check claim false — §5c does internal monitoring only | LOW |

## What was NOT changed

- AGENTS.md check count description (#200) — AGENTS.md is protected from agent modification; requires human update
- Code fixes for #198, #199, #202, #204 — these are behavior changes requiring full ENG→QA cycle

🤖 Generated with [Claude Code](https://claude.ai/code)