### PR TITLE
feat: vibe-vision.md hard rule — session ends after D4 artifacts land

### DIFF
--- a/.specify/specs/267/spec.md
+++ b/.specify/specs/267/spec.md
@@ -1,0 +1,48 @@
+# Spec: vibe-vision.md hard rule — session termination
+
+> Item: 267 | Created: 2026-04-18 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/07-d4-enforcement.md`
+- **Section**: `## Future`
+- **Implements**: `vibe-vision.md` hard rule: session ends after artifacts are on main (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — HARD RULES section in vibe-vision.md includes an explicit session termination rule.**
+The `## HARD RULES` section must include a rule that explicitly states:
+"Session ends when artifacts land on main. Do not implement, do not open issues,
+do not create branches, do not merge PRs after the vibe-vision session."
+
+Behavior that violates this: the HARD RULES section has no mention of session
+termination after artifacts are on main. The rule must be unambiguous.
+
+**O2 — The rule is in the HARD RULES section, not the MODE block.**
+The MODE block already has a shorter version. The HARD RULES section is where
+human-readable enforcement statements live. The full termination rule belongs there.
+
+Behavior that violates this: a new HARD RULE is added to the MODE block instead of HARD RULES.
+
+**O3 — Design doc 07 marks this item as ✅ Present.**
+
+Behavior that violates this: doc 07 still shows `vibe-vision.md` hard rule as 🔲.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to modify the MODE block: no. Add to HARD RULES only.
+- Whether to add a new STEP for session termination: no. HARD RULES is sufficient.
+- Exact wording: "**Session ends after landing.** Once D4 artifacts are on main,
+  the session is complete. Do not proceed to implementation. Do not open GitHub
+  issues. Do not create feat/* branches. Do not write specs or code. The autonomous
+  execution team picks up from here."
+
+---
+
+## Zone 3 — Scoped out
+
+- Changes to how the session ends mechanically (no new commands)
+- Adding a termination signal to the conversation (the rule is instructional only)

--- a/agents/vibe-vision.md
+++ b/agents/vibe-vision.md
@@ -302,6 +302,10 @@ If the human says "done": end the session.
 
 ## HARD RULES
 
+- **Session ends after landing.** Once D4 artifacts are on main, the session is
+  complete. Do not proceed to implementation. Do not open GitHub issues. Do not
+  create feat/* branches. Do not write specs or code. The autonomous execution
+  team picks up from here.
 - **Never write specs.** Specs are ENG's domain. You write design docs, not implementation specs.
 - **Never write code.** You are a vision agent.
 - **Never open GitHub issues.** Design doc Future items become issues when COORD reads them.

--- a/docs/design/07-d4-enforcement.md
+++ b/docs/design/07-d4-enforcement.md
@@ -139,11 +139,10 @@ The message names the correct command. The human knows exactly what to do.
 - ✅ Layer 3: `scripts/guard-ci.sh` + CI workflow step — blocks feat/* branches from creating new DOCS zone files, blocks vision/* branches from modifying CODE zone files; chore/* exempt; runs on every PR (PR #224, 2026-04-18)
 - ✅ `validate.sh` check 6: every agent file has a `## MODE` block — already enforced since PR #226 (check was already shipping; duplicate Future entry removed)
 - ✅ Layer 1: `## D4 ENFORCEMENT` section added to `onboarding-new-project.md` AGENTS.md template; `d4_enforcement: true` added to `otherness-config-template.yaml` (PR #262, 2026-04-18)
+- ✅ `vibe-vision.md` hard rule: explicit session termination rule added to HARD RULES — session ends after D4 artifacts land on main, no implementation/issues/specs (PR #267, 2026-04-18)
 
 ## Future (🔲)
 
-- 🔲 `vibe-vision.md` hard rule: session ends after artifacts are on main — no
-  implementation, no issue creation, no spec writing
 - 🔲 `otherness.onboard` mode: READ-ONLY for CODE zone, VISION for DOCS zone —
   onboarding generates docs/aide/ stubs only, no code changes
 


### PR DESCRIPTION
## Summary

Adds explicit session termination hard rule to `agents/vibe-vision.md`.

**What changes:**
- `agents/vibe-vision.md ## HARD RULES`: first rule now says: "Session ends after landing. Once D4 artifacts are on main: no implementation, no GitHub issues, no feat/* branches, no specs or code."
- The MODE block already had a brief version; this adds the full enforcement statement where humans reading the HARD RULES section will see it

## Design doc
Updated `docs/design/07-d4-enforcement.md`: vibe-vision hard rule 🔲 → ✅. Only 1 Future item remains in doc 07.

## Spec
`.specify/specs/267/spec.md` — 3 falsifiable obligations.