### PR TITLE
feat: perpetual loop trigger — standby behavior documented in standalone.md

### DIFF
--- a/.specify/specs/280/spec.md
+++ b/.specify/specs/280/spec.md
@@ -1,0 +1,50 @@
+# Spec: Perpetual loop trigger
+
+> Item: 280 | Created: 2026-04-18 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/12-perpetual-validation.md`
+- **Section**: `## Future`
+- **Implements**: Perpetual loop trigger (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — standalone.md LOOP contains a perpetual trigger check at the start of each cycle.**
+At the top of the LOOP (before Phase 1), standalone.md must check whether there are
+any new queue items (state has todo items, or design docs have unqueued Future items).
+This is already implicit in the loop structure — the explicit addition is a comment
+block that documents the standby mode behavior.
+
+Behavior that violates this: the loop exits on empty queue rather than entering standby.
+
+**O2 — The STOP CONDITION remains unchanged.**
+The only valid exit is still: all journeys ✅ validated AND human says "stop" or
+"confirmed complete". Empty queue is NOT a stop condition (this is already stated).
+This PR adds documentation clarity but does not change the existing stop condition logic.
+
+**O3 — A "standby mode" comment is added for when queue is empty and no new items.**
+When the queue is empty (COORD finds no todo items and no new Future items in design docs),
+standalone.md documents the expected behavior: "No new items. Re-checking in 60s."
+This is the existing `sleep 60 && continue` path in coord.md — just made explicit.
+
+**O4 — Design doc 12 marks Perpetual loop trigger as ✅ Present.**
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to change the loop behavior: NO. The loop already does this correctly —
+  COORD already sleeps 60s on empty queue. This PR adds documentation clarity only.
+- Where to add in standalone.md: a comment block at the start of THE LOOP section,
+  explaining the perpetual behavior.
+- Whether to add an explicit "standby mode" state: no new state needed.
+
+---
+
+## Zone 3 — Scoped out
+
+- Actual code changes to the loop behavior (already correct)
+- "Check daily" interval (loop already checks every ~60s on empty queue)
+- Automatic restart on vibe-vision artifacts (handled by queue-gen reading design docs)

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -534,6 +534,15 @@ If a resume item is found: go directly to the correct phase for its state.
 You are an autonomous agent. Completing one batch does NOT end the session. Empty queue →
 generate a new queue → claim an item → continue. The only valid exit is the STOP CONDITION.
 
+**Perpetual loop behavior (Stage 7 — Perpetual Autonomous Validation):**
+- After each batch, COORD checks state for todo items and design docs for unqueued Future items.
+- If new items exist (from queue-gen, vibe-vision stubs, or self-generating criteria): continue normally.
+- If no new items AND PM §5g health is GREEN AND all journeys pass: enter standby loop.
+  Standby loop: `sleep 60 && GOTO LOOP` — the agent waits for new items to appear.
+  New items appear when: a human runs /otherness.vibe-vision, an external contribution
+  arrives, or PM §5h opens a journey gap issue that COORD picks up.
+- Standby is NOT a stop. The session remains active, watching for work.
+
 ```
 LOOP:
 

--- a/docs/design/12-perpetual-validation.md
+++ b/docs/design/12-perpetual-validation.md
@@ -45,7 +45,7 @@ together produce a validation signal that evolves with the product.
 
 ## Present (✅)
 
-*(Not yet implemented — this is the design doc for a new capability.)*
+- ✅ Perpetual loop trigger — standalone.md THE LOOP section now documents standby behavior explicitly: empty queue + GREEN health → standby (sleep 60 && continue), not exit; new items from vibe-vision or PM §5h restart the active loop automatically (PR #280, 2026-04-18)
 
 ## Future (🔲)
 


### PR DESCRIPTION
## Summary

Adds documentation of standby loop behavior to standalone.md THE LOOP section.

**Change:** 10-line documentation block explaining that empty queue + GREEN health → standby (sleep 60 && continue), not exit. New items from vibe-vision or PM §5h restart the active loop.

**Risk:** Documentation-only change to standalone.md. No logic changes — the behavior was already correct (COORD's §1e already does sleep 60 on empty queue).

## Design doc
Doc 12: Perpetual loop trigger 🔲 → ✅.

## Spec
.specify/specs/280/spec.md — 4 obligations.