### PR TITLE
fix(commands): D4 command surface alignment — status/setup/upgrade (#216 #217 #218)

### DIFF
--- a/.opencode/command/otherness.setup.md
+++ b/.opencode/command/otherness.setup.md
@@ -106,17 +106,6 @@ else
 fi
 ```
 
-## Step 4b — Migrate .maqa/ → .otherness/ (upgrade from older otherness versions)
-
-```bash
-if [ -d ".maqa" ] && [ ! -d ".otherness" ]; then
-  mv .maqa .otherness
-  echo "Migrated .maqa/ → .otherness/"
-elif [ -d ".maqa" ] && [ -d ".otherness" ]; then
-  echo "Both .maqa/ and .otherness/ exist — .otherness/ takes precedence. Remove .maqa/ when confirmed."
-fi
-```
-
 ## Step 5 — Ensure .otherness/state.json exists
 
 ```bash
@@ -192,8 +181,45 @@ else
 fi
 ```
 
+## Step 7 — Initialize D4 artifacts (vision and roadmap stubs)
+
+The autonomous team reads `docs/aide/vision.md` and `docs/aide/roadmap.md` at every
+startup. Create stubs now if they don't exist so the project is D4-ready from the start.
+
+```bash
+mkdir -p docs/aide
+
+if [ ! -f docs/aide/vision.md ]; then
+  cat > docs/aide/vision.md << 'STUB'
+# Vision
+
+> Fill this in before running /otherness.run.
+> What is this project? What problem does it solve? Who is it for?
+> Write 2–4 sentences. This is the north star for everything that gets built.
+STUB
+  echo "Created docs/aide/vision.md (stub — edit before running /otherness.run)"
+else
+  echo "docs/aide/vision.md already exists — skipping."
+fi
+
+if [ ! -f docs/aide/roadmap.md ]; then
+  cat > docs/aide/roadmap.md << 'STUB'
+# Roadmap
+
+## Stage 1: Foundation
+> Describe your first delivery milestone here.
+> What should be working at the end of Stage 1?
+STUB
+  echo "Created docs/aide/roadmap.md (stub — edit before running /otherness.run)"
+else
+  echo "docs/aide/roadmap.md already exists — skipping."
+fi
+```
+
 ## Done
 
 Edit `otherness-config.yaml` to set your `BUILD_COMMAND`, `TEST_COMMAND`, `LINT_COMMAND`, and other project-specific values. If your project has a UI, add `project.job_family: FEE`; for platform/infrastructure projects use `SysDE`; backend-only projects can omit the field (defaults to `SDE`).
+
+**Before running `/otherness.run`**: edit `docs/aide/vision.md` to describe your project. This is the most important thing — the autonomous team reads it on every startup.
 
 Then run `/otherness.run` to start the autonomous team.

--- a/.opencode/command/otherness.status.md
+++ b/.opencode/command/otherness.status.md
@@ -17,7 +17,9 @@ Skip if `FLEET_MODE=true`.
 
 ```bash
 if [ "$FLEET_MODE" != "true" ]; then
-
+# Always read from _state branch first — local file may be stale or empty
+git fetch origin _state --quiet 2>/dev/null || true
+git show origin/_state:.otherness/state.json > .otherness/state.json 2>/dev/null || true
 python3 - << 'EOF'
 import json, datetime, os
 

--- a/.opencode/command/otherness.upgrade.md
+++ b/.opencode/command/otherness.upgrade.md
@@ -32,9 +32,12 @@ fi
 ## Step 2 — Available releases (changelog preview)
 
 ```bash
+OTHERNESS_REPO=$(git -C ~/.otherness remote get-url origin 2>/dev/null \
+  | sed 's|.*github.com[:/]||;s|\.git$||')
+
 echo ""
-echo "=== Available releases ==="
-gh release list --repo pnz1990/otherness --limit 10 \
+echo "=== Available releases (from $OTHERNESS_REPO) ==="
+gh release list --repo "$OTHERNESS_REPO" --limit 10 \
   --json tagName,name,publishedAt \
   --jq '.[] | "\(.tagName)  \(.name)  (\(.publishedAt[:10]))"' 2>/dev/null \
   || echo "(no releases found — repo may be unpinned-only)"
@@ -51,7 +54,9 @@ If the operator asks about a specific version:
 
 ```bash
 # Replace TAG with the version of interest
-gh release view TAG --repo pnz1990/otherness 2>/dev/null
+OTHERNESS_REPO=$(git -C ~/.otherness remote get-url origin 2>/dev/null \
+  | sed 's|.*github.com[:/]||;s|\.git$||')
+gh release view TAG --repo "$OTHERNESS_REPO" 2>/dev/null
 ```
 
 ## Step 4 — Pin to a version

--- a/.specify/specs/216-218/spec.md
+++ b/.specify/specs/216-218/spec.md
@@ -1,0 +1,28 @@
+# Spec: command surface fixes #216 #217 #218
+
+## Design reference
+- **Design doc**: `docs/design/06-command-surface.md`
+- **Implements**: UPDATE verdicts for status.md, setup.md, upgrade.md (🔲 → ✅)
+
+## Zone 1 — Obligations
+
+**O1** — `otherness.status.md` fetches from `origin/_state` before reading state.json.
+Falsifiable: `grep "fetch origin _state" .opencode/command/otherness.status.md` → match.
+
+**O2** — `otherness.setup.md` Step 4b (`.maqa/` migration) is removed.
+Falsifiable: `grep "\.maqa" .opencode/command/otherness.setup.md` → no match.
+
+**O3** — `otherness.setup.md` creates `docs/aide/vision.md` and `docs/aide/roadmap.md` stubs if absent.
+Falsifiable: `grep "docs/aide/vision.md" .opencode/command/otherness.setup.md` → match.
+
+**O4** — `otherness.upgrade.md` derives the otherness repo URL from git remote, not hardcoded slug.
+Falsifiable: `grep "pnz1990/otherness" .opencode/command/otherness.upgrade.md` → no match
+(except in comments/examples that are clearly illustrative).
+
+## Zone 2 — Implementer's judgment
+- D4 stubs in setup.md should be minimal — one or two sentences each, clearly marked for the human to fill in.
+- upgrade.md hardcode appears in Step 2 and Step 3 — both must be updated.
+
+## Zone 3 — Scoped out
+- Changing the structure of setup.md beyond the two specific issues
+- Changing the upgrade.md UI/UX

--- a/docs/design/06-command-surface.md
+++ b/docs/design/06-command-surface.md
@@ -51,22 +51,15 @@ operation. They should be documented as internal/advanced.
 
 ## Present (✅)
 
-- ✅ Command surface audit — all 10 commands measured against taxonomy; verdicts documented in §Audit findings (this PR, 2026-04-17)
-- ✅ Deprecate `otherness.cross-agent-monitor.md` — command deleted; validate.sh updated (PR #215, 2026-04-17)
+- ✅ Command surface audit — all 10 commands measured against taxonomy; verdicts documented in §Audit findings (PR #220, 2026-04-17)
+- ✅ Deprecate `otherness.cross-agent-monitor.md` — command deleted; validate.sh updated (PR #220, 2026-04-17)
+- ✅ Update `otherness.status.md` — reads _state branch before local file (this PR, 2026-04-17)
+- ✅ Update `otherness.setup.md` — removed stale .maqa migration; added D4 artifact stubs (this PR, 2026-04-17)
+- ✅ Update `otherness.upgrade.md` — derives otherness repo from git remote; no hardcoded slug (this PR, 2026-04-17)
 
 ## Future (🔲)
 
-- 🔲 Command surface audit — each existing command measured against this design doc's
-  taxonomy and criteria; findings documented with KEEP / UPDATE / DEPRECATE verdict
-- 🔲 Update `otherness.status.md` — description and behavior need D4 alignment
-  (currently reads from local state.json only; _state branch is the source of truth)
-- 🔲 Update `otherness.setup.md` — Step 4b `.maqa/` migration is stale infrastructure
-  noise; also missing D4 artifact initialization (docs/aide/ stubs)
-- 🔲 Update `otherness.upgrade.md` — hardcodes `pnz1990/otherness` as the releases
-  source; should read from otherness-config.yaml or derive from ~/.otherness remote
-- 🔲 Deprecate `otherness.cross-agent-monitor.md` — functionality fully covered by
-  `otherness.status --fleet`; running as a separate command is redundant
-- 🔲 Update README command table — reflect canonical type taxonomy, remove
+- 🔲 Update README command table — reflect canonical type taxonomy (PRIMARY / SETUP / INTERNAL),
   cross-agent-monitor from primary command list, add vibe-vision as the first entry
 - 🔲 `otherness.setup.md` — add D4 artifact initialization: create docs/aide/vision.md
   stub, docs/aide/roadmap.md stub during setup so the project starts in D4 mode


### PR DESCRIPTION
## Summary

Fixes #216 #217 #218. Three command alignment fixes from the `06-command-surface.md` audit.

## Changes

**otherness.status.md** (#216)
Reads from `origin/_state` branch before local `.otherness/state.json`. Local file can be stale or empty (0 bytes observed this session). _state branch is the authoritative source.

**otherness.setup.md** (#217)
- Removed Step 4b: `.maqa/` → `.otherness/` migration. Dead code — no project has `.maqa/` today.
- Added Step 7: creates `docs/aide/vision.md` and `docs/aide/roadmap.md` stubs if absent. A freshly setup project is now D4-ready from the start.

**otherness.upgrade.md** (#218)
Derives otherness repo URL from `git -C ~/.otherness remote get-url origin` instead of hardcoding `pnz1990/otherness`. Applies to Step 2 (release list) and Step 3 (release view). Users who fork otherness now see releases from their own fork.

## Design doc
`docs/design/06-command-surface.md` — 3 more items moved from Future to Present.

🤖 Generated with [Claude Code](https://claude.ai/code)