### PR TITLE
fix(eng): load difficulty-ledger.md in §2b before speccing (#204)

### DIFF
--- a/.specify/specs/204/spec.md
+++ b/.specify/specs/204/spec.md
@@ -1,0 +1,21 @@
+# Spec: wire difficulty-ledger.md into eng.md (#204)
+
+## Design reference
+- N/A — agent instruction update with no user-visible behavior change
+
+## Zone 1 — Obligations
+
+**O1** — `eng.md §2b` contains a `Load skill: difficulty-ledger.md` instruction before the spec-writing step.
+
+Falsifiable: `grep "difficulty-ledger" agents/phases/eng.md` returns at least one match.
+
+**O2** — The load instruction appears before the spec quality gate (Zone 1 obligations check), not after.
+
+Falsifiable: the load instruction appears before the line "Spec quality gate".
+
+## Zone 2 — Implementer's judgment
+- Exact placement: after loading declaring-designs.md, before writing the spec.
+- Instruction text: one line, same pattern as other skill loads.
+
+## Zone 3 — Scoped out
+- Changing when or how the difficulty ledger is written (that is SM phase work)

--- a/agents/phases/eng.md
+++ b/agents/phases/eng.md
@@ -47,6 +47,7 @@ fi
 ## 2b. SPEC-FIRST: find or create the design doc, then write the spec
 
 Load skill: `~/.otherness/agents/skills/declaring-designs.md` before writing the spec.
+Load skill: `~/.otherness/agents/skills/difficulty-ledger.md` — check if this is a known hard case before speccing.
 
 **Step 0 — Identify the design doc for this feature area (MANDATORY).**
 


### PR DESCRIPTION
## Summary

Fixes #204. Adds `Load skill: difficulty-ledger.md` to `eng.md §2b`.

## Change

The difficulty ledger records hard cases (>3 QA cycles, escalations, recurring bugs).
`skills/README.md` says it should be consulted in Phase 2 before writing specs.
`eng.md` had no load directive for it — it was written but never read.

Added alongside existing `declaring-designs.md` load in §2b.

## Design doc
N/A — agent instruction fix

🤖 Generated with [Claude Code](https://claude.ai/code)