### PR TITLE
fix(ci): export GIT_TERMINAL_PROMPT=0 in SELF-UPDATE to prevent CI hang

### DIFF
--- a/agents/standalone.md
+++ b/agents/standalone.md
@@ -29,6 +29,10 @@ Shape the vision first, then the team will implement.
 ## SELF-UPDATE
 
 ```bash
+# GIT_TERMINAL_PROMPT=0 prevents git from hanging on credential prompts in CI.
+# On GitHub Actions runners there is no TTY; without this, git pull blocks indefinitely.
+export GIT_TERMINAL_PROMPT=0
+
 # Pin to agent_version if set; otherwise pull latest
 AGENT_VERSION=$(python3 -c "
 import re


### PR DESCRIPTION
## Root cause

Every kardinal-promoter scheduled run since 2026-04-19 17:09 has hung and required manual cancellation.

The pattern in every run log:
```
19:15:01 - opencode session started
19:15:01 - Read otherness-config.yaml
19:15:05 - Bash {"command":"ls ~/.otherness/agents/..."}
19:53:26 - ##[error]The operation was canceled.   ← cancelled by human
```

**What actually happens:** The SELF-UPDATE block runs `git -C ~/.otherness pull --quiet` first. On GitHub Actions runners there is no TTY. Git blocks waiting for a credential prompt that never arrives. The opencode Bash tool has a 2-minute default timeout — after timeout, the agent retries the next command, which also hangs. This cycles for hours.

The log shows `ls ~/.otherness/agents/` because the agent logs the tool call at invocation time, but the previous command (git pull) is still blocking. After ~19 × 2-minute timeouts = 38 minutes, the runner is killed.

## Fix

```bash
export GIT_TERMINAL_PROMPT=0
```

Added as the first line of the SELF-UPDATE bash block. Makes git fail fast instead of blocking. For the public otherness repo: no credentials needed, pull works fine. For private repos on CI: git uses whatever credential helper is pre-configured.

## Risk tier

**CRITICAL-A** — modifies standalone.md (agent loop file). Change is 4 lines, all additive, no logic change. Validated: lint ✅ validate ✅

## [NEEDS HUMAN: critical-tier-change]

Per AGENTS.md policy: CRITICAL tier PRs require human review before merge. Leaving for human review.