### PR TITLE
feat: onboard.md mode — MODE: VISION + .otherness/ state bootstrap exception

### DIFF
--- a/.specify/specs/268/spec.md
+++ b/.specify/specs/268/spec.md
@@ -1,0 +1,53 @@
+# Spec: otherness.onboard mode declaration
+
+> Item: 268 | Created: 2026-04-18 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/07-d4-enforcement.md`
+- **Section**: `## Future`
+- **Implements**: `otherness.onboard` mode: READ-ONLY for CODE zone, VISION for DOCS zone (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — `agents/onboard.md` MODE block is updated to reflect actual behavior.**
+The current MODE block says READ-ONLY, but onboard.md writes to `docs/aide/` (DOCS zone)
+and `.otherness/state.json` (CODE zone exception for state bootstrap). The MODE block
+must be updated to accurately describe what onboard.md is permitted to do:
+- Write to DOCS zone (`docs/aide/`, `docs/design/`)
+- Write to `.otherness/` (state bootstrap — explicit exception)
+- NOT write to general CODE zone (no scripts, no agent files, no tests)
+
+Behavior that violates this: MODE block still says READ-ONLY after this PR merges.
+
+**O2 — The updated MODE block specifies the one CODE zone exception.**
+`.otherness/state.json` and `.otherness/state.json` seeding is an explicit exception
+to DOCS-only. The MODE block must mention this exception by name.
+
+Behavior that violates this: MODE block says VISION with no mention of .otherness/ exception.
+
+**O3 — Design doc 07 marks this item as ✅ Present.**
+
+Behavior that violates this: doc 07 still shows `otherness.onboard` mode as 🔲.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to declare mode as VISION or a new hybrid: use VISION as the base, with
+  an explicit ".otherness/ exception" note. This is the simplest accurate description.
+- Whether validate.sh check 6 needs updating: validate.sh check 6 verifies that all
+  agents have a MODE block. After this change, onboard.md will still have a MODE block.
+  No validate.sh change needed.
+- Exact wording for the exception note: "Exception: this agent may also write to
+  `.otherness/` for state bootstrap (`.otherness/state.json`). This is the only
+  CODE-adjacent write permitted."
+
+---
+
+## Zone 3 — Scoped out
+
+- Preventing onboard.md from writing outside its declared zones (it already doesn't)
+- Adding guard.sh calls to onboard.md (separate item if needed)
+- Changes to onboard.md behavior (mode declaration only, not behavior change)

--- a/agents/onboard.md
+++ b/agents/onboard.md
@@ -4,16 +4,20 @@ description: "One-shot onboarding agent. Reads an existing codebase and generate
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
-## MODE: READ-ONLY
+## MODE: VISION
 
-This agent reads files and produces output. It does not write, edit, create,
-or delete any file in any zone.
+This agent may write to the DOCS zone only.
+DOCS zone: `docs/aide/`, `docs/design/`, `docs/*.md`.
 
-If asked to implement, fix, or change code or docs: stop and redirect.
+Exception: this agent may also write to `.otherness/` for state bootstrap
+(`.otherness/state.json`). This is the only CODE-adjacent write permitted.
+The agent does NOT write to `agents/`, `scripts/`, or any other CODE zone path.
+
+If asked to implement features, fix code, or change agent files: stop and redirect.
 
 ```
-[🚫 D4 GATE] This session is READ-ONLY.
-To implement changes:        /otherness.run
+[🚫 D4 GATE] This session (otherness.onboard) writes docs/aide/ and state bootstrap only.
+To implement features:       /otherness.run
 To update vision or design:  /otherness.vibe-vision
 ```
 

--- a/docs/design/07-d4-enforcement.md
+++ b/docs/design/07-d4-enforcement.md
@@ -140,11 +140,11 @@ The message names the correct command. The human knows exactly what to do.
 - ✅ `validate.sh` check 6: every agent file has a `## MODE` block — already enforced since PR #226 (check was already shipping; duplicate Future entry removed)
 - ✅ Layer 1: `## D4 ENFORCEMENT` section added to `onboarding-new-project.md` AGENTS.md template; `d4_enforcement: true` added to `otherness-config-template.yaml` (PR #262, 2026-04-18)
 - ✅ `vibe-vision.md` hard rule: explicit session termination rule added to HARD RULES — session ends after D4 artifacts land on main, no implementation/issues/specs (PR #267, 2026-04-18)
+- ✅ `otherness.onboard` mode: MODE: VISION (writes docs/aide/ + .otherness/ exception for state bootstrap; does not write agents/ or scripts/) — accurately reflects actual behavior (PR #268, 2026-04-18)
 
 ## Future (🔲)
 
-- 🔲 `otherness.onboard` mode: READ-ONLY for CODE zone, VISION for DOCS zone —
-  onboarding generates docs/aide/ stubs only, no code changes
+*(All D4 enforcement layers now implemented. Future extensions should be opened as new issues.)*
 
 ---
 


### PR DESCRIPTION
## Summary

Corrects `agents/onboard.md` MODE declaration from READ-ONLY (incorrect) to VISION with a documented exception.

**Why this was wrong:**
- onboard.md writes `docs/aide/` files (DOCS zone ✓)
- onboard.md writes `.otherness/state.json` (CODE-adjacent, bootstrap exception)
- Declaring MODE: READ-ONLY was inaccurate — the agent DOES write files

**What changes:**
- MODE: VISION with explicit exception: `.otherness/` is permitted for state bootstrap
- Does NOT change any behavior — only the declaration

**Why this matters:**
With guard-ci.sh now in CI (PR #224), MODE declarations must be accurate. A READ-ONLY agent that actually writes would fail guard.sh if called.

This also **closes design doc 07 entirely** — all D4 enforcement layers are now implemented.

## Design doc
Updated `docs/design/07-d4-enforcement.md`: onboard mode 🔲 → ✅. Future section now empty.

## Spec
`.specify/specs/268/spec.md` — 3 falsifiable obligations.