### PR TITLE
fix(coord): use 'origin' not REPO slug in stale watchdog branch delete (#198)

### DIFF
--- a/.specify/specs/198/spec.md
+++ b/.specify/specs/198/spec.md
@@ -1,0 +1,27 @@
+# Spec: fix coord stale watchdog REPO→origin (#198)
+
+## Design reference
+- N/A — infrastructure bug fix with no user-visible behavior change
+
+## Zone 1 — Obligations
+
+**O1** — `coord.md` stale item watchdog branch-delete call uses `'origin'` as git remote, not `REPO`.
+
+Falsifiable: `grep "git.*push.*REPO.*--delete" agents/phases/coord.md` returns zero matches after this fix.
+
+**O2** — The queue-gen lock recovery (existing correct usage) is unchanged.
+
+Falsifiable: `grep "git.*push.*origin.*--delete.*queue-gen" agents/phases/coord.md` still returns one match.
+
+**O3** — No other `git push REPO` patterns exist in coord.md or other phase files for branch deletion.
+
+Falsifiable: scan of all agents/phases/*.md for `git push.*REPO.*--delete` returns zero matches.
+
+## Zone 2 — Implementer's judgment
+
+- Audit all phases/*.md for the same pattern as part of this fix.
+
+## Zone 3 — Scoped out
+
+- Fixing the REPO variable definition (it's correct for gh CLI — only wrong for git remote ops)
+- Changing gh CLI calls that correctly use the slug

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -333,7 +333,7 @@ for item_id, d in list(s.get('features', {}).items()):
         print(f"[COORD] Stale: {item_id} assigned {age_h:.1f}h ago, heartbeat {hb_age_h:.1f}h ago — resetting to todo")
         branch = d.get('branch', f'feat/{item_id}')
         # Delete remote branch (releases lock)
-        subprocess.run(['git','push',REPO,'--delete',branch.replace('refs/heads/','')],
+        subprocess.run(['git','push','origin','--delete',branch.replace('refs/heads/','')],
                        capture_output=True)
         d['state'] = 'todo'
         d['assigned_to'] = None


### PR DESCRIPTION
## Summary

Fixes #198. One-word change: `REPO` → `'origin'` in coord.md stale watchdog.

## Root cause

`REPO` = `'pnz1990/otherness'` (GitHub slug). Git remote operations require a
remote alias (`origin`), not a slug. The call `git push pnz1990/otherness --delete feat/X`
silently fails on every project.

Effect: crashed sessions leave orphaned `feat/<item-id>` branches that permanently
block item reclaiming (branch exists → item skipped by all future sessions).

## Change

```diff
- subprocess.run(['git','push',REPO,'--delete',branch.replace('refs/heads/','')],
+ subprocess.run(['git','push','origin','--delete',branch.replace('refs/heads/','')],
```

All three `--delete` calls in coord.md now use `'origin'`:
- Queue-gen lock release (line ~291): already correct ✓
- Item branch lock release (line ~336): **this fix** ✓  
- Stale queue-gen recovery (line ~359): already correct ✓

## Design doc
N/A — infrastructure bug fix

🤖 Generated with [Claude Code](https://claude.ai/code)