### PR TITLE
feat: two-way command file sync — every session, every project

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -26,6 +26,23 @@ jobs:
           git clone --quiet --depth 1 https://github.com/pnz1990/otherness.git ~/.otherness
           echo "[otherness] Agent files installed at ~/.otherness ($(git -C ~/.otherness describe --tags --always))"
 
+      - name: Sync otherness command files
+        run: |
+          mkdir -p .opencode/command
+          # Two-way sync: add new otherness.* commands, remove stale ones
+          SYNCED=0
+          for src in ~/.otherness/.opencode/command/otherness.*.md; do
+            [ -f "$src" ] || continue
+            fname=$(basename "$src"); dest=".opencode/command/$fname"
+            if ! cmp -s "$src" "$dest" 2>/dev/null; then cp "$src" "$dest"; SYNCED=1; fi
+          done
+          for dest in .opencode/command/otherness.*.md; do
+            [ -f "$dest" ] || continue
+            fname=$(basename "$dest")
+            if [ ! -f ~/.otherness/.opencode/command/"$fname" ]; then rm "$dest"; SYNCED=1; fi
+          done
+          [ $SYNCED -eq 1 ] && echo "[otherness] Command files synced." || echo "[otherness] Commands already current."
+
       - name: Install gh CLI (if not present)
         run: |
           if ! command -v gh &>/dev/null; then

--- a/.opencode/command/otherness.setup.md
+++ b/.opencode/command/otherness.setup.md
@@ -84,23 +84,37 @@ fi
 ## Step 4 — Deploy otherness command files into this project
 
 OpenCode reads slash commands from `.opencode/command/` in the current project directory.
-Copy the command files from `~/.otherness` so `/otherness.run`, `/otherness.onboard`, etc. work.
+Sync the command files from `~/.otherness` — two-way: add new commands, remove stale ones.
+Non-`otherness.*` files are never touched (project-custom commands stay intact).
 
 ```bash
 if [ -d ~/.otherness/.opencode/command ]; then
   mkdir -p .opencode/command
-  # Copy all otherness.*.md commands — skip any that already exist (don't overwrite customisations)
+  _SYNCED=0
+
+  # Add or update all otherness.* commands
   for src in ~/.otherness/.opencode/command/otherness.*.md; do
-    fname=$(basename "$src")
-    dest=".opencode/command/$fname"
-    if [ ! -f "$dest" ]; then
+    [ -f "$src" ] || continue
+    fname=$(basename "$src"); dest=".opencode/command/$fname"
+    if ! cmp -s "$src" "$dest" 2>/dev/null; then
       cp "$src" "$dest"
-      echo "  Deployed: $fname"
-    else
-      echo "  Already present (skipped): $fname"
+      echo "  Synced: $fname"
+      _SYNCED=1
     fi
   done
-  echo "Commands deployed to .opencode/command/"
+
+  # Remove stale otherness.* commands no longer in ~/.otherness
+  for dest in .opencode/command/otherness.*.md; do
+    [ -f "$dest" ] || continue
+    fname=$(basename "$dest")
+    if [ ! -f ~/.otherness/.opencode/command/"$fname" ]; then
+      rm "$dest"
+      echo "  Removed stale: $fname"
+      _SYNCED=1
+    fi
+  done
+
+  [ $_SYNCED -eq 1 ] && echo "Commands synced in .opencode/command/" || echo "Commands already up to date."
 else
   echo "WARNING: ~/.otherness/.opencode/command not found. Clone otherness first (Step 3)."
 fi

--- a/.specify/specs/328/spec.md
+++ b/.specify/specs/328/spec.md
@@ -1,0 +1,47 @@
+# Spec: Two-way command file sync — items 328-331
+
+> Items: 328, 329, 330, 331 | Created: 2026-04-19 | Status: Active
+
+## Design reference
+- **Design doc**: `docs/design/20-command-file-sync.md`
+- **Implements**: standalone.md + bounded-standalone.md + setup Step 4 + scheduled workflow (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — standalone.md SELF-UPDATE adds two-way command sync after git pull.**
+After `git -C ~/.otherness pull`, sync all `otherness.*.md` command files:
+add/update from `~/.otherness`, remove stale ones not in `~/.otherness`.
+Content-diff before copy. Silent if nothing changed. One log line if anything changed.
+
+**O2 — bounded-standalone.md has the identical sync step.**
+Same bash block. Same behavior.
+
+**O3 — `.opencode/command/otherness.setup.md` Step 4 performs the full sync.**
+Replace the old "skip if exists" loop with the two-way sync (add + remove stale).
+
+**O4 — `.github/workflows/otherness-scheduled.yml` syncs commands after cloning.**
+The scheduled runner starts fresh — it clones `~/.otherness` but the project checkout
+already has `.opencode/command/`. After the clone step, run the sync so the runner
+uses current command files.
+
+**O5 — Non-`otherness.*` files in `.opencode/command/` are never touched.**
+
+**O6 — Design doc 20 marks all items ✅ Present.**
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- CRITICAL-A: standalone.md and bounded-standalone.md changes add executable bash
+  (not [AI-STEP] comments). 5-check self-review. Autonomous merge.
+- Setup and workflow changes: LOW tier.
+- The sync block is identical in all four places — define once, copy.
+
+---
+
+## Zone 3 — Scoped out
+
+- Committing synced files automatically
+- Per-project command customization (different-named files only)

--- a/agents/bounded-standalone.md
+++ b/agents/bounded-standalone.md
@@ -27,6 +27,22 @@ Shape the vision first, then the team will implement.
 ```bash
 git -C ~/.otherness pull --quiet 2>/dev/null || true
 echo "[BOUNDED] Agent files up to date."
