### PR TITLE
feat(coord): D4 classification at issue intake

### DIFF
--- a/.specify/specs/207/spec.md
+++ b/.specify/specs/207/spec.md
@@ -1,0 +1,88 @@
+# Spec: D4 Classification at Issue Intake
+
+> Item: 207 | Created: 2026-04-18 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/01-declarative-design-driven-development.md`
+- **Section**: `## Future`
+- **Implements**: D4 enforced at issue intake — ENG classifies issue title/body before speccing (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — ENG classifies the claimed issue before speccing.**
+When ENG claims an issue in coord.md §1e (after the branch push succeeds), before
+reading or writing any spec, it reads the issue title and body from GitHub and
+classifies the instruction as IMPERATIVE, DECLARATIVE, or INFRA.
+
+Behavior that violates this: ENG reads the issue body and immediately starts writing
+spec.md without posting a classification.
+
+**O2 — IMPERATIVE issues trigger a D4 translation comment.**
+If the issue title/body is classified as IMPERATIVE (contains imperative language:
+add, fix, update, change, make, create, remove, implement, enable, enforce, migrate,
+bump), the agent posts a `[📋 D4 TRANSLATION]` block on the issue (same format as
+session-start D4: Heard / Intent / D4 layer / Artifact).
+
+Behavior that violates this: an imperative issue is specced and implemented without
+a translation comment ever appearing on it.
+
+**O3 — A 60-second wait follows the translation comment.**
+After posting the translation, the agent waits 60 seconds for human correction before
+proceeding.
+
+Behavior that violates this: the agent posts the translation and immediately continues
+without pausing.
+
+**O4 — DECLARATIVE and INFRA issues proceed without translation.**
+If the issue was created by a previous queue-gen run referencing a design doc 🔲 item,
+or if it is a pure maintenance task (classified as INFRA), the agent proceeds directly
+to the spec phase without translation.
+
+Behavior that violates this: every single issue — including design-doc-sourced queue
+items — triggers a translation comment, creating noise.
+
+**O5 — Classification uses the issue title as primary signal.**
+The title is the canonical summary of the issue. If the title is declarative (begins
+with "feat(" or "fix(" in conventional-commit format, or references a design doc item),
+it is classified DECLARATIVE even if the body contains imperative language in the
+"What correct looks like" section.
+
+Behavior that violates this: design-doc-sourced issues with "feat(...): ..." titles
+are incorrectly classified as IMPERATIVE and trigger unnecessary translations.
+
+**O6 — The classification logic is an [AI-STEP] in coord.md §1e.**
+The classification check is added to coord.md §1e, between the branch-lock success
+message and the state write, labeled as `[AI-STEP]`. It replaces or extends the
+existing `[AI-STEP]` stub for D4 check in that section.
+
+Behavior that violates this: the check is placed in a different phase file or in a
+separate new file.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Exact heuristic for IMPERATIVE/DECLARATIVE: title starts with `feat(` or `fix(` or
+  `chore(` → DECLARATIVE. Otherwise, presence of imperative verb in title → IMPERATIVE.
+  Body content alone does not override a DECLARATIVE title classification.
+- Whether to create a new GitHub issue from the translation (as the session-start D4
+  does): no — this is issue intake at claim time. The issue already exists. The
+  translation is a comment on the existing issue.
+- Whether the 60s wait can be shortened for obvious design-doc items: the 60s wait is
+  only triggered for IMPERATIVE classifications. DECLARATIVE and INFRA proceed immediately.
+- Placement of the [AI-STEP] in coord.md: after `echo "[COORD] ✅ Claimed $ITEM_ID"`,
+  before the worktree `git worktree add` call, or after it — whichever is cleaner.
+  The check must happen after the branch lock is secured.
+
+---
+
+## Zone 3 — Scoped out
+
+- Retroactively classifying issues already in the queue (only applies to newly claimed items)
+- Classifying comments added after the initial claim (that is the existing §1c stub,
+  a separate mechanism)
+- Refusing to proceed if the translation is not confirmed — the agent always proceeds
+  after 60s regardless of human response
+- Storing the classification result in state.json (not needed — it is ephemeral per-session context)

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -556,14 +556,38 @@ PYEOF
   gh issue comment $ISSUE_NUM --repo $REPO \
     --body "[$MY_SESSION_ID | otherness@${OTHERNESS_VERSION:-unknown}] Starting implementation. Branch: \`$MY_BRANCH\`" 2>/dev/null
 
-  # D4 check — scan recent human comments on the claimed issue for imperative instructions
-  # [AI-STEP] Fetch the last 5 comments on issue $ISSUE_NUM via:
-  #   gh issue view $ISSUE_NUM --repo $REPO --comments --json comments
-  # For each comment NOT starting with a role badge ([🎯 [🔨 [🔍 [🔄 [📋 [sess-):
-  #   Check if it contains imperative language (add, fix, update, change, make, create, remove)
-  #   If yes: post a [📋 D4 TRANSLATION] block on the issue (same format as session-start D4)
-  #   Wait 60s for human correction. Then create a new GitHub issue from the translation.
-  # If no imperative human comments: no-op, proceed to Phase 2.
+  # D4 classification at issue intake — classify the issue title/body before speccing.
+  # [AI-STEP]
+  # Step 1: Read the issue title and body.
+  #   ISSUE_DATA=$(gh issue view $ISSUE_NUM --repo $REPO --json title,body,comments \
+  #     --jq '{title: .title, body: .body, comments: [.comments[-5:][].body]}')
+  #
+  # Step 2: Classify the TITLE.
+  #   - DECLARATIVE: title matches /^(feat|fix|chore|docs|refactor|test|perf|ci|build)\(/ 
+  #     (conventional-commit format), OR title directly references a design doc 🔲 item.
+  #   - INFRA: title is clearly maintenance (bump, fix ci, fix lint, update dep, clean).
+  #   - IMPERATIVE: anything else — imperative verb in title (add, make, update, remove, etc.).
+  #   Title classification overrides body content — a feat(scope): title is DECLARATIVE
+  #   even if the body uses imperative language in examples or "what correct looks like" sections.
+  #
+  # Step 3: If IMPERATIVE (title only — do NOT re-classify DECLARATIVE issues):
+  #   Post a [📋 D4 TRANSLATION] block on the issue:
+  #     gh issue comment $ISSUE_NUM --repo $REPO --body "[📋 D4 TRANSLATION]
+  #   Heard:     \"<issue title verbatim>\"
+  #   Intent:    <one sentence — what this feature area achieves>
+  #   D4 layer:  <vision | roadmap | design doc | spec>
+  #   Artifact:  <exact text of the design doc entry or roadmap item this would create>
+  #   Proceeding in 60s unless you correct the translation."
+  #   Then: sleep 60
+  #
+  # Step 4: Scan the last 5 comments for human instructions not from the agent.
+  #   For each comment NOT starting with a role badge ([🎯 [🔨 [🔍 [🔄 [📋 [sess-):
+  #   If it contains imperative language (add, fix, update, change, make, create, remove):
+  #     Post a [📋 D4 TRANSLATION] block (as above, but for the comment text).
+  #     Wait 60s for human correction. Post the translation as a NEW GitHub issue.
+  #
+  # Step 5: If DECLARATIVE or INFRA (step 2), and no imperative comments (step 4):
+  #   No-op — proceed to Phase 2 immediately.
 
 else
   echo "[COORD] ⚡ $ITEM_ID already claimed — picking another."

--- a/docs/design/01-declarative-design-driven-development.md
+++ b/docs/design/01-declarative-design-driven-development.md
@@ -39,14 +39,9 @@ mark what is present vs future.
 - ✅ CI lint for `## Design reference` presence in spec files — validate.sh check 5 (PR #153, 2026-04-17)
 - ✅ Customer doc requirement checked by QA — MISS finding (follow-up issue) when non-N/A design ref has no customer doc (PR #159, 2026-04-17)
 - ✅ `/otherness.onboard` generates design doc stubs — Step 4b creates 2-4 inferred docs, marked ⚠️ Inferred (PR #163, 2026-04-17)
+- ✅ D4 enforced at issue intake — coord.md §1e classifies issue title/body as IMPERATIVE/DECLARATIVE/INFRA before ENG specs; IMPERATIVE titles trigger translation comment + 60s wait; design-doc-sourced issues (conventional-commit title) proceed directly (PR #207, 2026-04-18)
 
 ## Future (🔲)
-
-- 🔲 D4 enforced at issue intake — when ENG claims an issue, it must classify the issue
-  title/body as IMPERATIVE/DECLARATIVE/INFRA before speccing, same as session-start D4.
-  Currently the coord.md D4 check only catches human comments added after claiming, not
-  the original issue itself. Issues created by external contributors or by older
-  queue-gen without D4 awareness bypass the translation step entirely.
 - 🔲 Issue body must identify design doc Future item — the GitHub issue that sources work
   should reference which `docs/design/` file and 🔲 Future item it implements. Currently
   only spec.md requires `## Design reference`; the issue that precedes the spec does not.


### PR DESCRIPTION
## Summary

Extends coord.md §1e with a D4 classification step at issue intake.

DECLARATIVE issues (feat(/fix(/chore() titles) proceed directly. IMPERATIVE titles trigger D4 translation comment + 60s wait. Comment scan consolidated into same step.

## Design doc
Updated `docs/design/01-declarative-design-driven-development.md`: 🔲 → ✅

## Spec
`.specify/specs/207/spec.md`