### PR TITLE
feat: Layer 1 D4 ENFORCEMENT — AGENTS.md template + config template

### DIFF
--- a/.specify/specs/262/spec.md
+++ b/.specify/specs/262/spec.md
@@ -1,0 +1,68 @@
+# Spec: Layer 1 D4 ENFORCEMENT section in AGENTS.md template
+
+> Item: 262 | Created: 2026-04-18 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/07-d4-enforcement.md`
+- **Section**: `Layer 1 — AGENTS.md project guard`
+- **Implements**: Layer 1: add `## D4 ENFORCEMENT` section to `AGENTS.md` template (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — `otherness-config-template.yaml` includes a `d4_enforcement` config key.**
+The config template must add a commented `d4_enforcement: true` entry under the `maqa`
+section, documenting that D4 zone enforcement is enabled by default.
+
+Behavior that violates this: config template has no `d4_enforcement` key.
+
+**O2 — `onboarding-new-project.md` generates a `## D4 ENFORCEMENT` section in the target project's AGENTS.md.**
+The new-project onboarding document must include an instruction to write the
+`## D4 ENFORCEMENT` section to the project's AGENTS.md after setup. The section format
+is exactly as specified in design doc 07 Layer 1:
+
+```markdown
+## D4 ENFORCEMENT
+
+This project enforces D4. Agents may only act within their declared mode.
+
+| Zone | Permitted by |
+|---|---|
+| CODE (implementation) | /otherness.run only |
+| DOCS (vision/design) | /otherness.vibe-vision only |
+| Everything else | READ-ONLY |
+
+Any agent that attempts to act outside its mode must stop and print:
+  [🚫 D4 GATE] <zone> writes require <command>. Current session: <mode>.
+```
+
+Behavior that violates this: new-project onboarding does not generate the D4 ENFORCEMENT
+section in the target AGENTS.md.
+
+**O3 — Design doc 07 marks Layer 1 as ✅ Present.**
+`docs/design/07-d4-enforcement.md` must move Layer 1 from 🔲 Future to ✅ Present
+in this PR.
+
+Behavior that violates this: doc 07 still shows Layer 1 as 🔲 after this PR merges.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Where exactly to add in config template: after the `autonomous_mode` key in the `maqa`
+  section, with a comment explaining what it does.
+- Whether to modify the repo's own AGENTS.md: NO — `AGENTS.md` is listed in "Files Agents
+  Must Not Modify". The D4 ENFORCEMENT section is for managed projects, not the otherness
+  repo itself.
+- Whether to modify `otherness.setup.md` or `agents/onboard.md`: add to
+  `onboarding-new-project.md` since that's the new-project pathway documentation.
+  `agents/onboard.md` handles existing projects — add there too if appropriate.
+
+---
+
+## Zone 3 — Scoped out
+
+- Adding `## D4 ENFORCEMENT` to the otherness repo's own `AGENTS.md` (protected file)
+- Retroactively adding the section to existing managed projects
+- Validating that managed projects have the section (that's Layer 2's job via guard.sh)

--- a/docs/design/07-d4-enforcement.md
+++ b/docs/design/07-d4-enforcement.md
@@ -137,13 +137,11 @@ The message names the correct command. The human knows exactly what to do.
 - ✅ Layer 0: `## MODE` block added to all 12 agent files; validate.sh check 6 enforces it (PR #226, 2026-04-17)
 - ✅ Layer 2: `scripts/guard.sh` — pre-flight zone check, all 5 MODE/zone combinations verified (PR #223, 2026-04-17)
 - ✅ Layer 3: `scripts/guard-ci.sh` + CI workflow step — blocks feat/* branches from creating new DOCS zone files, blocks vision/* branches from modifying CODE zone files; chore/* exempt; runs on every PR (PR #224, 2026-04-18)
+- ✅ `validate.sh` check 6: every agent file has a `## MODE` block — already enforced since PR #226 (check was already shipping; duplicate Future entry removed)
+- ✅ Layer 1: `## D4 ENFORCEMENT` section added to `onboarding-new-project.md` AGENTS.md template; `d4_enforcement: true` added to `otherness-config-template.yaml` (PR #262, 2026-04-18)
 
 ## Future (🔲)
 
-- 🔲 Layer 1: add `## D4 ENFORCEMENT` section to `AGENTS.md` template and
-  `otherness-config-template.yaml` — project-level zone declaration
-- 🔲 `validate.sh` check 6: every agent file has a `## MODE` block with a valid
-  declaration (READ-ONLY | IMPLEMENT | VISION)
 - 🔲 `vibe-vision.md` hard rule: session ends after artifacts are on main — no
   implementation, no issue creation, no spec writing
 - 🔲 `otherness.onboard` mode: READ-ONLY for CODE zone, VISION for DOCS zone —

--- a/onboarding-new-project.md
+++ b/onboarding-new-project.md
@@ -127,6 +127,19 @@ All issues must have labels from each of these groups:
 - `AGENTS.md`
 - `.specify/memory/constitution.md`
 - `.specify/memory/sdlc.md`
+
+## D4 ENFORCEMENT
+
+This project enforces D4. Agents may only act within their declared mode.
+
+| Zone | Permitted by |
+|---|---|
+| CODE (implementation) | /otherness.run only |
+| DOCS (vision/design) | /otherness.vibe-vision only |
+| Everything else | READ-ONLY |
+
+Any agent that attempts to act outside its mode must stop and print:
+  [🚫 D4 GATE] <zone> writes require <command>. Current session: <mode>.
 ```
 
 ---

--- a/otherness-config-template.yaml
+++ b/otherness-config-template.yaml
@@ -56,6 +56,13 @@ maqa:
   # Recommended for projects with >1 external contributor or production SLA.
   agent_version: ""     # e.g. "v1.0.0" — leave empty for latest
 
+  # D4 zone enforcement — enforces declarative design-driven development.
+  # When true: guard.sh is called before file writes; guard-ci.sh runs in CI;
+  # feat/* branches cannot create new docs/aide/ or docs/design/ files;
+  # vision/* branches cannot modify code files.
+  # Disable only if your project does not use the D4 hierarchy (legacy projects).
+  d4_enforcement: true
+
 # ── CI gate ───────────────────────────────────────────────────────────────────
 ci:
   provider: github-actions            # github-actions | circleci | gitlab | bitbucket


### PR DESCRIPTION
## Summary

Implements Layer 1 of the 4-layer D4 enforcement model.

**Changes:**
- `onboarding-new-project.md`: AGENTS.md template now includes `## D4 ENFORCEMENT` section with zone table and redirect message format
- `otherness-config-template.yaml`: adds `d4_enforcement: true` under `maqa` with documentation comment

**Documentation drift fix:**
- `docs/design/07-d4-enforcement.md`: Layer 1 🔲 → ✅, validate.sh check 6 stale duplicate removed (was already ✅ since PR #226)

## Design doc
Updated `docs/design/07-d4-enforcement.md`: Layer 1 + validate.sh check 6 🔲 → ✅. Only 2 Future items remain: vibe-vision hard rule, otherness.onboard mode.

## Spec
`.specify/specs/262/spec.md` — 3 falsifiable obligations.