### PR TITLE
fix(docs): remove stale Future entries from design doc 06 (command-surface)

### DIFF
--- a/docs/design/06-command-surface.md
+++ b/docs/design/06-command-surface.md
@@ -60,10 +60,7 @@ operation. They should be documented as internal/advanced.
 
 ## Future (🔲)
 
-- 🔲 Update README command table — reflect canonical type taxonomy (PRIMARY / SETUP / INTERNAL),
-  cross-agent-monitor from primary command list, add vibe-vision as the first entry
-- 🔲 `otherness.setup.md` — add D4 artifact initialization: create docs/aide/vision.md
-  stub, docs/aide/roadmap.md stub during setup so the project starts in D4 mode
+*(All planned command surface items have been shipped.)*
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation drift fix. Design doc `06-command-surface.md` had two stale `🔲 Future` items that were already shipped:

1. **Update README command table** — already done by PR #209 (design doc shows ✅ Present AND 🔲 Future for same item)
2. **otherness.setup.md D4 artifact initialization** — already done by the PR that added Step 7 to setup.md (design doc shows ✅ Present AND 🔲 Future for same item)

Both items removed from Future section. No functional changes.

## Why this matters
PM §5f health scan (in review as PR #246) would catch these. This is a proactive fix ahead of that scan going live.

## Spec
N/A — infrastructure change with no user-visible behavior change.