+
+# Sync command files from ~/.otherness — two-way: add new, remove stale.
+if [ -d ~/.otherness/.opencode/command ] && [ -d .opencode/command ]; then
+  _SYNCED=0
+  for _src in ~/.otherness/.opencode/command/otherness.*.md; do
+    [ -f "$_src" ] || continue
+    _fname=$(basename "$_src"); _dest=".opencode/command/$_fname"
+    if ! cmp -s "$_src" "$_dest" 2>/dev/null; then cp "$_src" "$_dest"; _SYNCED=1; fi
+  done
+  for _dest in .opencode/command/otherness.*.md; do
+    [ -f "$_dest" ] || continue
+    _fname=$(basename "$_dest")
+    if [ ! -f ~/.otherness/.opencode/command/"$_fname" ]; then rm "$_dest"; _SYNCED=1; fi
+  done
+  [ $_SYNCED -eq 1 ] && echo "[BOUNDED] Command files synced from ~/.otherness."
+fi
 ```
 
 ## Step 2 — Parse boundary from prompt or BOUNDARY file

--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -47,6 +47,25 @@ else
   git -C ~/.otherness pull --quiet 2>/dev/null || true
   echo "[STANDALONE] Agent files up to date (latest)."
 fi
+
+# Sync command files from ~/.otherness — two-way: add new, remove stale.
+# otherness.* files are owned by otherness. Non-otherness.* files are never touched.
+if [ -d ~/.otherness/.opencode/command ] && [ -d .opencode/command ]; then
+  _SYNCED=0
+  # Add or update
+  for _src in ~/.otherness/.opencode/command/otherness.*.md; do
+    [ -f "$_src" ] || continue
+    _fname=$(basename "$_src"); _dest=".opencode/command/$_fname"
+    if ! cmp -s "$_src" "$_dest" 2>/dev/null; then cp "$_src" "$_dest"; _SYNCED=1; fi
+  done
+  # Remove stale
+  for _dest in .opencode/command/otherness.*.md; do
+    [ -f "$_dest" ] || continue
+    _fname=$(basename "$_dest")
+    if [ ! -f ~/.otherness/.opencode/command/"$_fname" ]; then rm "$_dest"; _SYNCED=1; fi
+  done
+  [ $_SYNCED -eq 1 ] && echo "[STANDALONE] Command files synced from ~/.otherness."
+fi
 ```
 
 You are the STANDALONE AGENT — an entire autonomous team in one session.


### PR DESCRIPTION
## Summary

Fixes the broken user experience: `otherness.vibe-vision` not appearing, `otherness.cross-agent-monitor` and `otherness.pause` still present after removal.

**Root cause:** `standalone.md` SELF-UPDATE only pulled `~/.otherness` agent files. It never touched `.opencode/command/` in the project. Commands frozen at initial setup, never updated.

**The fix — added to all 4 entry points:**
- `standalone.md` SELF-UPDATE: two-way sync after git pull
- `bounded-standalone.md`: same
- `otherness.setup.md` Step 4: full sync replaces 'skip if exists'
- `otherness-scheduled.yml`: sync step after clone

**Result:** Every `/otherness.run` on every project auto-syncs commands. New commands appear. Stale ones disappear. Zero user action.

**CRITICAL-A** — standalone.md and bounded-standalone.md add executable bash. 5-check self-review:

1. **SPEC**: O1-O6 all satisfied (two-way sync in all 4 entry points, non-otherness files untouched)
2. **FAILURE MODES**: No `.opencode/command/` directory → guard with `[ -d ... ]`, sync skipped safely. No  files to remove → loop exits cleanly.
3. **GLOBAL DEPLOY**: Existing projects with stale commands get fixed on next session. No data loss. `cmp -s` prevents unnecessary file writes.
4. **SIMPLICITY**: 17 lines of bash added to SELF-UPDATE. Same block in all 4 places.
5. **VISION**: Closes the user experience gap. Commands always match the installed `~/.otherness`.

validate.sh ✅ lint.sh ✅