### PR TITLE
feat(ci): GH_TOKEN preflight validation in otherness-scheduled.yml

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -43,6 +43,86 @@ jobs:
           git config --global user.name  "otherness[bot]"
           git config --global user.email "otherness[bot]@users.noreply.github.com"
 
+      - name: Validate GH_TOKEN
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Preflight: verify GH_TOKEN is set and valid before any agent work.
+          # On failure: post a [NEEDS HUMAN] issue using GITHUB_TOKEN (always valid)
+          # so the failure is visible even when GH_TOKEN is expired.
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GH_TOKEN secret is not configured on this repository."
+            gh issue create \
+              --repo "$REPO" \
+              --title "[NEEDS HUMAN] GH_TOKEN secret is missing — otherness scheduled run cannot proceed" \
+              --body "## otherness scheduled run: GH_TOKEN not configured
+
+          The \`GH_TOKEN\` secret is required for otherness to push commits, open PRs, and trigger CI.
+          It is not configured on this repository.
+
+          ## What to do
+          1. Create a GitHub PAT with \`repo\` and \`workflow\` scopes.
+          2. Add it as a repository secret named \`GH_TOKEN\`.
+          3. Re-run the workflow via workflow_dispatch to verify.
+
+          See \`docs/design/19-scheduled-execution.md\` §Credential model." \
+              --label "needs-human" 2>/dev/null || \
+            gh issue create \
+              --repo "$REPO" \
+              --title "[NEEDS HUMAN] GH_TOKEN secret is missing — otherness scheduled run cannot proceed" \
+              --body "## otherness scheduled run: GH_TOKEN not configured
+
+          The \`GH_TOKEN\` secret is required for otherness to push commits, open PRs, and trigger CI.
+          It is not configured on this repository.
+
+          ## What to do
+          1. Create a GitHub PAT with \`repo\` and \`workflow\` scopes.
+          2. Add it as a repository secret named \`GH_TOKEN\`.
+          3. Re-run the workflow via workflow_dispatch to verify.
+
+          See \`docs/design/19-scheduled-execution.md\` §Credential model." 2>/dev/null || true
+            exit 1
+          fi
+
+          # Verify the token is valid by calling the API
+          if ! GH_TOKEN="$GH_TOKEN" gh api user --jq '.login' > /dev/null 2>&1; then
+            echo "::error::GH_TOKEN is set but invalid or expired."
+            GH_TOKEN="" gh issue create \
+              --repo "$REPO" \
+              --title "[NEEDS HUMAN] GH_TOKEN has expired — otherness scheduled run cannot proceed" \
+              --body "## otherness scheduled run: GH_TOKEN invalid or expired
+
+          The \`GH_TOKEN\` PAT is set but the GitHub API returned an authentication error.
+          The token has likely expired or been revoked.
+
+          ## What to do
+          1. Generate a new GitHub PAT with \`repo\` and \`workflow\` scopes.
+          2. Update the \`GH_TOKEN\` repository secret with the new token.
+          3. Re-run the workflow via workflow_dispatch to verify.
+
+          See \`docs/design/19-scheduled-execution.md\` §Credential model." \
+              --label "needs-human" 2>/dev/null || \
+            GH_TOKEN="" gh issue create \
+              --repo "$REPO" \
+              --title "[NEEDS HUMAN] GH_TOKEN has expired — otherness scheduled run cannot proceed" \
+              --body "## otherness scheduled run: GH_TOKEN invalid or expired
+
+          The \`GH_TOKEN\` PAT is set but the GitHub API returned an authentication error.
+          The token has likely expired or been revoked.
+
+          ## What to do
+          1. Generate a new GitHub PAT with \`repo\` and \`workflow\` scopes.
+          2. Update the \`GH_TOKEN\` repository secret with the new token.
+          3. Re-run the workflow via workflow_dispatch to verify.
+
+          See \`docs/design/19-scheduled-execution.md\` §Credential model." 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "GH_TOKEN is valid. Proceeding."
+
       - name: Install otherness agent files
         run: |
           git clone --quiet --depth 1 https://github.com/pnz1990/otherness.git ~/.otherness

--- a/.specify/specs/339/spec.md
+++ b/.specify/specs/339/spec.md
@@ -1,0 +1,58 @@
+# Spec: feat(ci): token expiry preflight — validate GH_TOKEN scopes before push
+
+## Design reference
+- **Design doc**: `docs/design/19-scheduled-execution.md`
+- **Section**: `§ Future`
+- **Implements**: Token expiry detection: if `GH_TOKEN` PAT expires, the workflow fails silently on push; add a preflight step that validates the token has required scopes and posts a `[NEEDS HUMAN]` issue on failure (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+**O1 — A preflight step must exist before any agent work steps.**
+A step named "Validate GH_TOKEN" (or equivalent) must appear in `otherness-scheduled.yml`
+before the "Run otherness" step. Violation: no validation step, or validation step
+appears after "Run otherness".
+
+**O2 — The preflight step must detect an expired/invalid token.**
+If `GH_TOKEN` is empty, invalid, or expired, the preflight step must exit with a
+non-zero exit code, causing the job to fail. The step uses `gh auth status` or
+`gh api user` to verify token validity. Violation: step exits 0 on an invalid token.
+
+**O3 — On failure, a `[NEEDS HUMAN]` issue must be posted.**
+If the token check fails, a GitHub issue is created with title containing
+`[NEEDS HUMAN]` and body explaining the PAT has expired. The issue must be created
+using `GITHUB_TOKEN` (the built-in Actions token, always valid) as a fallback,
+NOT `GH_TOKEN` (which is the failing credential). Violation: failure exits without
+creating an issue.
+
+**O4 — On success, subsequent steps continue normally.**
+If token validation passes, the step exits 0 and the job continues to the next step.
+Violation: validation step exits non-zero when token is valid.
+
+**O5 — The step must handle the case where `GH_TOKEN` secret is not configured.**
+If `GH_TOKEN` is empty or not set, the step detects this as a misconfiguration and
+posts a `[NEEDS HUMAN]` issue identifying that the secret is missing. Violation: empty
+`GH_TOKEN` causes an opaque failure instead of a clear error message.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to use `gh auth status` vs `gh api user` for validation: both work; prefer
+  `gh api user` as it directly tests API access and is less verbose.
+- Issue label: `needs-human` if it exists on the repo, otherwise unlabeled (gh issue
+  create fails if label doesn't exist).
+- Whether to check specific scopes (repo, workflow) or just token validity: checking
+  validity is sufficient; scope checking via API is complex and fragile.
+- The preflight step runs before `Configure AWS credentials` — token failure should
+  abort before any AWS setup to keep the failure message clear.
+
+---
+
+## Zone 3 — Scoped out
+
+- Automatic PAT rotation (out of scope per design doc Zone 3)
+- Validating AWS credentials separately (already handled by configure-aws-credentials step)
+- Checking token expiry date proactively (only check validity, not remaining TTL)
+- Sending notifications via Slack, email, or other channels

--- a/docs/design/19-scheduled-execution.md
+++ b/docs/design/19-scheduled-execution.md
@@ -1,6 +1,6 @@
 # 19: Scheduled Execution — The Loop That Never Needs You to Press Play
 
-> Status: Active | Created: 2026-04-19 | Updated: 2026-04-19
+> Status: Active | Created: 2026-04-19 | Updated: 2026-04-20
 > Applies to: otherness itself and all managed projects
 
 ---
@@ -284,12 +284,11 @@ project-specific deployment record.
 - ✅ IAM OIDC provider `token.actions.githubusercontent.com` in account 569190534191 — trust scoped to `pnz1990/*` (2026-04-19)
 - ✅ IAM role `github-bedrock-key` — OIDC trust for `pnz1990/*`, inline `BedrockInvoke` policy (2026-04-19)
 - ✅ kardinal-promoter deployed — hourly cron, all secrets set, PR #828 (2026-04-19)
-
-## Future (🔲)
-
 - ✅ `/otherness.setup` and `/otherness.onboard`: add "activate scheduled loop" section that runs `setup-github-bedrock-key.sh` and copies the workflow template automatically — currently requires manual steps
 - ✅ `scripts/validate.sh`: verify `GH_TOKEN` secret exists on the repo when `schedule.cron` is configured (currently only checks for the workflow file)
-- 🔲 Token expiry detection: if `GH_TOKEN` PAT expires, the workflow fails silently on push; add a preflight step that validates the token has required scopes and posts a `[NEEDS HUMAN]` issue on failure
+- ✅ Token expiry detection: preflight step in `otherness-scheduled.yml` validates `GH_TOKEN` before agent work; posts `[NEEDS HUMAN]` issue via `GITHUB_TOKEN` on missing or invalid token (PR #339, 2026-04-20)
+
+## Future (🔲)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a `Validate GH_TOKEN` step to `otherness-scheduled.yml` that runs before any agent work
- Uses `gh api user` to verify the PAT is valid and set
- On failure: creates a `[NEEDS HUMAN]` GitHub issue using `GITHUB_TOKEN` (built-in, always valid) with clear remediation steps
- Prevents silent mid-run failures when the PAT expires — failure now surfaces immediately with actionable context

## Design doc
Updated `docs/design/19-scheduled-execution.md`: moved Token expiry detection from 🔲 Future to ✅ Present.

## Risk tier
LOW — touches only `.github/workflows/otherness-scheduled.yml` and a design doc. No agent phase files modified.