### PR TITLE
feat(sm): SM §4d-learn — auto-trigger /otherness.learn from Type B deficit

### DIFF
--- a/.specify/specs/269/spec.md
+++ b/.specify/specs/269/spec.md
@@ -1,0 +1,66 @@
+# Spec: Phase 1c — SM triggers /otherness.learn from simulation output
+
+> Item: 269 | Created: 2026-04-18 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/11-simulation-feedback-loop.md`
+- **Section**: `## Future`
+- **Implements**: Phase 1c: SM uses simulation output to trigger `/otherness.learn` (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — SM phase includes a learn trigger check running every 10 SM cycles.**
+`agents/phases/sm.md` must include a section (§4d-learn or appended to §4d) that
+checks whether real Type B rate is dropping below the simulated floor. Runs at the
+same cadence as §4d (every 10 SM cycles).
+
+Behavior that violates this: the learn trigger check is absent from sm.md.
+
+**O2 — The check compares real Type B rate from metrics.md against simulated floor.**
+"Type B rate" proxy: the `needs_human` column from metrics.md last 3 rows.
+The simulated floor is read from `scripts/sim-params.json` (or defaults to 0.1
+if the file doesn't exist). If real rate < simulated floor for 3 consecutive batches:
+trigger.
+
+Behavior that violates this: the check only looks at 1 batch, not 3 consecutive.
+
+**O3 — When triggered, SM schedules an automatic /otherness.learn cycle.**
+The learn trigger creates a `feat/learn-<date>` branch (same pattern as the
+existing COORD learn scheduling in §1e), posts a notice on REPORT_ISSUE, and
+proceeds to run the learn protocol.
+
+Behavior that violates this: the trigger fires but doesn't actually start a learn cycle.
+
+**O4 — The trigger only fires if needs_human has been 0 for at least 3 batches.**
+The learn trigger should not fire when the system is already escalating. If
+needs_human > 0 in any of the last 3 batches, skip the learn trigger.
+
+Behavior that violates this: learn trigger fires even when there are open escalations.
+
+**O5 — Duplicate prevention: don't trigger if a learn branch already exists.**
+Before creating `feat/learn-<date>`, check whether the branch already exists
+(`git ls-remote --heads origin feat/learn-`). If yes: skip.
+
+Behavior that violates this: multiple learn branches are created simultaneously.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How to detect "Type B rate": `needs_human` column is a reasonable proxy. A 0
+  needs_human means no escalation (agents handled everything themselves).
+  A sustained 0 may indicate low surprise/novelty (Type B deficit).
+- The simulated floor: default 0.1 means roughly 1 escalation per 10 batches is
+  "healthy". If real rate stays at 0 for 3+ batches AND sim floor is 0.1+: trigger.
+- Placement in sm.md: extend §4d or add a new §4d-learn sub-section immediately
+  after the calibration block.
+
+---
+
+## Zone 3 — Scoped out
+
+- Measuring Type B rate directly from code (pure metrics.md proxy)
+- Suppressing the trigger when autonomous_mode is false
+- Configuring the trigger threshold via otherness-config.yaml (default only)

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -331,7 +331,43 @@ The system will not take autonomous action. This is for your awareness." 2>/dev/
         echo "[SM §4d] Calibration skipped (calibrate.py not available or failed)."
     fi
 else
-    echo "[SM §4d] Calibration skipped (sm_cycle=$SM_CYCLE, next at $((((SM_CYCLE / 10) + 1) * 10)))."
+     echo "[SM §4d] Calibration skipped (sm_cycle=$SM_CYCLE, next at $((((SM_CYCLE / 10) + 1) * 10)))."
+fi
+
+# Phase 1c: Automatic /otherness.learn trigger (every 10 cycles, same cadence as calibration)
+if [ $((SM_CYCLE % 10)) -eq 0 ] && [ "${SM_CYCLE:-0}" -gt 0 ]; then
+  echo "[SM §4d-learn] Checking learn trigger..."
+
+  # [AI-STEP]
+  # Step 1: Read last 3 rows from docs/aide/metrics.md.
+  #   Parse 'needs_human' column (col 4, 1-indexed from date). Keep last 3 rows.
+  #
+  # Step 2: Check if needs_human = 0 for all 3 batches.
+  #   If any row has needs_human > 0: log "[SM §4d-learn] Skipping — escalations present." exit.
+  #
+  # Step 3: Compare real Type B rate (proxy: needs_human avg over last 10 batches)
+  #   against simulated floor from scripts/sim-params.json (default 0.1 if missing).
+  #   sim_floor = sim_params.get('expected_type_b_rate', 0.1)
+  #   If real_rate >= sim_floor: log "[SM §4d-learn] Type B rate OK — no learn trigger."; exit.
+  #
+  # Step 4: If real_rate < sim_floor for 3 consecutive batches AND no escalations:
+  #   LEARN_BRANCH="feat/learn-$(date +%Y%m%d)"
+  #   Check if branch exists: git ls-remote --heads origin $LEARN_BRANCH
+  #   If exists: log "[SM §4d-learn] Learn branch already exists — skipping."; exit.
+  #
+  #   Create branch and worktree:
+  #   git push origin "HEAD:refs/heads/$LEARN_BRANCH"
+  #   LEARN_WT="../${REPO_NAME}.learn-$(date +%Y%m%d)"
+  #   git worktree add "$LEARN_WT" "$LEARN_BRANCH"
+  #
+  #   Post notice:
+  #   gh issue comment $REPORT_ISSUE --repo $REPO \
+  #     --body "[🔄 SM §4d-learn | $MY_SESSION_ID] Auto-learn triggered (Type B deficit: real=${real_rate:.2f} < floor=${sim_floor:.2f}). Starting /otherness.learn."
+  #
+  #   Read and follow ~/.otherness/agents/otherness.learn.md from $LEARN_WT.
+  #   After learn PR open and CI green: merge and clean up (same pattern as coord.md learn scheduling).
+
+  echo "[SM §4d-learn] Learn trigger check complete."
 fi
 ```
 

--- a/docs/design/11-simulation-feedback-loop.md
+++ b/docs/design/11-simulation-feedback-loop.md
@@ -39,12 +39,10 @@ You don't need Phase 2 to start. Phase 2 emerges from Phase 1 running long enoug
 - ✅ Phase 1a: `scripts/calibrate.py` — grid search, writes `scripts/sim-params.json` (PR #240, 2026-04-18)
 - ✅ Phase 1b: SM §4d — calibration every 10 batches, arch-convergence alarm at >0.7, sim-params.json updated (PR #239, 2026-04-18)
 - ✅ Phase 2b: arch-convergence signal in SM — SM §4d reads mean_arch_convergence; opens [NEEDS HUMAN] if >0.7 for 2 consecutive batches (PR #239, 2026-04-18)
+- ✅ Phase 1c: SM §4d-learn — checks Type B rate (needs_human proxy) vs simulated floor every 10 cycles; auto-triggers /otherness.learn if rate < floor for 3 consecutive batches and no escalations; duplicate-suppressed (PR #269, 2026-04-18)
 
 ## Future (🔲)
 
-- 🔲 Phase 1c: SM uses simulation output to trigger `/otherness.learn` — if real
-  Type B rate drops below simulated floor for 3 consecutive batches, SM fires
-  a `/otherness.learn` cycle automatically
 - 🔲 Phase 2a: per-project calibration — when a project's `_state` contains ≥10
   batches of metrics, SM runs calibration against that project's data instead
   of otherness defaults; stores project-specific `sim-params.json` in `_state`


### PR DESCRIPTION
## Summary

Implements Phase 1c of the simulation feedback loop.

**What §4d-learn does (every 10 SM cycles):**
1. Reads last 3 metrics.md batches — skips if any had needs_human > 0
2. Compares real Type B rate (needs_human proxy) vs simulated floor from sim-params.json
3. If real < floor for 3+ consecutive batches AND no escalations: creates learn branch and runs /otherness.learn
4. Duplicate-suppressed (checks for existing learn branch)

## Design doc
Updated `docs/design/11-simulation-feedback-loop.md`: Phase 1c 🔲 → ✅

## Spec
`.specify/specs/269/spec.md` — 5 falsifiable obligations.