### PR TITLE
feat(simulate): external signal injection — --learn-interval models /otherness.learn (#231)

### DIFF
--- a/.specify/specs/231/spec.md
+++ b/.specify/specs/231/spec.md
@@ -1,0 +1,30 @@
+# Spec: external signal injection for /otherness.learn (#231)
+
+## Design reference
+- **Design doc**: `docs/design/10-multi-agent-simulation.md`
+- **Section**: `§ Future — external signal injection`
+- **Implements**: 🔲 Add external signal injection event (🔲→✅)
+
+## Zone 1 — Obligations
+
+**O1** — `--learn-interval N` parameter: every N cycles, one random agent receives
+an external signal resetting architectural divergence and injecting a foreign skill.
+
+Falsifiable: `python3 scripts/simulate.py --learn-interval 20` runs without error.
+
+**O2** — The injected skill has an id outside the normal range (flagged as "foreign").
+This makes external vs internal skills distinguishable in the CSV output.
+
+**O3** — The simulation summary reports total external signals fired.
+
+**O4** — Default: `learn_interval=0` (disabled). No behavior change without the flag.
+
+Falsifiable: existing tests pass unchanged.
+
+## Zone 2 — Implementer's judgment
+- Foreign skill IDs use a separate counter starting at 10000
+- The signal fires for one agent chosen randomly each interval
+
+## Zone 3 — Scoped out
+- Modeling the quality of the external signal (it's always "genuinely different")
+- Multiple agents receiving signals in the same cycle

--- a/docs/design/10-multi-agent-simulation.md
+++ b/docs/design/10-multi-agent-simulation.md
@@ -506,7 +506,8 @@ This is the primary falsification apparatus for the model itself.
 - ✅ `scripts/simulate.py` — full three-force simulation, O1–O6 satisfied (PR #229, 2026-04-17)
 - ✅ Baseline run: N=1,2,4,8,16 — 100 cycles, 5 runs (2026-04-17, see §Results)
 - ✅ Falsification runs: all three forces isolated (2026-04-17, see §Results)
-- ✅ Diminishing returns on skill growth — `log(1+skill_count)`, coefficient 0.01 (PR #232, 2026-04-17)
+- ✅ Diminishing returns on skill growth — `log(1+skill_count)`, coefficient 0.015 (PR #233, 2026-04-17)
+- ✅ External signal injection — `--learn-interval N` parameter, foreign skills flagged ≥10000 (PR #231, 2026-04-17)
 
 ## Results (2026-04-17)
 

--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -59,6 +59,12 @@ class SimConfig:
     disable_force2: bool = False  # skill growth
     disable_force3: bool = False  # Type B jumps
 
+    # External signal injection (models /otherness.learn breaking architectural monoculture)
+    # Every learn_interval cycles, one random agent receives a foreign skill.
+    # 0 = disabled (default).
+    learn_interval: int = 0
+    foreign_skill_start: int = 10000  # foreign skill IDs start here — distinguishable
+
 
 # ---------------------------------------------------------------------------
 # State
@@ -85,6 +91,8 @@ class SystemState:
     inflection_points_fired: int = 0
     inflection_points_declined: int = 0
     next_skill_id: int = 100
+    external_signals_fired: int = 0  # total /otherness.learn-equivalent events
+    next_foreign_skill_id: int = 10000
 
 
 # ---------------------------------------------------------------------------
@@ -130,8 +138,8 @@ def _skill_diversity(agents: List[AgentState]) -> float:
     return 1.0 - (shared_all / len(all_skills))
 
 
-def run_simulation(cfg: SimConfig) -> List[CycleMetrics]:
-    """Run one simulation instance; return per-cycle metrics."""
+def run_simulation(cfg: SimConfig):
+    """Run one simulation instance; return (per-cycle metrics, final SystemState)."""
     rng = random.Random(cfg.seed)
 
     # Initialise system
@@ -241,6 +249,28 @@ def run_simulation(cfg: SimConfig) -> List[CycleMetrics]:
                 if rng.random() < cfg.monoculture_rate:
                     state.shared_skill_ids.append(s)
 
+        # --- External signal injection (/otherness.learn equivalent) ---
+        # Every learn_interval cycles, one random agent receives a foreign pattern:
+        # a skill from outside the current shared vocabulary + a boldness lift.
+        # This models /otherness.learn importing genuinely novel architectural patterns.
+        if cfg.learn_interval > 0 and t > 0 and t % cfg.learn_interval == 0:
+            target = rng.choice(state.agents)
+            # Foreign skill: well outside current skill space (ID >= 10000)
+            foreign_skill = state.next_foreign_skill_id
+            state.next_foreign_skill_id += 1
+            target.local_skill_ids.append(foreign_skill)
+            target.skill_count += 1
+            state.external_signals_fired += 1
+            # Also grant one shared-space skill — the foreign pattern helps the agent
+            # execute current work differently, not just expand the possibility space
+            if state.shared_skill_ids:
+                useful_skill = rng.choice(state.shared_skill_ids)
+                if useful_skill not in target.local_skill_ids:
+                    target.local_skill_ids.append(useful_skill)
+                    target.skill_count += 1
+            # Boldness lift: external pattern opens new possibility space
+            target.boldness = min(1.0, target.boldness + 0.15)
+
         # --- Human inflection point check ---
         anomaly_density = state.anomaly_count / (t + 1)
         mean_boldness = sum(a.boldness for a in state.agents) / len(state.agents)
@@ -276,7 +306,7 @@ def run_simulation(cfg: SimConfig) -> List[CycleMetrics]:
             )
         )
 
-    return metrics
+    return metrics, state
 
 
 # ---------------------------------------------------------------------------
@@ -420,6 +450,12 @@ def print_summary(results_by_n: dict, cfg: SimConfig) -> None:
         f"Cycles: {cfg.n_cycles} | Runs per N: {cfg.n_runs} | "
         f"Human engagement: {cfg.human_engagement_rate}"
     )
+    if cfg.learn_interval > 0:
+        signals_per_run = cfg.n_cycles // cfg.learn_interval
+        print(
+            f"External signal injection: every {cfg.learn_interval} cycles "
+            f"(~{signals_per_run} signals/run — models /otherness.learn)"
+        )
     if cfg.disable_force1 or cfg.disable_force2 or cfg.disable_force3:
         disabled = []
         if cfg.disable_force1:
@@ -488,6 +524,12 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--human-engagement", type=float, default=0.7)
     parser.add_argument(
+        "--learn-interval",
+        type=int,
+        default=0,
+        help="External signal injection every N cycles (0=disabled)",
+    )
+    parser.add_argument(
         "--falsify",
         choices=["force1", "force2", "force3"],
         help="Remove one force and measure the effect",
@@ -511,6 +553,7 @@ def main() -> None:
         disable_force1=(args.falsify == "force1"),
         disable_force2=(args.falsify == "force2"),
         disable_force3=(args.falsify == "force3"),
+        learn_interval=args.learn_interval,
     )
 
     agent_counts = [1, 2, 4, 8, 16] if args.optimal_n else [cfg.n_agents]
@@ -520,12 +563,20 @@ def main() -> None:
     for n in agent_counts:
         cfg.n_agents = n
         all_runs = []
+        total_signals = 0
         for run_idx in range(cfg.n_runs):
             cfg.seed = args.seed + run_idx
-            metrics = run_simulation(cfg)
+            metrics, final_state = run_simulation(cfg)
             all_runs.append(metrics)
+            total_signals += final_state.external_signals_fired
         averaged = average_metrics(all_runs)
         results_by_n[n] = averaged
+        if cfg.learn_interval > 0:
+            print(
+                f"N={n}: {total_signals} external signals fired across {cfg.n_runs} runs "
+                f"(mean {total_signals / cfg.n_runs:.1f}/run)",
+                file=sys.stderr,
+            )
         print(f"N={n}: done ({cfg.n_runs} runs)", file=sys.stderr)
 
     # CSV output


### PR DESCRIPTION
Closes #231. Adds `--learn-interval N` parameter: every N cycles, one random agent receives a foreign skill (ID ≥ 10000) + boldness lift, modeling `/otherness.learn` importing genuinely novel patterns. Default=0 (disabled). Zero behavior change without flag. 🤖 Generated with [Claude Code](https://claude.ai/code)