### PR TITLE
docs(design): anchor framework docs 24/25/26 — project-specific evolution metrics

### DIFF
--- a/docs/design/24-project-anchor-framework.md
+++ b/docs/design/24-project-anchor-framework.md
@@ -1,0 +1,215 @@
+# 24: Project Anchor Framework — Every Project Defines Its Own Evolution Metric
+
+> Status: Active | Created: 2026-04-20
+> Applies to: all projects using otherness
+
+---
+
+## The problem this solves
+
+Counting PRs merged is a proxy metric. It tells you the team is active. It does not
+tell you whether the product is better. A project that merges 50 PRs fixing test
+flakiness has not made the product more capable. A project that merges 3 PRs covering
+a previously untested integration scenario has advanced meaningfully.
+
+The simulation (doc 23) measures team health — the abstract dynamics of boldness,
+skill growth, and convergence that apply to any autonomous agent loop. That is Layer 1.
+
+Layer 2 is missing: is the *product* getting better? That answer is different for
+every project. It cannot be generic. It must be defined by the project.
+
+---
+
+## The two-layer model
+
+```
+Layer 1 — Universal team health (simulation, doc 23)
+  Same for every project. Measures agent loop dynamics.
+  Signals: items/batch, skill growth rate, Type B rate, arch convergence.
+  Tells you: is the team healthy?
+
+Layer 2 — Project anchor (this doc, per-project)
+  Defined per project in AGENTS.md §Anchor and docs/design/<N>-anchor-<name>.md.
+  Measures product evolution — does the product do more than it did last week?
+  Tells you: is the product getting better?
+```
+
+The two layers talk. When Layer 1 shows stall (items/batch below floor), it is
+possible the anchor is the cause — the team is spending cycles on anchor repair
+instead of growth. When Layer 2 shows anchor stagnation (no new coverage in 3
+sessions), COORD generates anchor-growth items before feature items.
+
+---
+
+## What an anchor is
+
+An anchor is a **continuously growing validation suite** that exercises the actual
+product from the outside — the way a real user would. Not unit tests. Not CI passing.
+The real product, doing real things, measured against a growing matrix of scenarios.
+
+An anchor has three properties:
+
+**1. It is executable by the agent without human setup.**
+The agent can trigger it via `gh workflow run`. It runs in CI. It produces a
+machine-readable score. The agent reads that score after each batch.
+
+**2. It grows automatically as features are added.**
+Every new feature creates a corresponding anchor obligation. When the agent
+ships a feature with no anchor coverage, COORD opens an anchor-growth issue
+before the next feature item.
+
+**3. Its growth is the primary measure of project success.**
+Not PR count. Not velocity. Anchor coverage ratio: how many of the product's
+defined capabilities are validated end-to-end.
+
+---
+
+## The feature → anchor gap
+
+The core mechanism that makes this work:
+
+```
+feature registry (design docs ✅ Present items)
+        ↓
+    gap detection (SM §4g variant)
+        ↓
+anchor registry (AGENTS.md §Anchor coverage matrix)
+        ↓
+    uncovered features → anchor-growth issues
+        ↓
+COORD prioritizes anchor-growth above feature queue when coverage < threshold
+```
+
+**Gap detection runs in SM every 10 cycles:**
+1. Read all ✅ Present items from docs/design/*.md — this is the feature registry
+2. Read the anchor coverage matrix from AGENTS.md §Anchor — this is what's validated
+3. For each Present feature with no corresponding anchor entry: open anchor-growth issue
+4. Post coverage ratio: `[SM §4g-anchor] Feature→anchor coverage: N/M (X%)`
+5. If coverage < 80%: COORD gate fires — generate anchor-growth items before feature items
+
+---
+
+## AGENTS.md §Anchor section
+
+Every managed project adds a `## Anchor` section to its AGENTS.md. Structure:
+
+```markdown
+## Anchor
+
+**Anchor type**: <demo | e2e-journey-suite | integration-scenario | benchmark>
+**Coverage target**: ≥ 80% of ✅ Present features validated end-to-end
+**Growth obligation**: every merged feature PR must have a corresponding anchor entry
+  within 2 sessions of merge
+**Run command**: gh workflow run <anchor-workflow>.yml --repo <owner/repo>
+**Score field**: the workflow posts a coverage line to issue #<N> matching:
+  `[ANCHOR] coverage: <N>/<M> (<X>%) scenarios passing`
+**Stagnation threshold**: if anchor score does not improve in 3 consecutive sessions,
+  COORD generates anchor-growth items before any feature items
+
+### Coverage Matrix
+
+| Feature area | Anchor entries | Status |
+|---|---|---|
+| <area> | <N> scenarios | ✅ covered / ⚠️ partial / ❌ none |
+```
+
+---
+
+## otherness-config.yaml anchor fields
+
+```yaml
+anchor:
+  workflow: pdca.yml          # workflow file that runs the anchor
+  score_pattern: "PASS=([0-9]+) FAIL=([0-9]+)"  # regex to extract score from issue comment
+  coverage_target: 80         # minimum % of features that must have anchor coverage
+  stagnation_sessions: 3      # sessions without growth before COORD prioritizes anchor
+  report_issue: 1             # issue where anchor scores are posted
+```
+
+---
+
+## The bottlenecks (N+1, N+2, N+3) — acknowledged and scoped
+
+**N+1: anchor infrastructure reliability.**
+The anchor must run reliably before it can be a growth instrument. Flaky infrastructure
+causes the agent to spend cycles on flakiness triage instead of coverage expansion.
+Mitigation: each project's anchor design doc (docs 25, 26) includes an infrastructure
+reliability section with known flakiness patterns and mitigation requirements.
+
+**N+2: feature→anchor gap detection requires a structured feature registry.**
+The gap detection algorithm reads ✅ Present items from design docs. This only works
+if design docs exist and are maintained. Projects with sparse design docs (kro-ui has
+1) cannot compute coverage ratios until more design docs are written. Mitigation:
+COORD generates design doc stubs for feature areas with no docs, gated by the same
+anchor-growth obligation that generates scenario issues.
+
+**N+3: anchor infrastructure doesn't cover the full product surface.**
+CLI can be tested in bash. UI requires a browser. Concurrent operations require
+parallel runners. Each project's anchor design doc defines which surfaces are covered
+and which are not, with explicit Future items for uncovered surfaces. The anchor grows
+toward completeness rather than claiming completeness it doesn't have.
+
+---
+
+## Present (✅)
+
+- ✅ Simulation (doc 23) — Layer 1 team health, per-project calibration designed (2026-04-20)
+- ✅ SM §4g — codebase hygiene scan, surfaces undocumented files (2026-04-20, PR #347)
+- ✅ kardinal-promoter PDCA workflow — 6 scenarios, weekly execution (2026-04-19)
+- ✅ kro-ui E2E workflow — runs on push/PR, Playwright-based (2026-04-14)
+
+## Future (🔲)
+
+- 🔲 `otherness-config.yaml` + template: add `anchor:` section (workflow, score_pattern, coverage_target, stagnation_sessions)
+- 🔲 `SM §4g-anchor`: feature→anchor gap detection — read Present items, diff against AGENTS.md §Anchor matrix, open anchor-growth issues for uncovered features
+- 🔲 `SM §4g-anchor`: post `[ANCHOR] coverage: N/M (X%)` to report issue after each gap scan
+- 🔲 `COORD §1c`: anchor-growth gate — when coverage < coverage_target, generate anchor-growth items before feature items
+- 🔲 `COORD §1c`: read anchor score from last N report issue comments; if no improvement in stagnation_sessions, trigger anchor-growth queue generation
+- 🔲 `docs/design/25-anchor-kardinal-promoter.md` — kardinal-promoter anchor design (PDCA expansion matrix, CLI/UI surface, infrastructure reliability, feature→scenario gap)
+- 🔲 `docs/design/26-anchor-kro-ui.md` — kro-ui anchor design (E2E journey suite growth, feature→journey coverage, kro API surface, persona coverage)
+- 🔲 `standalone.md` AGENTS.md template: add `## Anchor` section with standard structure
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Anchor growth precedes feature growth when coverage < target.**
+COORD must check anchor coverage before generating the feature queue. A project
+below 80% coverage generates anchor-growth items first. Feature items are generated
+only when coverage is at or above target.
+
+**O2 — Every ✅ Present feature must have an anchor entry within 2 sessions.**
+The gap between shipping a feature and validating it anchors drift. The 2-session
+window prevents unbounded accumulation of unvalidated features.
+
+**O3 — Anchor infrastructure failures are bugs, not noise.**
+When the anchor workflow fails due to infrastructure (flaky cluster, network timeout),
+the agent opens an infrastructure bug with priority/high and does NOT open coverage
+issues. Infrastructure reliability is a precondition for anchor usefulness.
+
+**O4 — The anchor score is posted by the workflow, not computed by the agent.**
+The agent reads scores from the report issue. It does not compute coverage itself.
+This means the anchor workflow is the source of truth, not the agent's interpretation
+of test results.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Coverage target of 80% is a starting point. Projects with mature anchors may raise
+  it. Projects bootstrapping their anchor start lower and raise as coverage grows.
+- The stagnation threshold of 3 sessions is conservative. Adjust per project cadence
+  — hourly sessions may use 5; 6-hour sessions may use 2.
+- Whether to block the feature queue entirely or just deprioritize: start with
+  deprioritize (interleave anchor and feature items) to avoid the queue running dry
+  when a large surface needs coverage.
+
+---
+
+## Zone 3 — Scoped out
+
+- Automated anchor writing (the agent writes scenarios from design docs automatically
+  without human review — deferred; scenarios require product understanding that may
+  exceed current capability)
+- Cross-project anchor comparison (each project anchors independently)
+- Anchor quality scoring (pass/fail ratio is sufficient; complexity scoring deferred)

--- a/docs/design/25-anchor-kardinal-promoter.md
+++ b/docs/design/25-anchor-kardinal-promoter.md
@@ -1,0 +1,268 @@
+# 25: Anchor — kardinal-promoter
+
+> Status: Active | Created: 2026-04-20
+> Applies to: pnz1990/kardinal-promoter
+> Framework: docs/design/24-project-anchor-framework.md
+
+---
+
+## What kardinal-promoter's anchor is
+
+The anchor is the **PDCA validation suite** — a live end-to-end test that exercises
+kardinal-promoter the way a real platform engineer would use it: real cluster, real
+ArgoCD, real application images, real CLI commands, real policy evaluation.
+
+Not unit tests. Not CI. The actual product, doing actual work, measured against a
+growing matrix of real-world scenarios.
+
+**The anchor must grow in two dimensions simultaneously:**
+1. **Coverage width** — more of the product surface is exercised each week
+2. **Scenario depth** — each area is exercised at higher complexity (basic → edge case → adversarial)
+
+A project where anchor width grows but depth stays shallow has coverage theater.
+A project where depth grows but width stagnates has gaps. Both dimensions must advance.
+
+---
+
+## Current state (as of 2026-04-20)
+
+**Anchor workflow:** `.github/workflows/pdca.yml` — runs weekly (Sundays 04:00 UTC) + manual dispatch
+**Also:** `.github/workflows/demo-validate.yml` — runs nightly, broader demo surface
+
+**Current PDCA coverage (6 scenarios):**
+
+| Scenario | Surface | Depth | Status |
+|---|---|---|---|
+| S1: Happy path promotion | CLI + controller | basic | ✅ passing |
+| S2: Pause blocks promotion | CLI + controller | basic | ✅ passing |
+| S3: Weekend gate blocks prod | policy evaluation | basic | ✅ passing |
+| S4: Explain shows gate details | CLI output | basic | ✅ passing |
+| S5: Rollback opens PR | CLI + GitHub | basic | ✅ passing |
+| S6: Concurrent bundles | CLI + controller | intermediate | ✅ passing |
+
+**Coverage score:** 6/? scenarios — denominator is undefined because the full feature
+surface has not been mapped to the anchor matrix. That is the first gap to close.
+
+---
+
+## The feature surface — what needs to be covered
+
+Derived from kardinal-promoter's 10 design docs + CLI surface:
+
+### Surface 1: Promotion mechanics (docs 01, 02, 03, 08)
+| Feature | Current anchor | Gap |
+|---|---|---|
+| Basic bundle create + promote | S1 | ✅ covered |
+| Pause/resume in-flight promotion | S2 | ✅ covered |
+| Rollback | S5 | ✅ covered |
+| Config-only promotions (no image change) | none | ❌ |
+| Multi-stage promotion (test→uat→prod) | S1 partial | ⚠️ partial |
+| Promotion with failing health check | none | ❌ |
+| Bundle supersession when newer image arrives | S6 partial | ⚠️ partial |
+| Promotion with ArgoCD sync timeout | none | ❌ |
+| Distributed architecture (separate control/agent) | none | ❌ |
+
+### Surface 2: Policy gates (doc 04)
+| Feature | Current anchor | Gap |
+|---|---|---|
+| Time-based gate (weekend block) | S3 | ✅ covered |
+| Time-based gate (business hours allow) | S3 partial | ⚠️ partial |
+| Explain shows gate details | S4 | ✅ covered |
+| Policy simulate CLI | S3 | ✅ covered |
+| Multiple gates on same pipeline | none | ❌ |
+| Gate with custom expression | none | ❌ |
+| Gate override (emergency deploy) | none | ❌ |
+
+### Surface 3: Health adapters (doc 05)
+| Feature | Current anchor | Gap |
+|---|---|---|
+| HTTP healthcheck adapter | none | ❌ |
+| Prometheus metrics adapter | none | ❌ |
+| ArgoCD sync status adapter | S1 implicit | ⚠️ implicit |
+| Health check failure blocks promotion | none | ❌ |
+| Health check recovery unblocks promotion | none | ❌ |
+| Custom health adapter configuration | none | ❌ |
+
+### Surface 4: CLI completeness (all docs)
+| Command | Current anchor | Gap |
+|---|---|---|
+| `kardinal create bundle` | S1 | ✅ covered |
+| `kardinal get pipelines` | S1 | ✅ covered |
+| `kardinal pause` / `kardinal resume` | S2 | ✅ covered |
+| `kardinal rollback` | S5 | ✅ covered |
+| `kardinal explain` | S4 | ✅ covered |
+| `kardinal policy simulate` | S3 | ✅ covered |
+| `kardinal get bundles` | none | ❌ |
+| `kardinal delete bundle` | none | ❌ |
+| `kardinal get steps` | none | ❌ |
+| `kardinal describe pipeline` | none | ❌ |
+| `kardinal apply` (config-only) | none | ❌ |
+
+### Surface 5: Real-world complexity (no doc — scenario-driven)
+| Scenario | Current anchor | Gap |
+|---|---|---|
+| 2 concurrent bundles, correct supersession | S6 | ✅ covered |
+| 3+ concurrent bundles | none | ❌ |
+| Promotion during ArgoCD outage | none | ❌ |
+| Clock skew between clusters | none | ❌ |
+| Network partition between control and agent | none | ❌ |
+| App that fails readiness probe | none | ❌ |
+| App with database migration | none | ❌ |
+| SRE persona: full incident response (rollback + policy + explain) | none | ❌ |
+| Developer persona: full feature deploy lifecycle | none | ❌ |
+| Platform engineer persona: multi-env pipeline setup | none | ❌ |
+
+### Surface 6: UI/UX (doc 06)
+| Feature | Current anchor | Gap |
+|---|---|---|
+| Bundle status visible in UI | none | ❌ |
+| Policy gate status in UI | none | ❌ |
+| Rollback button in UI | none | ❌ |
+| Pipeline graph visualization | none | ❌ |
+| All CLI functionality accessible via UI | none | ❌ |
+
+**Note on UI surface:** current PDCA is bash-only. UI coverage requires Playwright
+or a similar browser automation tool. This is an infrastructure gap, not just a
+scenario gap. See Infrastructure section below.
+
+---
+
+## Coverage score formula
+
+```
+coverage_score = (scenarios_passing / total_defined_scenarios) * 100
+
+Current: 6 / ~35 defined = ~17%
+Target: ≥ 80% within 1 quarter
+```
+
+The denominator grows as new scenarios are defined. The score should grow faster
+than the denominator — each session should add more passing scenarios than new
+scenario definitions.
+
+---
+
+## Infrastructure reliability requirements (N+1 bottleneck)
+
+Before the anchor can grow, the infrastructure must be reliable. Observed failure
+modes from PDCA run history:
+
+| Failure mode | Frequency | Mitigation required |
+|---|---|---|
+| kind cluster creation timeout | occasional | Retry logic + timeout increase |
+| ArgoCD sync timeout (app not synced in time) | occasional | Increase wait timeout, add retry |
+| krocodile not ready after helm install | rare | Wait-for-ready probe before tests |
+| `ghcr.io` image pull rate limit | rare | Pre-pull image in setup step |
+| Flaky S1 (controller not reconciling fast enough) | occasional | Increase reconcile wait, add polling |
+
+**Obligation:** before adding scenario N+1, ensure the existing N scenarios pass
+in ≥ 3 consecutive runs without infrastructure failures. Anchor growth on a flaky
+base produces false signals.
+
+**Infrastructure health gate (SM §4g-anchor sub-check):**
+If the last 3 PDCA runs show infrastructure failures (not scenario failures), COORD
+generates infrastructure-fix items before anchor-growth items.
+
+---
+
+## Growth roadmap
+
+### Week 1 (now → +7 days): foundation reliability + coverage to 30%
+- Scenario 7: config-only promotion (no image change)
+- Scenario 8: multi-stage full path (test→uat→prod, all three assertions)
+- Scenario 9: health check failure blocks promotion
+- Scenario 10: `kardinal get bundles` + `kardinal delete bundle` CLI coverage
+- Infrastructure: make PDCA run daily (not weekly), add retry logic to S1
+
+### Month 1 (+30 days): coverage to 60%, depth increase
+- Scenarios 11-15: policy gate completeness (multiple gates, custom expr, override)
+- Scenarios 16-18: health adapter coverage (HTTP, Prometheus, custom)
+- Scenarios 19-21: real-world complexity (3+ concurrent, app readiness failure)
+- Scenarios 22-24: persona journeys (SRE incident, developer feature deploy)
+- Infrastructure: add Playwright to PDCA for UI surface (first 3 UI scenarios)
+
+### Quarter 1 (+90 days): coverage ≥ 80%, full product surface
+- UI coverage complete (all CLI commands accessible via UI)
+- Edge cases: distributed architecture, ArgoCD outage, clock skew
+- All 3 persona journeys: SRE, developer, platform engineer — full lifecycle
+- PDCA runs on every PR that touches controller, CLI, or ArgoCD integration (not just daily)
+
+---
+
+## The anchor score comment format
+
+PDCA posts to issue #1 after every run:
+```
+[ANCHOR | kardinal-promoter | YYYY-MM-DD] coverage: N/M (X%) | PASS=A FAIL=B
+```
+
+The agent reads this pattern to track coverage ratio across sessions.
+
+---
+
+## Present (✅)
+
+- ✅ PDCA workflow — 6 scenarios, weekly execution, posts results to issue #1 (2026-04-19)
+- ✅ Demo-validate workflow — nightly, broader demo surface (2026-04-19)
+- ✅ test infrastructure: kind + krocodile + ArgoCD + kardinal-test-app (2026-04-09)
+
+## Future (🔲)
+
+- 🔲 Anchor score comment format: PDCA posts `[ANCHOR | kardinal-promoter | DATE] coverage: N/M (X%) | PASS=A FAIL=B` to issue #1 after every run
+- 🔲 PDCA runs daily (not weekly) — change cron to `0 2 * * *` matching demo-validate cadence
+- 🔲 Infrastructure reliability: retry logic for S1 reconcile wait + ArgoCD sync timeout increase
+- 🔲 Scenario 7: config-only promotion — `kardinal apply` with no image change, verify PromotionStep created
+- 🔲 Scenario 8: full multi-stage assertion — verify each stage independently (test health ✅, uat health ✅, prod gate ✅)
+- 🔲 Scenario 9: health check failure blocks promotion — deploy app with failing readiness probe, verify promotion pauses
+- 🔲 Scenarios 10-12: CLI completeness — `kardinal get bundles`, `kardinal delete bundle`, `kardinal get steps`
+- 🔲 Scenarios 13-15: policy gate completeness — multiple gates, custom expression, emergency override
+- 🔲 Scenarios 16-18: health adapter coverage — explicit HTTP, Prometheus, and custom adapter scenarios
+- 🔲 Scenarios 19-21: real-world complexity — 3+ concurrent bundles, app readiness failure, SRE rollback+explain flow
+- 🔲 Scenarios 22-24: persona journeys — developer full lifecycle, platform engineer pipeline setup, SRE incident response
+- 🔲 Playwright integration in PDCA — first 3 UI scenarios (bundle status, pipeline graph, rollback button)
+- 🔲 Feature→scenario gap detection: SM §4g-anchor reads ✅ Present items from docs/design/*.md, diffs against this coverage matrix, opens anchor-growth issues for uncovered features
+- 🔲 otherness-config.yaml: `anchor:` section — workflow, score_pattern, coverage_target: 80, stagnation_sessions: 3
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Infrastructure reliability before growth.**
+Before adding scenario N+1, the existing N scenarios must pass in ≥ 3 consecutive runs
+without infrastructure failures. Never grow a flaky anchor.
+
+**O2 — UI surface requires its own infrastructure investment.**
+Playwright must be added to PDCA before any UI scenario can be validated. Do not
+create UI scenarios without the infrastructure to run them.
+
+**O3 — The anchor score comment format is the source of truth.**
+The agent reads coverage from the structured comment, not from parsing workflow logs.
+The PDCA workflow is responsible for posting this comment. Never let the comment
+format drift from the pattern the agent reads.
+
+**O4 — Persona journeys are the highest-value scenarios.**
+A passing S1 (happy path) proves the product works. A passing persona journey
+(SRE incident response end-to-end) proves the product is useful. Persona journeys
+are prioritized over narrow CLI command coverage in the growth roadmap.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to add retries inside the PDCA bash script or at the workflow level:
+  retry at the step level (GitHub Actions `continue-on-error` + explicit re-run)
+  is simpler and more observable than bash retry loops.
+- Whether the UI tests use Playwright embedded in PDCA or a separate workflow:
+  separate is cleaner for isolation but requires two workflows to stay in sync.
+  Start with embedded Playwright in PDCA; split only if test time exceeds 30 minutes.
+- Coverage target of 80% by end of quarter is ambitious given current 17%.
+  Achievable if each session adds 2-3 new passing scenarios.
+
+---
+
+## Zone 3 — Scoped out
+
+- Automated scenario generation from design docs (agent writes scenarios without human review)
+- Performance/load testing scenarios (separate concern)
+- Multi-cluster cross-region scenarios (requires infrastructure not yet available)
+- External integrations (PagerDuty, Slack alerts) — future extension point

--- a/docs/design/26-anchor-kro-ui.md
+++ b/docs/design/26-anchor-kro-ui.md
@@ -1,0 +1,240 @@
+# 26: Anchor — kro-ui
+
+> Status: Active | Created: 2026-04-20
+> Applies to: pnz1990/kro-ui
+> Framework: docs/design/24-project-anchor-framework.md
+
+---
+
+## What kro-ui's anchor is
+
+The anchor is the **E2E journey suite** — Playwright tests running against a real
+kro cluster, exercising every shipped feature through a real browser, measuring
+whether the UI correctly represents what kro is actually doing.
+
+Unlike kardinal-promoter's bash-based PDCA, kro-ui's anchor is already a browser
+automation suite with 71 journey files. The infrastructure exists. The problem is
+not absence — it is that the suite is **reactive**: journeys are added after features
+ship, not as a mandatory growth obligation. There is no coverage ratio tracked. There
+is no mechanism that generates journey-growth issues when a feature has no corresponding
+journey. The anchor exists but is not being treated as one.
+
+**The anchor must grow in three dimensions:**
+1. **Feature→journey parity** — every spec has a corresponding journey file
+2. **Scenario depth** — each journey tests not just "the feature exists" but edge
+   cases, error states, loading states, empty states, accessibility
+3. **kro upstream tracking** — as kro adds new API surface, kro-ui adds coverage
+
+---
+
+## Current state (as of 2026-04-20)
+
+**Anchor workflow:** `.github/workflows/e2e.yml` — runs on every push to main
+and every PR
+**Test framework:** Playwright + Chromium, via `test/e2e/journeys/*.spec.ts`
+**Journey count:** 71 spec files
+**Spec count:** 67 shipped specs
+
+**Coverage score:** 71 journeys / 67 specs = **106%** — but this is misleading.
+Several specs have no journey (gaps), and several journeys cover features not in the
+spec list. The real metric is: of the 67 shipped specs, how many have journeys that
+test edge cases, error states, and not just happy paths?
+
+**Honest assessment:** most journeys test the happy path. Error states, loading
+states, empty states, accessibility, and concurrent operations are sparsely covered.
+Journey count ≠ journey depth.
+
+---
+
+## The two coverage metrics
+
+**Metric 1: Feature→journey parity**
+```
+parity = journeys_with_matching_spec / total_merged_specs * 100
+Current: ~67/67 (apparent parity — actual gaps exist in newer specs 063-070)
+Target: 100% within 1 session of spec merge
+```
+
+**Metric 2: Journey depth score**
+Each journey earns points for:
+- Happy path: 1 point (baseline)
+- Error state (API failure, network error): +1 point
+- Empty state (no resources): +1 point
+- Loading/skeleton state: +1 point
+- Accessibility check (axe, aria): +1 point
+- Edge case (large dataset, long names, special characters): +1 point
+
+```
+depth_score = total_points / (total_journeys * 6) * 100
+Current estimate: ~20-30% (most journeys are happy-path-only)
+Target: ≥ 60% within 1 quarter
+```
+
+The anchor score posted to issue #439 tracks both:
+```
+[ANCHOR | kro-ui | DATE] parity: N/M (X%) | depth: P/Q (Y%) | journeys: J | pass: A fail: B
+```
+
+---
+
+## Feature surface — what needs depth coverage
+
+### Tier 1: Core data display (specs 001-007)
+| Feature | Happy path | Error state | Empty state | Loading | A11y | Edge case |
+|---|---|---|---|---|---|---|
+| RGD list | ✅ | ⚠️ partial | ⚠️ partial | ⚠️ partial | ⚠️ partial | ❌ |
+| RGD DAG | ✅ | ❌ | ❌ | ⚠️ partial | ❌ | ❌ |
+| Instance list | ✅ | ⚠️ partial | ✅ | ⚠️ partial | ⚠️ partial | ❌ |
+| Instance detail (live) | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Context switcher | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Feature flags | ✅ | ❌ | — | — | — | ❌ |
+
+### Tier 2: Advanced features (specs 008-040)
+| Feature | Happy path | Error state | Empty state | Edge case |
+|---|---|---|---|---|
+| Graph diff | ✅ | ❌ | ❌ | ❌ |
+| Collection explorer | ✅ | ❌ | ✅ | ❌ |
+| Multi-cluster overview | ✅ | ❌ | ❌ | ❌ |
+| RGD Designer | ✅ | ⚠️ partial | ❌ | ❌ |
+| RBAC visualizer | ✅ | ❌ | ❌ | ❌ |
+| Smart event stream | ✅ | ❌ | ✅ | ❌ |
+| Per-context metrics | ✅ | ❌ | ❌ | ❌ |
+| Global instance search | ✅ | ❌ | ✅ | ❌ |
+| Cache invalidation on context switch | ✅ | ❌ | — | ❌ |
+
+### Tier 3: kro upstream tracking (specs 046, 063+)
+| kro feature | UI coverage | Journey depth |
+|---|---|---|
+| GraphRevision API (kro v0.9.0) | ✅ journey 063 | shallow |
+| kro v0.9.1 upgrade | ✅ journey 063 | shallow |
+| CEL extensions | ⚠️ partial | shallow |
+| readyWhen conditions | ⚠️ partial | shallow |
+| includeWhen | ✅ | shallow |
+| Fleet reconciling count | ✅ journey 064 | shallow |
+
+### Tier 4: Persona journeys (none exist yet)
+| Persona | Scenario | Status |
+|---|---|---|
+| Operator | Deploy new RGD, verify instances appear, check health | ❌ no journey |
+| Developer | Author RGD in designer, validate, apply to cluster | ❌ no journey |
+| SRE | Cluster degraded — diagnose which RGDs/instances affected | ❌ no journey |
+| Kro contributor | Review upstream fixture alignment, identify drift | ❌ no journey |
+
+---
+
+## The N+1 and N+2 bottlenecks for kro-ui specifically
+
+**N+1: feature→journey gap detection requires structured mapping.**
+The gap detection algorithm (doc 24) reads ✅ Present items from docs/design/*.md.
+kro-ui has 1 design doc. The feature registry lives in AGENTS.md's spec inventory
+table, not in design docs with Present/Future markers. Before gap detection works,
+either: (a) the spec inventory becomes the source of truth for the gap algorithm,
+or (b) design docs are created for major feature areas.
+
+Mitigation: extend the gap detection to also read AGENTS.md spec inventory rows
+where `Merged (PR #N)` — these are the ✅ Present items for kro-ui specifically.
+
+**N+2: depth scoring requires journey analysis.**
+The depth score cannot be computed by reading file names. The algorithm must read
+journey file contents and count which of the 6 depth dimensions are present
+(look for `axe`, `toHaveCount(0)`, error response mocking, etc.).
+This is more complex than the parity check but tractable.
+
+Mitigation: start with parity-only scoring in the anchor comment. Add depth scoring
+in a second pass once parity is near 100%.
+
+---
+
+## Growth roadmap
+
+### Week 1: parity for specs 063-070
+- Journey depth audit: identify which of the last 10 journeys are happy-path-only
+- Add error state to journeys 063, 064, 065, 066 (kro v0.9.1 features)
+- Anchor score comment: post `[ANCHOR | kro-ui]` to issue #439 after each E2E run
+
+### Month 1: depth to 50% + first persona journeys
+- Error states for Tier 1 core features (RGD list, DAG, instance detail)
+- Empty states for context switcher, RGD designer, graph diff
+- First persona journey: Operator — deploy RGD, verify instances, check health
+- Accessibility audit: run axe on all Tier 1 pages, fix violations, add axe assertions
+  to existing journeys
+
+### Quarter 1: depth ≥ 60% + full persona coverage + kro upstream tracking
+- All Tier 1 and Tier 2 features have error + empty state coverage
+- All 4 persona journeys: operator, developer, SRE, kro contributor
+- kro upstream tracking: when a new kro version lands, a journey exists within 2 sessions
+- kro API surface coverage metric: what % of kro CRD fields are exercised in journeys
+
+---
+
+## The anchor score comment format
+
+After each E2E run, post to issue #439:
+```
+[ANCHOR | kro-ui | YYYY-MM-DD] parity: N/M (X%) | depth: P/Q (Y%) | journeys: J | pass: A fail: B
+```
+
+Until depth scoring is implemented, use:
+```
+[ANCHOR | kro-ui | YYYY-MM-DD] journeys: J | pass: A fail: B
+```
+
+---
+
+## Present (✅)
+
+- ✅ E2E workflow: `.github/workflows/e2e.yml` — Playwright, runs on push/PR (2026-04-14)
+- ✅ 71 journey files covering 67 merged specs — high parity (2026-04-20)
+- ✅ Journey infrastructure: kind-less (uses mock fixtures), fast, reliable (2026-04-14)
+- ✅ Constitution §XIV E2E standards — anti-patterns documented (PR #311, 2026-04-15)
+
+## Future (🔲)
+
+- 🔲 Anchor score comment: E2E workflow posts `[ANCHOR | kro-ui | DATE] journeys: J | pass: A fail: B` to issue #439
+- 🔲 Feature→journey parity check: SM §4g-anchor reads AGENTS.md spec inventory (Merged rows), diffs against journey file names, opens anchor-growth issues for specs with no journey
+- 🔲 Journey depth: add error state coverage to journeys 063-070 (kro v0.9.1 features)
+- 🔲 Journey depth: add error + empty state to all Tier 1 journeys (001-007)
+- 🔲 First persona journey: Operator — deploy RGD via designer, verify instances appear, check health indicators
+- 🔲 Accessibility: run axe assertions on Tier 1 pages (RGD list, DAG, instance list, context switcher)
+- 🔲 kro upstream tracking: when kro version bumps, SM opens anchor-growth issue for new API surface
+- 🔲 otherness-config.yaml: `anchor:` section — score_pattern for `[ANCHOR | kro-ui]`, coverage_target: 60, stagnation_sessions: 5
+- 🔲 docs/design/: add design docs for major feature areas (RGD display, instance management, health system, designer) to enable generic gap detection
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Every merged spec has a journey within 2 sessions.**
+Parity must be maintained. A spec with no journey is an untested feature.
+
+**O2 — Happy-path-only journeys count as half-coverage.**
+A journey that only tests success is better than no journey but does not count as
+full coverage. Depth is part of the anchor obligation, not optional polish.
+
+**O3 — kro upstream changes trigger anchor obligations.**
+Every kro version upgrade opens an anchor-growth issue for new API surface. The
+journey suite must track the upstream, not lag behind it.
+
+**O4 — The journey infrastructure must stay reliable.**
+Constitution §XIV anti-patterns are obligations. Violations must be fixed before
+new journeys are added — a flaky existing journey degrades the whole anchor.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Journey depth scoring algorithm: start simple (grep for `axe`, error mock patterns,
+  `toHaveCount(0)`) rather than AST parsing. Refine if false positives are significant.
+- Whether to use axe-playwright or custom aria checks: axe-playwright is standard
+  and already referenced in Constitution §XIV. Use it.
+- Persona journey complexity: start with the simplest persona (Operator happy path)
+  before adding complex multi-step SRE scenarios.
+
+---
+
+## Zone 3 — Scoped out
+
+- Visual regression testing (screenshot diffing) — deferred, high maintenance cost
+- Performance journey tests (LCP, FCP metrics) — future extension point
+- Multi-cluster E2E with real clusters (current fixtures simulate multiple clusters)
+- Cross-browser testing beyond Chromium — out of scope for kro-ui donation readiness


### PR DESCRIPTION
## Summary

Three design docs that define how every project measures its own evolution — separate from the universal simulation layer (doc 23).

## Why N+1/N+2/N+3 thinking matters here

Before writing these docs I traced the full bottleneck chain:

**N+1:** Add anchor obligation → agent needs to RUN the anchor → demo/PDCA infrastructure is occasionally flaky → agent spends cycles on flakiness instead of growth → **doc 25 documents the reliability requirement as an obligation before growth**

**N+2:** Fix infrastructure → agent needs to know WHAT to add next → no machine-readable feature→anchor mapping exists → **doc 24 defines the gap detection algorithm; doc 25/26 define the per-project feature registry**

**N+3:** Know what to add → infrastructure doesn't cover the full surface (PDCA is bash-only, no UI) → **doc 25 documents Playwright as a required Future item; doc 26 already has Playwright and documents depth scoring**

## doc 24 — Project Anchor Framework (universal)
- Two-layer model: simulation (team health) + anchor (product evolution)
- Feature→anchor gap detection algorithm (SM §4g-anchor)
- COORD anchor-growth gate: coverage < 80% → generate anchor items before features
- otherness-config.yaml  section spec
- AGENTS.md §Anchor template

## doc 25 — Anchor: kardinal-promoter
- Full feature surface mapped across 6 dimensions (promotion, policy, health, CLI, real-world, UI)
- Current coverage: 6/~35 scenarios = 17%
- Growth roadmap: week 1 (30%), month 1 (60%), quarter (80%+)
- Infrastructure reliability requirements before growth

## doc 26 — Anchor: kro-ui
- Two coverage metrics: parity (71/67 = ~100%) AND depth (~25%)
- Depth scoring: 6-dimension matrix per journey
- N+1 fix: gap detection reads AGENTS.md spec inventory, not design docs
- 4 persona journeys needed: operator, developer, SRE, kro contributor
- kro upstream tracking obligation