### PR TITLE
feat(agents): add ## MODE block to all agent files — Layer 0 D4 enforcement (#222)

### DIFF
--- a/.specify/specs/222/spec.md
+++ b/.specify/specs/222/spec.md
@@ -1,0 +1,39 @@
+# Spec: add ## MODE block to every agent file (#222)
+
+## Design reference
+- **Design doc**: `docs/design/07-d4-enforcement.md`
+- **Section**: Layer 0 — Agent MODE DECLARATION
+- **Implements**: 🔲 Layer 0: add ## MODE block to every agent file (🔲→✅)
+
+## Zone 1 — Obligations
+
+**O1** — Every agent file in `agents/` has a `## MODE` block as its first section
+after the frontmatter.
+
+Falsifiable: `grep -L "^## MODE" agents/*.md agents/phases/*.md` → empty (all files have it).
+
+**O2** — MODE assignments are correct per design doc 07:
+- `standalone.md`, `bounded-standalone.md` → `IMPLEMENT`
+- `vibe-vision.md` → `VISION`
+- All others → `READ-ONLY`
+
+Falsifiable: grep confirms each file's MODE matches its correct assignment.
+
+**O3** — Each MODE block contains the redirect message naming the correct command.
+
+Falsifiable: each MODE block contains `[🚫 D4 GATE]` text.
+
+**O4** — `validate.sh` check 6 verifies every agent file has a MODE block.
+
+Falsifiable: `bash scripts/validate.sh` passes; deliberately removing a MODE block
+causes it to fail.
+
+## Zone 2 — Implementer's judgment
+- MODE block goes after frontmatter `---`, before SELF-UPDATE section.
+- Redirect messages are concise — 3–4 lines max.
+- validate.sh check uses grep pattern `^## MODE:` on agents/*.md and phases/*.md.
+
+## Zone 3 — Scoped out
+- guard.sh integration (Layer 2) — that is #223
+- Enforcing the MODE at bash-execution level — that requires guard.sh
+- Modifying skills/*.md files — skills are not agents

--- a/agents/bounded-standalone.md
+++ b/agents/bounded-standalone.md
@@ -4,6 +4,20 @@ description: "Bounded standalone agent. Scope-constrained version of standalone.
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
+## MODE: IMPLEMENT
+
+This agent may write to the CODE zone only.
+CODE zone: all files outside `docs/`, `docs/aide/`, and `docs/design/`.
+
+If a task requires writing to `docs/aide/` or `docs/design/`: stop and redirect.
+
+```
+[🚫 D4 GATE] Blocked. docs/ writes require /otherness.vibe-vision.
+This session (/otherness.run) cannot modify vision or design docs.
+Shape the vision first, then the team will implement.
+```
+
+
 > **These instructions live at `~/.otherness/agents/` and are auto-updated on startup.**
 
 > **Working directory**: Run from the **main repo directory**.

--- a/agents/cross-agent-monitor.md
+++ b/agents/cross-agent-monitor.md
@@ -4,6 +4,20 @@ description: "Cross-project health monitor. Checks all otherness-managed project
 tools: Bash, Read
 ---
 
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
+
 > **Self-update first.**
 ```bash
 git -C ~/.otherness pull --quiet 2>/dev/null || true

--- a/agents/onboard.md
+++ b/agents/onboard.md
@@ -4,6 +4,20 @@ description: "One-shot onboarding agent. Reads an existing codebase and generate
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
+
 > **These instructions live at `~/.otherness/agents/` and are auto-updated from GitHub on every startup.**
 > Never edit them locally — push changes to your otherness fork instead.
 

--- a/agents/otherness.arch-audit.md
+++ b/agents/otherness.arch-audit.md
@@ -4,6 +4,20 @@ description: "Thorough architectural audit agent. Checks documentation against s
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
+
 You are the ARCH-AUDIT AGENT. Your job is to find what is wrong, stale, or improvable in the
 architecture — not to fix it. You produce issues and docs corrections. Code changes are
 downstream work that the issues authorize.

--- a/agents/otherness.learn.md
+++ b/agents/otherness.learn.md
@@ -2,6 +2,20 @@
 description: "Learn from open-source projects and agent systems in the wild. Extracts reusable patterns from codebases, AGENTS.md files, workflow designs, and agent loop implementations. Updates ~/.otherness/agents/skills/ with distilled learnings. Safe to run periodically."
 ---
 
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
+
 You are the otherness learning agent. You study external projects to find patterns worth
 internalizing into the otherness process. You extract, evaluate, distill, and commit.
 

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -1,3 +1,17 @@
+
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
 # PHASE 1 — [🎯 COORD] HEARTBEAT + ASSIGN
 
 **Role identity**: You are an engineering coordinator. Your goal: claim exactly the right next

--- a/agents/phases/eng.md
+++ b/agents/phases/eng.md
@@ -1,3 +1,17 @@
+
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
 # PHASE 2 — [🔨 ENG] SPEC + IMPLEMENT
 
 **Role identity** — read `job_family` from `otherness-config.yaml`:

--- a/agents/phases/pm.md
+++ b/agents/phases/pm.md
@@ -1,3 +1,17 @@
+
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
 # PHASE 5 — [📋 PM] PRODUCT REVIEW
 
 **Role identity** (load skill: `~/.otherness/agents/skills/role-based-agent-identity.md` §PM):

--- a/agents/phases/qa.md
+++ b/agents/phases/qa.md
@@ -1,3 +1,17 @@
+
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
 # PHASE 3 — [🔍 QA] ADVERSARIAL REVIEW
 
 **Role identity** — use same `JOB_FAMILY` from Phase 2. Adopt the matching QA backstory from

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -1,3 +1,17 @@
+
+## MODE: READ-ONLY
+
+This agent reads files and produces output. It does not write, edit, create,
+or delete any file in any zone.
+
+If asked to implement, fix, or change code or docs: stop and redirect.
+
+```
+[🚫 D4 GATE] This session is READ-ONLY.
+To implement changes:        /otherness.run
+To update vision or design:  /otherness.vibe-vision
+```
+
 # PHASE 4 — [🔄 SDM] SDLC REVIEW
 
 **Role identity** (load skill: `~/.otherness/agents/skills/triage-discipline.md`):

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -5,6 +5,20 @@ tools: Bash, Read, Write, Edit, Glob, Grep
 agent_version: ""
 ---
 
+## MODE: IMPLEMENT
+
+This agent may write to the CODE zone only.
+CODE zone: all files outside `docs/`, `docs/aide/`, and `docs/design/`.
+
+If a task requires writing to `docs/aide/` or `docs/design/`: stop and redirect.
+
+```
+[🚫 D4 GATE] Blocked. docs/ writes require /otherness.vibe-vision.
+This session (/otherness.run) cannot modify vision or design docs.
+Shape the vision first, then the team will implement.
+```
+
+
 > **These instructions live at `~/.otherness/agents/` and are auto-updated on every startup.**
 > Never edit locally — push changes to your otherness fork.
 

--- a/agents/vibe-vision.md
+++ b/agents/vibe-vision.md
@@ -4,6 +4,24 @@ description: "Conversational vision authoring agent. Runs a dialogue session wit
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
+## MODE: VISION
+
+This agent may write to the DOCS zone only.
+DOCS zone: `docs/aide/`, `docs/design/`, `docs/*.md`.
+
+This agent does NOT write specs, code, scripts, or any file outside `docs/`.
+This agent stops after D4 artifacts are on main. It does not claim issues,
+open feat/* branches, write specs, or merge implementation PRs.
+
+If asked to implement: stop and redirect.
+
+```
+[🚫 D4 GATE] Blocked. Code changes require /otherness.run.
+This session (/otherness.vibe-vision) writes vision artifacts only.
+Your design doc is ready. The autonomous team will implement it.
+```
+
+
 > **Working directory**: Run from the **project's main repo directory**.
 
 You are the VIBE-VISION AGENT. You operate at the vision layer only.

--- a/docs/design/07-d4-enforcement.md
+++ b/docs/design/07-d4-enforcement.md
@@ -134,12 +134,10 @@ The message names the correct command. The human knows exactly what to do.
 
 ## Present (✅)
 
-*(Not yet implemented — this is the design doc for a new capability.)*
+- ✅ Layer 0: `## MODE` block added to all 12 agent files; validate.sh check 6 enforces it (PR #222, 2026-04-17)
 
 ## Future (🔲)
 
-- 🔲 Layer 0: add `## MODE` block to every agent file — declare READ-ONLY, IMPLEMENT,
-  or VISION; agent refuses out-of-zone writes before acting
 - 🔲 Layer 1: add `## D4 ENFORCEMENT` section to `AGENTS.md` template and
   `otherness-config-template.yaml` — project-level zone declaration
 - 🔲 Layer 2: `scripts/guard.sh` — pre-flight zone check script, callable from any

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -184,5 +184,19 @@ else
   [ $MISSING_REF -eq 0 ] && echo "  OK: all spec files have ## Design reference" || exit 1
 fi
 
+# 6. Check every agent file has a ## MODE block
+echo "[6/6] Checking agent files for ## MODE block..."
+MISSING_MODE=0
+for agent_file in "$AGENTS_DIR"/*.md "$AGENTS_DIR/phases"/*.md; do
+  [ -f "$agent_file" ] || continue
+  fname=$(basename "$agent_file")
+  [ "$fname" = "gh-features.md" ] && continue  # reference doc, not an agent
+  if ! grep -q "^## MODE:" "$agent_file" 2>/dev/null; then
+    echo "  ERROR: agent file missing ## MODE block: $agent_file"
+    MISSING_MODE=1
+  fi
+done
+[ $MISSING_MODE -eq 0 ] && echo "  OK: all agent files have ## MODE block" || exit 1
+
 echo ""
 echo "=== validate: PASSED ==="


### PR DESCRIPTION
## Summary

Implements `docs/design/07-d4-enforcement.md` Layer 0 — the innermost D4 enforcement layer.

## What this adds

Every agent file now begins with a `## MODE` block declaring exactly what zone it may write to. The agent reads this before any other instruction.

| Mode | Files | Zone |
|---|---|---|
| `IMPLEMENT` | standalone.md, bounded-standalone.md | CODE only |
| `VISION` | vibe-vision.md | DOCS only |
| `READ-ONLY` | all 10 others | nothing |

Each block contains a `[🚫 D4 GATE]` redirect message naming the correct command.

## validate.sh check [6/6]

New check: every agent file (excluding gh-features.md reference doc) must have a `## MODE:` line. Build fails if missing. Catches regressions where a new agent file is added without a MODE declaration.

## Design doc
`docs/design/07-d4-enforcement.md` — Layer 0 marked ✅ Present.

[NEEDS HUMAN: critical-tier-change] — touches standalone.md, bounded-standalone.md, and all phases/*.md

🤖 Generated with [Claude Code](https://claude.ai/code)