### PR TITLE
feat(pm): PM §5j reference project health check — Journey 2 stall detection

### DIFF
--- a/.specify/specs/301/spec.md
+++ b/.specify/specs/301/spec.md
@@ -1,0 +1,39 @@
+# Spec: PM §5 reference project health check
+
+> Item: 301 | Created: 2026-04-19 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/16-journey-2-reference-project.md`
+- **Section**: `§ Future`
+- **Implements**: PM §5 reference project health check — detect Journey 2 failure, [NEEDS HUMAN] once per stall (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — PM phase has a reference project health check that detects Journey 2 failure.**
+A [AI-STEP] block in PM §5 (or §5j as a new sub-section) checks whether the reference
+project's `_state` branch has been updated within 72 hours.
+
+**O2 — When Journey 2 fails, the agent opens a [NEEDS HUMAN] issue exactly once per stall event.**
+Issue title: `"[NEEDS HUMAN] Journey 2: reference project stalled >72h — restart otherness on <project>"`.
+Check for an existing open issue with this title before creating (duplicate suppression).
+
+**O3 — The check runs every N_PM_CYCLES cycles.**
+
+**O4 — Design doc 16 marks this item as ✅ Present.**
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Placement: new §5j in pm.md, after §5i.
+- Reference project: first non-otherness entry in otherness-config.yaml monitor.projects.
+- Threshold: 72 hours (matches test.sh check 5b).
+
+---
+
+## Zone 3 — Scoped out
+
+- AMBER/RED escalation based on duration (that's item 302)
+- Per-project health checks beyond the reference project

--- a/agents/phases/pm.md
+++ b/agents/phases/pm.md
@@ -421,3 +421,56 @@ if [ $((${PM_CYCLE:-0} % ${N_PM_CYCLES:-3})) -eq 0 ]; then
   echo "[PM §5g] README/AGENTS.md claims cross-check complete."
 fi
 ```
+
+---
+
+## 5j. Reference project health check (runs every N_PM_CYCLES)
+
+Detect Journey 2 failure. Open [NEEDS HUMAN] issue once per stall.
+
+```bash
+if [ $((${PM_CYCLE:-0} % ${N_PM_CYCLES:-3})) -eq 0 ]; then
+  echo "[PM §5j] Checking reference project health..."
+
+  # [AI-STEP]
+  # Step 1: Read reference project from otherness-config.yaml.
+  #   REF_PROJECT=$(python3 -c "
+  #     import re
+  #     in_monitor = in_projects = False
+  #     for line in open('otherness-config.yaml'):
+  #         if re.match(r'^monitor:',line): in_monitor=True
+  #         if in_monitor and re.match(r'\s+projects:',line): in_projects=True
+  #         if in_projects:
+  #             m=re.match(r'\s+- (.+)',line)
+  #             if m:
+  #                 r=m.group(1).strip()
+  #                 if not r.endswith('/otherness'): print(r); break
+  #   " 2>/dev/null)
+  #   if [ -z "$REF_PROJECT" ]: echo "[PM §5j] No reference project found — skipping."; exit
+  #
+  # Step 2: Check _state branch age.
+  #   LAST_COMMIT=$(gh api "repos/$REF_PROJECT/branches/_state"
+  #     --jq '.commit.commit.committer.date' 2>/dev/null || echo "")
+  #   if [ -z "$LAST_COMMIT" ]: echo "[PM §5j] No _state branch on $REF_PROJECT — skipping."; exit
+  #   AGE_H=$(python3 -c "
+  #     import datetime
+  #     d = datetime.datetime.fromisoformat('$LAST_COMMIT'.replace('Z','+00:00'))
+  #     print(int((datetime.datetime.now(datetime.timezone.utc) - d).total_seconds() / 3600))
+  #   ")
+  #
+  # Step 3: If AGE_H > 72 (Journey 2 failing):
+  #   TITLE="[NEEDS HUMAN] Journey 2: reference project stalled >72h — restart otherness on $REF_PROJECT"
+  #   EXISTING=$(gh issue list --repo $REPO --state open --search "$TITLE" --json number --jq 'length')
+  #   if [ "$EXISTING" -eq 0 ]:
+  #     gh issue create --repo $REPO --title "$TITLE"
+  #       --label "needs-human,area/agent-loop"
+  #       --body "Reference project $REF_PROJECT has not had _state activity in ${AGE_H}h (threshold: 72h).
+  #               Journey 2 is failing. Run /otherness.run on $REF_PROJECT to restart."
+  #   fi
+  #
+  # Step 4: If AGE_H <= 72:
+  #   echo "[PM §5j] Journey 2 OK: $REF_PROJECT last active ${AGE_H}h ago."
+
+  echo "[PM §5j] Reference project health check complete."
+fi
+```

--- a/docs/design/16-journey-2-reference-project.md
+++ b/docs/design/16-journey-2-reference-project.md
@@ -78,7 +78,7 @@ escalation handles future stalls.
 
 ## Present (✅)
 
-*(Not yet implemented beyond test.sh check 5b.)*
+- ✅ PM §5j: reference project health check — reads ref project from config, checks _state age >72h, opens [NEEDS HUMAN] issue once per stall (duplicate-suppressed) (PR #301, 2026-04-19)
 
 ## Future (🔲)
 


### PR DESCRIPTION
## Summary

Adds PM §5j — detects when Journey 2 (reference project) is stalling.

**What it does:** Reads reference project from otherness-config.yaml, checks _state age. If >72h: opens one [NEEDS HUMAN] issue per stall (duplicate-suppressed). Graceful fallback.

**CRITICAL-B:** All additions are [AI-STEP] comments. Confirmed by git diff classifier.

Design doc 16: PM §5 health check 🔲 → ✅