### PR TITLE
fix(tooling): extend lint.sh to cover agents/phases/*.md (#202)

### DIFF
--- a/.specify/specs/202/spec.md
+++ b/.specify/specs/202/spec.md
@@ -1,0 +1,20 @@
+# Spec: fix lint.sh to cover agents/phases/*.md (#202)
+
+## Design reference
+- N/A — tooling fix with no user-visible behavior change
+
+## Zone 1 — Obligations
+
+**O1** — `scripts/lint.sh` checks CRLF and null bytes for all files in `agents/phases/*.md`.
+
+Falsifiable: `bash scripts/lint.sh` would catch a CRLF-contaminated phase file.
+
+**O2** — The existing check loop is extended in-place; no other lint behavior changes.
+
+Falsifiable: `bash scripts/lint.sh` still passes with no spurious errors on the current clean files.
+
+## Zone 2 — Implementer's judgment
+- One glob added to the for loop: `"$AGENTS_DIR/phases"/*.md`
+
+## Zone 3 — Scoped out
+- Adding structural checks for phase file content (headers, etc.) — only CRLF/null coverage

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,7 +10,7 @@ echo "=== otherness lint ==="
 
 ERRORS=0
 
-for file in "$AGENTS_DIR"/*.md "$AGENTS_DIR/skills"/*.md; do
+for file in "$AGENTS_DIR"/*.md "$AGENTS_DIR/skills"/*.md "$AGENTS_DIR/phases"/*.md; do
   [ -f "$file" ] || continue
   filename=$(basename "$file")
 


### PR DESCRIPTION
## Summary

Fixes #202. Adds `agents/phases/*.md` to the lint.sh file loop.

## Change

```diff
- for file in "$AGENTS_DIR"/*.md "$AGENTS_DIR/skills"/*.md; do
+ for file in "$AGENTS_DIR"/*.md "$AGENTS_DIR/skills"/*.md "$AGENTS_DIR/phases"/*.md; do
```

Phase files (coord.md, eng.md, qa.md, sm.md, pm.md) are CRITICAL tier.
CRLF or null bytes in them would now be detected before merge.

## Design doc
N/A — tooling fix

🤖 Generated with [Claude Code](https://claude.ai/code)