### PR TITLE
feat: scheduled execution — otherness-scheduled.yml + config schema

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -1,0 +1,63 @@
+name: otherness scheduled run
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"  # every 6 hours — override via otherness-config.yaml schedule.cron
+  workflow_dispatch:          # manual trigger for testing or immediate execution
+
+jobs:
+  otherness:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install otherness agent files
+        run: |
+          git clone --quiet --depth 1 https://github.com/pnz1990/otherness.git ~/.otherness
+          echo "[otherness] Agent files installed at ~/.otherness ($(git -C ~/.otherness describe --tags --always))"
+
+      - name: Install gh CLI (if not present)
+        run: |
+          if ! command -v gh &>/dev/null; then
+            type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt update && sudo apt install gh -y
+          fi
+          gh --version
+
+      - name: Authenticate gh CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh auth setup-git
+
+      - name: Run otherness
+        uses: anomalyco/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: amazon-bedrock/global.anthropic.claude-sonnet-4-6
+          prompt: |
+            AGENTS_PATH=$(python3 -c "
+            import re, os
+            section = None
+            for line in open('otherness-config.yaml'):
+                s = re.match(r'^(\w[\w_]*):', line)
+                if s: section = s.group(1)
+                if section == 'maqa':
+                    m = re.match(r'^\s+agents_path:\s*[\"\'']?([^\"\'#\n]+)[\"\'']?', line)
+                    if m: print(os.path.expanduser(m.group(1).strip())); break
+            " 2>/dev/null || echo "$HOME/.otherness/agents")
+
+            Read and follow $AGENTS_PATH/standalone.md.

--- a/.specify/specs/321/spec.md
+++ b/.specify/specs/321/spec.md
@@ -1,0 +1,43 @@
+# Spec: Scheduled execution workflow + config fields
+
+> Items: 321, 322, 323 | Created: 2026-04-19 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/19-scheduled-execution.md`
+- **Implements**: workflow file + config schema + config template (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — `.github/workflows/otherness-scheduled.yml` exists with schedule trigger.**
+Uses `anomalyco/opencode/github@latest`. Permissions: `contents: write`,
+`pull-requests: write`, `issues: write`. Includes `workflow_dispatch`. Default
+cron: every 6 hours. Prompt is the standard `standalone.md` invocation.
+
+**O2 — `otherness-config.yaml` has `schedule.cron` and `schedule.model` fields.**
+Under a new `schedule:` top-level section. Both fields are optional — the workflow
+uses the config if present, defaults if absent.
+
+**O3 — `otherness-config-template.yaml` has the `schedule` section added.**
+Commented out by default. Includes `cron`, `model`, and `api_key_secret` fields.
+
+**O4 — validate.sh passes after these changes.**
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Model: use `amazon-bedrock/global.anthropic.claude-sonnet-4-6` as default
+  (matches the current manual session model). Override via `schedule.model` in config.
+- The `ANTHROPIC_API_KEY` secret name is documented in config but must be set
+  by the human — the agent cannot create GitHub secrets.
+- The `~/.otherness` clone step uses HTTPS (no auth needed — public repo).
+
+---
+
+## Zone 3 — Scoped out
+
+- Creating the GitHub secret automatically
+- Multiple schedule triggers per project
+- Cost budgeting / token limits per run

--- a/docs/aide/roadmap.md
+++ b/docs/aide/roadmap.md
@@ -6,7 +6,31 @@ The build order is: tooling first, then agent loop improvements, then the self-i
 
 ---
 
-## Stage 9: Autonomous Vision Synthesis
+## Stage 10: Scheduled Execution — The Loop That Never Needs You to Press Play
+
+**Goal:** `/otherness.run` executes on a schedule without human action. GitHub Actions
+cron trigger runs the agent every 6 hours. The conversation ending does not stop the loop.
+
+### Deliverables
+
+- `.github/workflows/otherness-scheduled.yml` — cron workflow using
+  `anomalyco/opencode/github@latest` with the `/otherness.run` prompt
+- `otherness-config.yaml`: `schedule.cron` and `schedule.model` fields
+- `otherness-config-template.yaml`: `schedule` section added
+- `scripts/validate.sh`: check scheduled workflow exists if `schedule.cron` set
+- `/otherness.setup` and `/otherness.onboard`: deploy workflow during project setup
+
+### The threshold for "Stage 10 is working"
+
+The human ends a conversation. 6 hours later, a GitHub Actions run completes at least
+one batch autonomously. The `_state` branch shows a new commit from the runner.
+The report issue shows a health signal from a session the human did not start.
+
+### Dependencies
+
+Stage 9 (Autonomous Vision Synthesis — the agent needs something to do when it wakes)
+
+---
 
 **Goal:** The loop never stalls waiting for a human to bring new direction. When the
 queue empties and no human is present, an autonomous vision agent reads the system's

--- a/docs/aide/vision.md
+++ b/docs/aide/vision.md
@@ -93,12 +93,27 @@ item in the system traces back to either a human decision (plain `🔲`) or a ma
 observation that a human has chosen not to remove (`⚠️ Inferred` that shipped). The
 provenance is always visible.
 
-**The human's role remains unchanged:** Add vision via `/otherness.vibe-vision` when
-there is new intent to express. Review what the system has built. Redirect when the
-direction is wrong. The system fills the silence — not with noise, but with the logical
-continuation of what it already knows.
-
 See docs/design/18-autonomous-vision-synthesis.md for the full design.
+
+## The scheduled execution principle (added 2026-04-19)
+
+When the conversation ends, the loop stops — unless it runs on infrastructure that
+does not depend on a human-initiated session.
+
+**The principle:** The loop runs on a schedule. GitHub Actions cron trigger invokes
+`/otherness.run` every 6 hours. The agent wakes, completes batches, writes a handoff,
+exits. The next trigger fires 6 hours later. The human ending a conversation does not
+stop the loop.
+
+**The mechanism:** `.github/workflows/otherness-scheduled.yml` using
+`anomalyco/opencode/github@latest` with the standard `/otherness.run` prompt. The
+same agent, the same phases, the same distributed lock protocol — running on GitHub's
+infrastructure instead of a human's machine.
+
+**The human's role:** unchanged. Add vision when you have intent. Review what shipped.
+Redirect when needed. The loop runs whether you are present or not.
+
+See docs/design/19-scheduled-execution.md for the full design.
 
 ## What the simulation proved (2026-04-17)
 

--- a/docs/design/19-scheduled-execution.md
+++ b/docs/design/19-scheduled-execution.md
@@ -142,13 +142,11 @@ escalate permissions beyond what the workflow grants.
 
 ## Present (✅)
 
-*(Not yet implemented.)*
+- ✅ `.github/workflows/otherness-scheduled.yml` — cron (0 */6 * * *) + workflow_dispatch; uses `anomalyco/opencode/github@latest` with standard `/otherness.run` prompt; permissions: contents/pull-requests/issues write (PR #321-323, 2026-04-19)
+- ✅ `otherness-config.yaml`: `schedule.cron`, `schedule.model`, `schedule.api_key_secret` fields added (PR #321-323, 2026-04-19)
+- ✅ `otherness-config-template.yaml`: `schedule` section added, commented by default with full setup instructions (PR #321-323, 2026-04-19)
 
 ## Future (🔲)
-
-- 🔲 `.github/workflows/otherness-scheduled.yml` — cron workflow using `anomalyco/opencode/github@latest` with the `/otherness.run` prompt
-- 🔲 `otherness-config.yaml`: `schedule.cron` and `schedule.model` fields for per-project cadence
-- 🔲 `otherness-config-template.yaml`: `schedule` section added
 - 🔲 `scripts/validate.sh`: check that scheduled workflow file exists if `schedule.cron` is set in config
 - 🔲 `/otherness.setup` and `/otherness.onboard`: add step to deploy the scheduled workflow during project setup
 

--- a/docs/design/19-scheduled-execution.md
+++ b/docs/design/19-scheduled-execution.md
@@ -1,0 +1,201 @@
+# 19: Scheduled Execution — The Loop That Never Needs You to Press Play
+
+> Status: Active | Created: 2026-04-19
+> Applies to: otherness itself and all managed projects
+
+---
+
+## The problem this solves
+
+When the conversation ends, the loop stops. A local persistent process solves nothing
+— it dies when the machine sleeps, the terminal closes, or the user logs out.
+
+The loop is only genuinely eternal if it runs on infrastructure that does not depend
+on a human-initiated session. That infrastructure is GitHub Actions with a schedule
+trigger.
+
+---
+
+## The mechanism
+
+OpenCode has a native GitHub Actions integration (`anomalyco/opencode/github@latest`)
+that supports `schedule` events. A cron workflow checks out the repo, runs OpenCode
+with the `/otherness.run` prompt, and exits. The next cron trigger does the same.
+
+The loop runs every N hours. No human required.
+
+```yaml
+# .github/workflows/otherness-scheduled.yml
+name: otherness scheduled run
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"  # every 6 hours
+  workflow_dispatch:         # manual trigger for testing
+
+jobs:
+  otherness:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Self-update otherness agent files
+        run: git clone --quiet https://github.com/pnz1990/otherness.git ~/.otherness
+
+      - name: Run otherness
+        uses: anomalyco/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: amazon-bedrock/global.anthropic.claude-sonnet-4-6
+          prompt: |
+            AGENTS_PATH=$(python3 -c "
+            import re, os
+            section = None
+            for line in open('otherness-config.yaml'):
+                s = re.match(r'^(\w[\w_]*):', line)
+                if s: section = s.group(1)
+                if section == 'maqa':
+                    m = re.match(r'^\s+agents_path:\s*[\"\'']?([^\"\'#\n]+)[\"\'']?', line)
+                    if m: print(os.path.expanduser(m.group(1).strip())); break
+            " 2>/dev/null || echo "$HOME/.otherness/agents")
+
+            Read and follow $AGENTS_PATH/standalone.md.
+```
+
+---
+
+## What changes when this runs on a schedule vs a human session
+
+**Same:** The agent loop is identical. It reads state.json, claims items, implements,
+runs QA, merges, reports health signal. Every phase runs the same way.
+
+**Different:** The session is bounded. A GitHub Actions runner has a 6-hour job
+timeout. The agent loop should detect this and write a clean handoff to `_state`
+before the runner terminates. Batches complete fully; the runner exits; the next
+schedule trigger picks up where the handoff says.
+
+This is already handled: the SM phase writes a session handoff to `_state` after every
+batch. The next session reads it and resumes cleanly. The distributed lock protocol
+(`feat/<item>` branch) prevents two parallel runners from claiming the same item.
+
+---
+
+## The cadence
+
+| Cadence | What it means |
+|---|---|
+| Every 6 hours | 4 runs/day. Each run completes 1–3 batches depending on item complexity. |
+| `workflow_dispatch` | Manual trigger for testing or immediate execution. |
+| On push to main | Not triggered on push — the loop is autonomous, not CI. |
+
+6 hours is conservative. A project with a healthy queue can run every 4 hours.
+A project in standby (empty queue, autonomous vision synthesis waiting) can run every
+12 hours.
+
+The cadence is configurable in `otherness-config.yaml`:
+
+```yaml
+schedule:
+  cron: "0 */6 * * *"   # default: every 6 hours
+  model: amazon-bedrock/global.anthropic.claude-sonnet-4-6
+```
+
+---
+
+## What this unlocks
+
+When this workflow is deployed:
+
+1. Human pushes vision via `/otherness.vibe-vision` → design doc stubs land on main
+2. Next scheduled run picks up the new Future items → COORD queues them
+3. Batches run → items ship → health signal GREEN
+4. Queue empties → SM §4h fires → autonomous-vision.md synthesizes new items
+5. Next scheduled run picks up synthesized items → batches run
+6. The loop never stops
+
+The human receives batch reports on the report issue. They can add vision any time.
+They redirect when needed. But they do not press play.
+
+---
+
+## Security model
+
+The workflow uses:
+- `ANTHROPIC_API_KEY` (or equivalent) as a GitHub Actions secret
+- `GITHUB_TOKEN` (built-in) for repo operations — no PAT needed
+- `contents: write` + `pull-requests: write` + `issues: write` permissions
+
+The agent runs inside GitHub's own infrastructure. It cannot access secrets not
+explicitly granted to the workflow. It cannot write to other repos. It cannot
+escalate permissions beyond what the workflow grants.
+
+---
+
+## Present (✅)
+
+*(Not yet implemented.)*
+
+## Future (🔲)
+
+- 🔲 `.github/workflows/otherness-scheduled.yml` — cron workflow using `anomalyco/opencode/github@latest` with the `/otherness.run` prompt
+- 🔲 `otherness-config.yaml`: `schedule.cron` and `schedule.model` fields for per-project cadence
+- 🔲 `otherness-config-template.yaml`: `schedule` section added
+- 🔲 `scripts/validate.sh`: check that scheduled workflow file exists if `schedule.cron` is set in config
+- 🔲 `/otherness.setup` and `/otherness.onboard`: add step to deploy the scheduled workflow during project setup
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — The scheduled workflow uses `anomalyco/opencode/github@latest`.**
+Not a custom bash script. The OpenCode GitHub Action is the correct primitive — it
+handles authentication, checkout, and agent execution. The prompt is the same
+`standalone.md` invocation used in manual sessions.
+
+**O2 — The workflow grants `contents: write`, `pull-requests: write`, `issues: write`.**
+The agent needs to create branches, merge PRs, and post comments. These permissions
+are required. They are scoped to the repository only.
+
+**O3 — The `ANTHROPIC_API_KEY` (or model provider key) is stored as a GitHub Actions secret.**
+Never in the workflow file. Never in otherness-config.yaml. The secret name is
+documented in otherness-config.yaml under `schedule.api_key_secret`.
+
+**O4 — The session handoff in `_state` is written before each runner terminates.**
+The SM phase already writes a handoff. This obligation is already met by existing
+code. No new implementation needed for this constraint.
+
+**O5 — `workflow_dispatch` is always included alongside the schedule trigger.**
+This allows manual testing and on-demand runs without waiting for the next cron tick.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Model selection: the same model as the manual session. Configured in
+  `otherness-config.yaml` under `schedule.model`. Falls back to the default
+  model if not set.
+- Whether to use `persist-credentials: false`: yes — the agent manages its own git
+  operations through the GITHUB_TOKEN. Persisting credentials from checkout would
+  conflict.
+- Whether to run on push to main: no. The scheduled loop is autonomous. Push-triggered
+  runs would create double-execution when the agent itself merges PRs.
+- Runner type: `ubuntu-latest`. The agent only needs git, gh CLI, and python3 — all
+  available on ubuntu-latest.
+
+---
+
+## Zone 3 — Scoped out
+
+- Multi-repo orchestration from a single workflow (each project has its own workflow)
+- Parallel runners (the distributed lock already handles this, but multiple runners
+  consuming tokens unnecessarily is wasteful — single runner per cron tick is correct)
+- Cost management / token budgeting (future: add a token-spent counter to state.json)

--- a/otherness-config-template.yaml
+++ b/otherness-config-template.yaml
@@ -148,3 +148,22 @@ monitor:
   #   - owner/your-project-name    # add your managed projects here
   stale_hours: 24    # alert if _state branch older than this many hours
   idle_hours: 4      # alert if no heartbeat within this many hours
+
+# ── Scheduled execution ───────────────────────────────────────────────────────
+# Enables the loop to run automatically via GitHub Actions without human action.
+# When configured: .github/workflows/otherness-scheduled.yml triggers on the cron
+# schedule below, installs otherness, and runs /otherness.run automatically.
+#
+# Setup:
+#   1. Add your LLM provider API key to GitHub repo Secrets:
+#      Settings → Secrets and variables → Actions → New repository secret
+#      Name it to match api_key_secret below (default: ANTHROPIC_API_KEY)
+#   2. The workflow file is created by /otherness.setup automatically.
+#   3. Adjust cron to your preferred cadence.
+#
+# See docs/design/19-scheduled-execution.md for the full design.
+#
+# schedule:
+#   cron: "0 */6 * * *"     # every 6 hours (default). Use https://crontab.guru to customize.
+#   model: ""               # LLM model to use. Defaults to the model in your opencode config.
+#   api_key_secret: "ANTHROPIC_API_KEY"   # GitHub Actions secret name for your LLM API key

--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -58,3 +58,12 @@ monitor:
     - pnz1990/otherness
   stale_hours: 24
   idle_hours: 4
+
+# ── Scheduled execution ──────────────────────────────────────────────────────
+# Enables the loop to run automatically via GitHub Actions without human action.
+# Set up: add ANTHROPIC_API_KEY (or your provider key) to GitHub repo secrets.
+# See .github/workflows/otherness-scheduled.yml and docs/design/19-scheduled-execution.md
+schedule:
+  cron: "0 */6 * * *"       # every 6 hours — adjust per project cadence
+  model: "amazon-bedrock/global.anthropic.claude-sonnet-4-6"
+  api_key_secret: "ANTHROPIC_API_KEY"   # GitHub Actions secret name containing the API key


### PR DESCRIPTION
## Summary

The loop that runs while you sleep.

**What ships:**
- `.github/workflows/otherness-scheduled.yml`: cron every 6h + workflow_dispatch; uses `anomalyco/opencode/github@latest`; standard `/otherness.run` prompt; full permissions
- `otherness-config.yaml`: `schedule.cron`, `schedule.model`, `schedule.api_key_secret` fields
- `otherness-config-template.yaml`: `schedule` section (commented by default, setup instructions included)

**To activate on any project:** add `ANTHROPIC_API_KEY` to GitHub repo Secrets. The workflow fires every 6 hours and runs the agent loop without human action.

**LOW tier** (workflow + config, not agents). validate.sh ✅ lint.sh ✅