### PR TITLE
fix(coord): rename duplicate §1c sections — stale watchdog→§1d, claim→§1e (#199)

### DIFF
--- a/.specify/specs/199/spec.md
+++ b/.specify/specs/199/spec.md
@@ -1,0 +1,26 @@
+# Spec: fix duplicate §1c section labels in coord.md (#199)
+
+## Design reference
+- N/A — infrastructure fix with no user-visible behavior change
+
+## Zone 1 — Obligations
+
+**O1** — `coord.md` has no duplicate section-level headings. All `## N<letter>` headings are unique.
+
+Falsifiable: `grep "^## 1c" agents/phases/coord.md` returns exactly one match.
+
+**O2** — The stale watchdog section is renamed `## 1d` and the claim section is renamed `## 1e`.
+
+Falsifiable: `grep "^## 1d\." agents/phases/coord.md` returns one match containing "Stale".
+
+**O3** — standalone.md §PARALLEL SESSION PROTOCOL reference to `§1c` is updated to match the new claim section label.
+
+Falsifiable: `grep "§1c\|§1d\|§1e" agents/standalone.md` shows the reference points to the correct label.
+
+## Zone 2 — Implementer's judgment
+
+- Which becomes 1d/1e: stale watchdog → 1d (it runs before claiming), claim next item → 1e.
+
+## Zone 3 — Scoped out
+
+- Renumbering 1a/1b (not needed — those are unique).

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -297,7 +297,7 @@ fi
 
 ---
 
-## 1c. Stale item watchdog (SM sub-task — run every coord cycle)
+## 1d. Stale item watchdog (SM sub-task — run every coord cycle)
 
 Reset items stuck in `assigned` with no live heartbeat for >2 hours. Delete the stale branch lock.
 
@@ -366,7 +366,7 @@ EOF
 
 ---
 
-## 1c. Claim next item (branch-lock protocol)
+## 1e. Claim next item (branch-lock protocol)
 
 Re-read state from `_state` first — always use canonical IDs from the queue-gen winner.
 

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -573,7 +573,7 @@ Losers wait up to 90s then re-read `_state`. Winner deletes lock after writing q
 
 ### Lock 2: Item claiming (`refs/heads/feat/<item-id>`)
 Before working on an item, push `feat/<item-id>`. Winner owns it.
-Loser picks a different item. See coord.md §1c.
+Loser picks a different item. See coord.md §1e.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #199. Renames two sections that both had label `## 1c` in `coord.md`.

## Change

| Before | After |
|---|---|
| `## 1c. Stale item watchdog` (line 300) | `## 1d. Stale item watchdog` |
| `## 1c. Claim next item` (line 369) | `## 1e. Claim next item` |

Also updates cross-reference in `standalone.md` §PARALLEL SESSION PROTOCOL:
`See coord.md §1c` → `See coord.md §1e`

## Design doc
N/A — infrastructure fix

🤖 Generated with [Claude Code](https://claude.ai/code)