### PR TITLE
fix(pm): resolve §5f merge conflict + implement executable doc health scan

### DIFF
--- a/.specify/specs/208/spec.md
+++ b/.specify/specs/208/spec.md
@@ -1,0 +1,35 @@
+# Spec: PM §5f Documentation Health Scan + Merge Conflict Fix
+
+## Design reference
+- **Design doc**: `docs/design/04-documentation-health.md`
+- **Section**: `§ Present — PM §5f periodic doc health scan`
+- **Implements**: Fix corrupted §5f merge conflict markers + add executable implementation; add lint check for conflict markers (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+**O1** — `agents/phases/pm.md` must NOT contain any git merge conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>>`). Violation: grep finds these patterns.
+
+**O2** — `agents/phases/pm.md` §5f must contain executable python3 code (not `[AI-STEP]` comments) that: (a) reads merged PR titles, (b) scans `docs/design/*.md` for Present items without `(PR #N)` references, (c) scans for Future items matching merged PR titles, (d) checks freshness (>60d). Violation: §5f contains only comments with no executable `python3 - <<'...'` block.
+
+**O3** — `scripts/lint.sh` must detect and fail on git merge conflict markers in any file under `agents/`. Violation: running lint.sh on a file with `<<<<<<< HEAD` returns exit 0.
+
+**O4** — `docs/design/04-documentation-health.md` Present items for §5f must include a PR reference for this fix. Violation: PR reference absent.
+
+**O5** — All validate and lint checks pass in the worktree. Violation: non-zero exit.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- The python3 block in §5f uses subprocess to call `gh`, consistent with all other phase python3 blocks.
+- Duplicate suppression uses the open_if_absent pattern (search for open issue with matching title prefix before creating).
+- Freshness threshold: 60 days (per design doc Zone 2).
+
+---
+
+## Zone 3 — Scoped out
+
+- Cross-checking README/AGENTS.md claims (separate item 254)
+- Per-PR CI lint for conflict markers (only lint.sh coverage in scope)

--- a/agents/phases/pm.md
+++ b/agents/phases/pm.md
@@ -297,7 +297,6 @@ gh issue comment $REPORT_ISSUE --repo $REPO \
 
 ---
 
-<<<<<<< HEAD
 ## 5f. Documentation health scan + freshness check (runs every N_PM_CYCLES)
 
 Verify `docs/design/` files reflect reality: Present items have PR references,
@@ -308,60 +307,107 @@ Opens `kind/docs` issues for each gap. No file writes — issues only.
 if [ $((${PM_CYCLE:-0} % ${N_PM_CYCLES:-3})) -eq 0 ]; then
   echo "[PM §5f] Running documentation health scan..."
 
-  # [AI-STEP]
-  # Step 0: Graceful fallback if no design docs exist.
-  #   if [ ! -d "docs/design" ] || [ -z "$(ls docs/design/*.md 2>/dev/null)" ]; then
-  #     echo "[PM §5f] No design docs found — skipping."; skip
-  #   fi
-  #
-  # Step 1: Fetch merged PR titles once (reused across all steps).
-  #   MERGED_TITLES=$(gh pr list --repo $REPO --state merged --limit 200 \
-  #     --json title --jq '.[].title' 2>/dev/null | tr '[:upper:]' '[:lower:]')
-  #
-  # Step 2: For each docs/design/*.md file (duplicate-suppressed — open_if_absent):
-  #
-  #   2a. Check ✅ Present items for (PR #N) references.
-  #     present_items = re.findall(r'^- ✅ (.+)', content, re.MULTILINE)
-  #     for item in present_items:
-  #       if not re.search(r'\(PR #\d+', item):
-  #         title = f"docs: {fname} Present item missing PR reference: {item[:60]}"
-  #         open_if_absent(title, "kind/docs,otherness")
-  #
-  #   2b. Check 🔲 Future items not silently shipped.
-  #     future_items = re.findall(r'^- 🔲 (?!.*🚫)(.+)', content, re.MULTILINE)
-  #     for item in future_items:
-  #       desc_key = item[:60].lower().strip()
-  #       if any(desc_key in pr for pr in MERGED_TITLES.splitlines()):
-  #         title = f"docs: {fname} Future item may be shipped but not marked Present: {item[:60]}"
-  #         open_if_absent(title, "kind/docs,otherness")
-  #
-  # Step 3: Duplicate suppression helper.
-  #   def open_if_absent(title, labels):
-  #     r = subprocess.run(['gh','issue','list','--repo',REPO,'--state','open',
-  #                         '--search',title[:60],'--json','number','--jq','length'],
-  #                        capture_output=True, text=True)
-  #     if int(r.stdout.strip() or '0') == 0:
-  #       subprocess.run(['gh','issue','create','--repo',REPO,
-  #                       '--title',title,'--label',labels,'--body',
-  #                       f'PM §5f health scan finding: {title}'], capture_output=True)
-  #
-  # Step 4: Post summary comment.
-  #   gh issue comment $REPORT_ISSUE --repo $REPO \
-  #     --body "[📋 PM §5f | $MY_SESSION_ID] Health scan complete. <N> issues opened."
-  #
-  # Step 5: Design doc freshness check (stale docs = no updates in >60 days).
-  #   STALE_DAYS=60
-  #   NOW=$(date +%s)
-  #   for each docs/design/*.md file:
-  #     LAST_MODIFIED=$(git log -1 --format=%ct -- "docs/design/$fname" 2>/dev/null || echo "")
-  #     if [ -z "$LAST_MODIFIED" ]: skip (no git history)
-  #     AGE_DAYS=$(( (NOW - LAST_MODIFIED) / 86400 ))
-  #     if [ AGE_DAYS -gt STALE_DAYS ]:
-  #       title = "docs: design doc $fname may be stale — no updates in ${AGE_DAYS} days"
-  #       open_if_absent(title, "kind/docs,otherness,priority/low")
+  python3 - <<'SCAN_EOF'
+import subprocess, re, os, sys
+
+REPO = os.environ.get('REPO', '')
+MY_SESSION_ID = os.environ.get('MY_SESSION_ID', 'sess-unknown')
+REPORT_ISSUE = os.environ.get('REPORT_ISSUE', '')
+
+# Step 0: Graceful fallback if no design docs exist.
+design_dir = 'docs/design'
+if not os.path.isdir(design_dir) or not any(f.endswith('.md') for f in os.listdir(design_dir)):
+    print("[PM §5f] No design docs found — skipping.")
+    sys.exit(0)
+
+# Step 1: Fetch merged PR titles once.
+try:
+    merged_titles = subprocess.check_output(
+        ['gh','pr','list','--repo',REPO,'--state','merged','--limit','200',
+         '--json','title','--jq','.[].title'], text=True).lower().splitlines()
+except Exception:
+    merged_titles = []
+
+issues_opened = 0
+
+def open_if_absent(title, labels):
+    global issues_opened
+    try:
+        r = subprocess.run(
+            ['gh','issue','list','--repo',REPO,'--state','open',
+             '--search', title[:60], '--json','number','--jq','length'],
+            capture_output=True, text=True)
+        if int(r.stdout.strip() or '0') == 0:
+            subprocess.run(
+                ['gh','issue','create','--repo',REPO,
+                 '--title', title, '--label', labels,
+                 '--body', f'## Design reference\n- **Design doc**: `docs/design/04-documentation-health.md`\n- **Implements**: O1/O2 health scan obligations\n\nPM §5f health scan finding:\n\n{title}'],
+                capture_output=True)
+            issues_opened += 1
+            print(f"[PM §5f] Opened: {title[:80]}")
+    except Exception as e:
+        print(f"[PM §5f] open_if_absent error: {e}")
+
+# Step 2: Scan each design doc.
+for fname in sorted(os.listdir(design_dir)):
+    if not fname.endswith('.md'): continue
+    try:
+        content = open(f'{design_dir}/{fname}').read()
+    except Exception:
+        continue
+
+    # 2a. Check ✅ Present items for (PR #N) references.
+    present_items = re.findall(r'^- ✅ (.+)', content, re.MULTILINE)
+    for item in present_items:
+        if not re.search(r'\(PR #\d+', item):
+            title = f"docs: {fname} Present item missing PR ref: {item[:55]}"
+            open_if_absent(title, 'kind/docs,otherness')
+
+    # 2b. Check 🔲 Future items not silently shipped.
+    future_items = re.findall(r'^- 🔲 (?!.*🚫)(.+)', content, re.MULTILINE)
+    for item in future_items:
+        desc_key = item[:60].lower().strip()
+        if any(desc_key in pr for pr in merged_titles):
+            title = f"docs: {fname} Future item may be shipped but not marked Present: {item[:50]}"
+            open_if_absent(title, 'kind/docs,otherness')
+
+# Step 5: Design doc freshness check (stale docs = no updates in >60 days).
+import time
+STALE_DAYS = 60
+NOW = time.time()
+for fname in sorted(os.listdir(design_dir)):
+    if not fname.endswith('.md'): continue
+    try:
+        r = subprocess.run(
+            ['git','log','-1','--format=%ct','--','f{design_dir}/{fname}'.replace('f','')],
+            capture_output=True, text=True)
+        r2 = subprocess.run(
+            ['git','log','-1','--format=%ct','--', f'{design_dir}/{fname}'],
+            capture_output=True, text=True)
+        ts = r2.stdout.strip()
+        if not ts: continue
+        age_days = int((NOW - int(ts)) / 86400)
+        if age_days > STALE_DAYS:
+            title = f"docs: {fname} may be stale — no updates in {age_days} days"
+            open_if_absent(title, 'kind/docs,otherness,priority/low')
+    except Exception:
+        continue
+
+# Step 4: Post summary comment.
+if REPORT_ISSUE:
+    subprocess.run(
+        ['gh','issue','comment',REPORT_ISSUE,'--repo',REPO,
+         '--body', f'[📋 PM §5f | {MY_SESSION_ID}] Health scan complete. {issues_opened} issues opened.'],
+        capture_output=True)
+
+print(f"[PM §5f] Documentation health scan complete. {issues_opened} issues opened.")
+SCAN_EOF
 
   echo "[PM §5f] Documentation health scan complete."
-=======
+fi
+```
+
+---
 ## 5g. Simulation health score + self-correction (runs every N_PM_CYCLES)
 
 Produce GREEN/AMBER/RED health signal. AMBER auto-triggers /otherness.learn.

--- a/docs/design/04-documentation-health.md
+++ b/docs/design/04-documentation-health.md
@@ -32,8 +32,8 @@ generically, for any project using otherness.
 - ✅ Deprecated marker `🚫` — COORD queue-gen skips `🔲` items containing `🚫` (PR #209, 2026-04-17)
 - ✅ Self-seeding check in COORD startup — §1b vision check: opens [NEEDS HUMAN] issue once when docs/aide/vision.md absent, proceeds with empty queue (PR #244, 2026-04-18)
 - ✅ Codebase hygiene scan — SM §4g: scans agents/*.md and scripts/*.{sh,py} every 20 SM cycles; files with no design doc coverage get kind/chore issues; duplicate-suppressed; graceful fallback (PR #258, 2026-04-18)
-- ✅ PM §5f: periodic doc health scan — Steps 0-5: Present item PR ref check, Future item shipping check, freshness metric (>60d stale); duplicate-suppressed; graceful fallback (PR #287 integration, 2026-04-19)
-- ✅ Design doc freshness metric — Step 5 in PM §5f: git log age per design doc, stale docs get kind/docs issue; PR #287 integration, 2026-04-19)
+- ✅ PM §5f: periodic doc health scan — Steps 0-5: Present item PR ref check, Future item shipping check, freshness metric (>60d stale); duplicate-suppressed; graceful fallback; merge conflict resolved (PR #287 integration, 2026-04-19; fix PR #208, 2026-04-20)
+- ✅ Design doc freshness metric — Step 5 in PM §5f: git log age per design doc, stale docs get kind/docs issue (PR #287 integration, 2026-04-19; fix PR #208, 2026-04-20)
 - ✅ Codebase hygiene scan — SM §4g: every 20 cycles, agents/+scripts/ coverage check; PR #287 integration, 2026-04-19)
 - ✅ Self-seeding check in COORD startup — §1b vision check gate; PR #244, 2026-04-18)
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -47,6 +47,19 @@ if b'\x00' in content:
     ERRORS=$((ERRORS+1))
   fi
 
+  # Check for git merge conflict markers
+  if python3 -c "
+import sys, re
+content = open('$file').read()
+if re.search(r'^<{7} |^={7}$|^>{7} ', content, re.MULTILINE):
+    sys.exit(1)
+" 2>/dev/null; then
+    :
+  else
+    echo "  ERROR: $filename contains git merge conflict markers"
+    ERRORS=$((ERRORS+1))
+  fi
+
 done
 
 # Check that standalone.md has the required phase headers


### PR DESCRIPTION
## Summary

- Fixes committed merge conflict markers (`<<<<<<< HEAD` / `=======` with no `>>>>>>>`) in `agents/phases/pm.md`
- Replaces `[AI-STEP]` comments in §5f with executable `python3` block (Present item PR ref check, Future item shipping detection, freshness check >60d)
- Adds merge conflict marker lint check to `scripts/lint.sh` to prevent recurrence

## Design doc

Updated `docs/design/04-documentation-health.md`: PM §5f present item PR references updated.

## Risk tier

CRITICAL — touches `agents/phases/pm.md`.

Diff classification: `git diff` contains executable python3 added/modified → CRITICAL-A.
`AUTONOMOUS_MODE=true` → proceeding with 5-check self-review.

## Self-review (CRITICAL-A, 5 checks)

- [x] No hardcoded project paths in added code
- [x] Graceful fallback if docs/design/ absent (sys.exit(0))
- [x] Self-update present in standalone.md (unchanged)
- [x] State write pattern unchanged
- [x] All tests pass (validate.sh + lint.sh green in worktree)

[NEEDS HUMAN: critical-tier-change]