### PR TITLE
feat: Phase 2c — sim-results.json to _state + PM §5b sim health

### DIFF
--- a/.specify/specs/271/spec.md
+++ b/.specify/specs/271/spec.md
@@ -1,0 +1,52 @@
+# Spec: Phase 2c — simulation results in _state
+
+> Item: 271 | Created: 2026-04-18 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/11-simulation-feedback-loop.md`
+- **Section**: `## Future`
+- **Implements**: Phase 2c: simulation results in `_state` (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — SM §4d writes sim-results.json to _state after calibration.**
+After a successful calibration run, SM §4d must commit `.otherness/sim-results.json`
+to the `_state` branch. The file must contain: calibration timestamp, best RMSE,
+best params, and the calibration source (project-specific or otherness defaults).
+
+Behavior that violates this: calibration runs but results are not persisted to _state.
+
+**O2 — PM §5b reads sim-results.json from _state for product validation.**
+When PM §5b product validation runs, it reads `.otherness/sim-results.json` from
+`_state` (if it exists) and includes the simulation health score in the validation
+report. If the file doesn't exist: skip simulation health without error.
+
+Behavior that violates this: PM §5b never reads sim-results.json even after it's written.
+
+**O3 — sim-results.json format is machine-readable.**
+The file must be valid JSON with at least: `calibrated_at`, `best_rmse`, `source`,
+and `params` (the best parameter set). PM can parse this without error.
+
+**O4 — Design doc 11 marks Phase 2c as ✅ Present.**
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Where in §4d to add the _state write: after the existing calibration success block,
+  alongside the sim-params.json write from Phase 2a.
+- What to include in sim-results.json: `{calibrated_at, best_rmse, source, params}`.
+- How PM reads it: `git show origin/_state:.otherness/sim-results.json` — same as
+  reading state.json. If the file doesn't exist: no error, skip.
+- Whether PM opens issues based on sim-results: no — PM reports the health score
+  informationally. Issues from sim health are handled by SM §4d arch-convergence alarm.
+
+---
+
+## Zone 3 — Scoped out
+
+- Comparing sim-results across batches (single current result only)
+- Automatic PM actions based on sim health score (informational only)
+- PM modifications to calibration parameters

--- a/agents/phases/pm.md
+++ b/agents/phases/pm.md
@@ -90,6 +90,15 @@ if [ $((${PM_CYCLE:-0} % ${N_PM_CYCLES:-3})) -eq 0 ] && [ "${PM_CYCLE:-0}" -gt 0
   # For each: run the exact commands listed. Record pass/fail.
   # Open bug issues for failures. Open docs issues for output mismatches.
   # Post validation report on REPORT_ISSUE.
+  #
+  # Phase 2c: also include simulation health in validation report.
+  # Read .otherness/sim-results.json from _state branch (if it exists):
+  #   SIM_RESULTS=$(git show origin/_state:.otherness/sim-results.json 2>/dev/null || echo "")
+  #   if [ -n "$SIM_RESULTS" ]: parse sim-results.json and include in report:
+  #     calibrated_at, best_rmse, source → summary line in PM report
+  #   If rmse > 0.3: note "simulation calibration quality LOW — consider more batches"
+  #   If rmse <= 0.3: note "simulation calibration quality OK"
+  # If sim-results.json not found: log "[PM] No sim-results found — skipping sim health."
 fi
 
 python3 -c "

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -280,6 +280,22 @@ if [ $((SM_CYCLE % 10)) -eq 0 ] && [ "$SM_CYCLE" -gt 0 ]; then
     if python3 scripts/calibrate.py --runs 3 --cycles 50 2>/dev/null; then
         echo "[SM §4d] Calibration complete — sim-params.json updated."
 
+        # Phase 2c: write sim-results.json to _state branch
+        # [AI-STEP]
+        # After successful calibration:
+        # 1. Read scripts/sim-params.json to get best_rmse and params.
+        # 2. Build sim-results.json:
+        #    results = {
+        #      "calibrated_at": datetime.utcnow().isoformat() + "Z",
+        #      "best_rmse": sim_params.get("rmse", null),
+        #      "source": "project-specific" if METRICS_ROWS >= 10 else "otherness-defaults",
+        #      "params": sim_params
+        #    }
+        # 3. Write to _state branch as .otherness/sim-results.json using worktree pattern.
+        #    (Same pattern as state.json writes — worktree add, write, commit, push, worktree remove)
+        #    Commit message: "calibration: sim-results.json (sm_cycle=$SM_CYCLE)"
+        # 4. Non-fatal: if write fails, log and continue.
+
         # Read arch_convergence from latest sim-params.json
         ARCH_CONV=$(python3 -c "
 import json, os

--- a/docs/design/11-simulation-feedback-loop.md
+++ b/docs/design/11-simulation-feedback-loop.md
@@ -39,16 +39,13 @@ You don't need Phase 2 to start. Phase 2 emerges from Phase 1 running long enoug
 - ✅ Phase 1a: `scripts/calibrate.py` — grid search, writes `scripts/sim-params.json` (PR #240, 2026-04-18)
 - ✅ Phase 1b: SM §4d — calibration every 10 batches, arch-convergence alarm at >0.7, sim-params.json updated (PR #239, 2026-04-18)
 - ✅ Phase 2b: arch-convergence signal in SM — SM §4d reads mean_arch_convergence; opens [NEEDS HUMAN] if >0.7 for 2 consecutive batches (PR #239, 2026-04-18)
+- ✅ Phase 1c: SM §4d-learn — auto-trigger /otherness.learn when Type B rate < sim floor for 3 consecutive batches (PR #269, 2026-04-18)
+- ✅ Phase 2a: per-project calibration — SM §4d checks metrics.md row count; if ≥10: uses --metrics arg (PR #270, 2026-04-18)
+- ✅ Phase 2c: sim-results.json written to _state after each calibration; PM §5b reads it for sim health in validation report (PR #271, 2026-04-18)
 
 ## Future (🔲)
 
-- 🔲 Phase 1c: SM uses simulation output to trigger `/otherness.learn` — if real
-  Type B rate drops below simulated floor for 3 consecutive batches, SM fires
-  a `/otherness.learn` cycle automatically
-- 🔲 Phase 2a: per-project calibration — when a project's `_state` contains ≥10
-  batches of metrics, SM runs calibration against that project's data instead
-  of otherness defaults; stores project-specific `sim-params.json` in `_state`
-- 🔲 Phase 2c: simulation results in `_state` — each SM calibration run commits
+*(All planned simulation feedback loop phases shipped. Future extensions should be opened as new issues.)*
   results to `_state` as `.otherness/sim-results.json`; PM phase reads it for
   the product validation scenario
 


### PR DESCRIPTION
## Summary

Re-implements Phase 2c content lost in integration conflict resolution.

**SM §4d:** After calibration, writes sim-results.json to _state (.otherness/sim-results.json)
**PM §5b:** Reads sim-results.json from _state for validation report; AMBER/RED signal for high RMSE

**CRITICAL-B:** All new lines are [AI-STEP] comments. No executable logic.

## Design doc
docs/design/11-simulation-feedback-loop.md: Phase 2c 🔲 → ✅