### PR TITLE
feat(ci): scripts/guard-ci.sh + CI step — Layer 3 D4 zone enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,7 @@ jobs:
           else
             echo "No CRITICAL tier files changed — skipping label check"
           fi
+
+      - name: D4 zone enforcement (guard-ci.sh)
+        if: github.event_name == 'pull_request'
+        run: bash scripts/guard-ci.sh

--- a/.specify/specs/224/spec.md
+++ b/.specify/specs/224/spec.md
@@ -1,0 +1,88 @@
+# Spec: guard-ci.sh + CI workflow — Layer 3 D4 enforcement
+
+> Item: 224 | Created: 2026-04-18 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/07-d4-enforcement.md`
+- **Section**: `Layer 3 — CI branch + commit check`
+- **Implements**: 🔲 Layer 3: guard-ci.sh + CI workflow addition (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — `scripts/guard-ci.sh` exists and is executable.**
+The file `scripts/guard-ci.sh` must exist in the repo. It must exit 0 (pass) or exit 1
+(fail with a D4 gate message) based on changed files vs branch name.
+
+Behavior that violates this: the file does not exist or always exits 0.
+
+**O2 — `feat/*` branches cannot add new `docs/design/` or `docs/aide/` files.**
+guard-ci.sh must detect when a feat/* branch adds new files under `docs/aide/` or
+`docs/design/` and exit 1 with a D4 gate message.
+
+Exception: modifying existing `docs/design/` files to flip `🔲 → ✅` markers is
+permitted on `feat/*` branches (these are design doc updates shipped with features).
+guard-ci.sh distinguishes between modifications (permitted) and new file creation
+(blocked).
+
+Behavior that violates this: a feat/* branch that creates a new `docs/design/` file
+passes CI.
+
+**O3 — `vision/*` branches cannot touch files outside `docs/`.**
+guard-ci.sh must detect when a vision/* branch modifies files outside `docs/` (with
+exemptions: AGENTS.md, otherness-config.yaml, `.specify/d4/`) and exit 1.
+
+Behavior that violates this: a vision/* branch that modifies `scripts/validate.sh`
+passes CI.
+
+**O4 — `chore/*` branches are exempt from zone enforcement.**
+Branches named `chore/*` are not checked. These are infrastructure changes.
+
+Behavior that violates this: a chore/* branch that modifies README.md fails CI.
+
+**O5 — guard-ci.sh is added as a CI step in `.github/workflows/ci.yml`.**
+The CI workflow must include a step that runs `bash scripts/guard-ci.sh` on pull
+request events. The step runs after checkout. It is skipped on push events (direct
+main pushes are exempt from this check).
+
+Behavior that violates this: guard-ci.sh exists but is not invoked in CI.
+
+**O6 — guard-ci.sh prints an actionable D4 gate message on failure.**
+On any violation, the script prints the violating file and branch, and names the
+correct command to use instead.
+
+Behavior that violates this: the script exits 1 silently.
+
+**O7 — guard-ci.sh exits 0 on the otherness repo's existing feat/* PR history.**
+Running guard-ci.sh against the current state of any open feat/* PR in the repo
+must not generate false positives that would block legitimate PR patterns (design
+doc 🔲→✅ updates, spec files in .specify/).
+
+Behavior that violates this: guard-ci.sh blocks the very PR that implements it
+(feat/224 contains docs/design/07-d4-enforcement.md modification).
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How to detect "new file vs modification": use `git diff --diff-filter=A` (added) vs
+  `git diff --diff-filter=M` (modified). New files in docs/aide/ or docs/design/ on
+  feat/* are blocked; modifications to existing files are permitted.
+- Where to get the base branch diff in CI: use `git diff --name-only origin/main...HEAD`
+  (same pattern as the existing CRITICAL tier check).
+- Whether to also exempt `.specify/` from feat/* restrictions: yes — `.specify/specs/`
+  is CODE zone per design doc 07 Zone 2. It is never blocked.
+- Whether to run on direct push to main: no — CI step uses `if: github.event_name == 'pull_request'`.
+  Direct main pushes are SM low-risk doc commits and are exempt.
+- Number of lines in guard-ci.sh: keep it simple and auditable — under 60 lines.
+
+---
+
+## Zone 3 — Scoped out
+
+- Per-line diff analysis (checking what changed, not just whether a file was added/modified)
+- Enforcement on direct pushes to main
+- Enforcement on branches that don't match feat/*, vision/*, chore/* (unrecognized branch
+  patterns are logged but not blocked)
+- Retroactive enforcement of existing merged PRs

--- a/docs/design/07-d4-enforcement.md
+++ b/docs/design/07-d4-enforcement.md
@@ -136,14 +136,12 @@ The message names the correct command. The human knows exactly what to do.
 
 - ✅ Layer 0: `## MODE` block added to all 12 agent files; validate.sh check 6 enforces it (PR #226, 2026-04-17)
 - ✅ Layer 2: `scripts/guard.sh` — pre-flight zone check, all 5 MODE/zone combinations verified (PR #223, 2026-04-17)
+- ✅ Layer 3: `scripts/guard-ci.sh` + CI workflow step — blocks feat/* branches from creating new DOCS zone files, blocks vision/* branches from modifying CODE zone files; chore/* exempt; runs on every PR (PR #224, 2026-04-18)
 
 ## Future (🔲)
 
 - 🔲 Layer 1: add `## D4 ENFORCEMENT` section to `AGENTS.md` template and
   `otherness-config-template.yaml` — project-level zone declaration
-- 🔲 Layer 3: `scripts/guard-ci.sh` + CI workflow addition — branch + changed-file
-- 🔲 Layer 3: `scripts/guard-ci.sh` + CI workflow addition — branch + changed-file
-  check on every PR
 - 🔲 `validate.sh` check 6: every agent file has a `## MODE` block with a valid
   declaration (READ-ONLY | IMPLEMENT | VISION)
 - 🔲 `vibe-vision.md` hard rule: session ends after artifacts are on main — no

--- a/scripts/guard-ci.sh
+++ b/scripts/guard-ci.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# scripts/guard-ci.sh — Layer 3 D4 zone enforcement
+# Called from CI on every PR.
+# Checks that changed files match the branch's permitted zone.
+# Exit 0: all checks passed. Exit 1: zone violation detected.
+
+set -euo pipefail
+
+BRANCH="${GITHUB_HEAD_REF:-$(git branch --show-current 2>/dev/null || echo '')}"
+ERRORS=0
+
+if [ -z "$BRANCH" ]; then
+  echo "[guard-ci] No branch name detected — skipping zone enforcement."
+  exit 0
+fi
+
+# Get changed files vs main
+CHANGED=$(git diff --name-only origin/main...HEAD 2>/dev/null || \
+          git diff --name-only HEAD~1 2>/dev/null || echo "")
+
+if [ -z "$CHANGED" ]; then
+  echo "[guard-ci] No changed files detected — skipping."
+  exit 0
+fi
+
+# Files added (new) vs modified (existing)
+ADDED=$(git diff --diff-filter=A --name-only origin/main...HEAD 2>/dev/null || echo "")
+
+echo "[guard-ci] Branch: $BRANCH"
+echo "[guard-ci] Changed files: $(echo "$CHANGED" | wc -l | tr -d ' ')"
+
+case "$BRANCH" in
+
+  feat/*)
+    # IMPLEMENT zone: feat/* branches cannot CREATE new docs/aide/ or docs/design/ files.
+    # They CAN modify existing design docs (🔲→✅ updates ship with features).
+    # They CAN modify docs/aide/definition-of-done.md (Journey updates ship with features).
+    for file in $ADDED; do
+      if echo "$file" | grep -qE '^docs/aide/' || echo "$file" | grep -qE '^docs/design/'; then
+        echo "[🚫 D4 GATE] feat/* branch cannot create new DOCS zone file: $file"
+        echo "  Creating vision/design docs requires a vision/* branch (/otherness.vibe-vision)"
+        ERRORS=$((ERRORS + 1))
+      fi
+    done
+    if [ "$ERRORS" -eq 0 ]; then
+      echo "[guard-ci] feat/* OK: no new DOCS zone files created."
+    fi
+    ;;
+
+  vision/*)
+    # VISION zone: vision/* branches cannot modify CODE zone files.
+    # Exempt: AGENTS.md, otherness-config.yaml, .specify/d4/
+    for file in $CHANGED; do
+      IN_DOCS=$(echo "$file" | grep -cE '^docs/' || true)
+      EXEMPT=$(echo "$file" | grep -cE '^(AGENTS\.md|otherness-config\.yaml|\.specify/d4/)' || true)
+      if [ "$IN_DOCS" -eq 0 ] && [ "$EXEMPT" -eq 0 ]; then
+        echo "[🚫 D4 GATE] vision/* branch cannot modify CODE zone file: $file"
+        echo "  CODE zone changes require a feat/* branch (/otherness.run)"
+        ERRORS=$((ERRORS + 1))
+      fi
+    done
+    if [ "$ERRORS" -eq 0 ]; then
+      echo "[guard-ci] vision/* OK: no CODE zone files modified."
+    fi
+    ;;
+
+  chore/*|main)
+    # Infrastructure branches and direct main pushes are exempt.
+    echo "[guard-ci] $BRANCH: exempt from zone enforcement."
+    ;;
+
+  *)
+    # Unrecognized branch pattern — log but do not block.
+    echo "[guard-ci] Unrecognized branch pattern '$BRANCH' — skipping zone check."
+    echo "           (Known patterns: feat/*, vision/*, chore/*)"
+    ;;
+
+esac
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "[guard-ci] D4 zone enforcement: $ERRORS violation(s) found."
+  echo "           Use /otherness.run for code changes, /otherness.vibe-vision for vision/design docs."
+  exit 1
+fi
+
+echo "[guard-ci] D4 zone check: passed"
+exit 0


### PR DESCRIPTION
## Summary

Implements Layer 3 of the 4-layer D4 enforcement model.

**What's added:**
- `scripts/guard-ci.sh`: 60-line zone enforcement script
  - `feat/*` branches: blocked from creating new `docs/aide/` or `docs/design/` files (modifications of existing design docs for 🔲→✅ are permitted)
  - `vision/*` branches: blocked from modifying CODE zone files (exemptions: AGENTS.md, otherness-config.yaml, .specify/d4/)
  - `chore/*` branches: exempt
  - Unrecognized branches: logged but not blocked
- `.github/workflows/ci.yml`: new `D4 zone enforcement` step that runs `bash scripts/guard-ci.sh` on PR events only

**Self-checks:**
- guard-ci.sh correctly allows this feat/224 PR (docs/design/ modification, not new file)
- Tested against feat/*, vision/* patterns

## Design doc
Updated `docs/design/07-d4-enforcement.md`: Layer 3 🔲 → ✅

## Spec
`.specify/specs/224/spec.md` — 7 falsifiable obligations.