### PR TITLE
docs(security): note M5 Bedrock ARN restriction deferred

### DIFF
--- a/docs/design/27-security-model.md
+++ b/docs/design/27-security-model.md
@@ -535,7 +535,8 @@ The following are accepted design tradeoffs, not failures:
 - 🔲 M6: Add `agents_path` allowlist validation in workflow prompt section (1 line bash check)
 - 🔲 M7: Add branch protection to `_state` branches on all 3 repos (restrict to App push after M3)
 - 🔲 M8: AGENTS.md change detection CI check — block non-collaborator AGENTS.md modifications
-- 🔲 M5: Restrict Bedrock IAM `Resource` from `*` to specific model ARNs; add AWS Budget alert at $50/day
+- ✅ M5: AWS Budget alert at $50/day Bedrock spend — posted to rrroizma@amazon.com (2026-04-20)
+- 🔲 M5b: Restrict Bedrock Resource to specific ARNs — DEFERRED. opencode uses cross-region inference profile ARNs (arn:aws:bedrock:<region>:<acct>:inference-profile/*) that vary by model version. Resource:* with Budget alert is the current mitigaton. Revisit when ARN patterns stabilize.
 - 🔲 M3: Replace GH_TOKEN PAT with GitHub App — per-repo scoped, non-exportable, auditable
 - 🔲 M10: Issue label restriction workflow — prevent external contributors adding `otherness` label
 


### PR DESCRIPTION
opencode uses inference-profile ARNs that don't match foundation-model format. Resource:* reverted. Budget alert remains.