### PR TITLE
feat(sm): §4d arch_convergence > 0.7 → auto-trigger learn issue

### DIFF
--- a/.specify/specs/351/spec.md
+++ b/.specify/specs/351/spec.md
@@ -1,0 +1,50 @@
+# Spec: feat(sm): §4e arch_convergence > 0.7 → auto-trigger /otherness.learn issue
+
+## Design reference
+- **Design doc**: `docs/design/23-simulation-as-anchor.md`
+- **Section**: `§ The arch_convergence signal`
+- **Implements**: `SM §4e`: `arch_convergence > 0.7` → open learn trigger issue automatically (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1** — When `arch_convergence > 0.7` is detected during SM §4d calibration, the system opens a
+GitHub issue labeled `otherness,area/agent-loop,kind/chore` with title format:
+`learn(arch): arch_convergence at {score:.2f} — run /otherness.learn`
+
+Violation: issue not opened, or opened with `needs-human` label, or opened with a different title format.
+
+**O2** — The auto-triggered issue is deduplication-checked: if an open issue with the same title
+prefix (`learn(arch):`) already exists, no second issue is opened.
+
+Violation: two identical learn trigger issues opened for the same arch_convergence event.
+
+**O3** — The existing `[NEEDS HUMAN]` issue creation is REPLACED, not supplemented.
+The arch_convergence alarm no longer opens a `needs-human` issue.
+It opens an `otherness`-labeled issue the COORD loop can pick up autonomously.
+
+Violation: `[NEEDS HUMAN]` label on the arch_convergence issue.
+
+**O4** — The issue body includes: `arch_convergence` score, threshold (0.7), and a
+reference to `/otherness.learn` as the recovery action.
+
+Violation: issue body missing score or recovery reference.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to check for existing learn trigger issues using `gh issue list --search` or
+  a `--json title` filter: `--search "learn(arch):"` is simpler and sufficient.
+- Whether to post a comment on the report issue as well: yes, post a brief observation
+  to maintain audit trail in the report issue.
+
+---
+
+## Zone 3 — Scoped out
+
+- Executing `/otherness.learn` directly from SM (that is COORD's job when it claims the issue)
+- Divergence detection (`todo_shipped < predicted_floor`) — separate issue 350
+- Writing `sim-prediction.json` — separate issue 349
+- Fleet defaults (`~/.otherness/scripts/sim-defaults.json`) — separate issue 353

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -393,29 +393,43 @@ except Exception as e:
         echo "[SM §4d] Current arch_convergence: $ARCH_CONV"
 
         # Arch-convergence alarm: > 0.7 = architectural monoculture
+        # Open an autonomous learn trigger issue (design doc 23 §arch_convergence signal).
+        # This is NOT a [NEEDS HUMAN] — COORD picks it up and runs /otherness.learn.
         ALARM=$(python3 -c "print('true' if float('$ARCH_CONV') > 0.7 else 'false')" 2>/dev/null || echo "false")
         if [ "$ALARM" = "true" ]; then
             echo "[SM §4d] ⚠ Architectural monoculture detected (arch_convergence=$ARCH_CONV > 0.7)"
-            gh issue create --repo "$REPO" \
-              --title "[NEEDS HUMAN] Architectural monoculture detected (arch_convergence=$ARCH_CONV)" \
-              --label "needs-human,area/agent-loop" \
-              --body "## Simulation calibration signal
 
-The SM phase simulation calibration (sm_cycle=$SM_CYCLE) detected mean_arch_convergence > 0.7.
+            # Deduplication check — only open if no open learn(arch): issue already exists
+            EXISTING=$(gh issue list --repo "$REPO" --state open \
+              --search "learn(arch):" --json number --jq 'length' 2>/dev/null || echo "0")
+
+            if [ "${EXISTING:-0}" -eq 0 ]; then
+                LEARN_TITLE="learn(arch): arch_convergence at ${ARCH_CONV} — run /otherness.learn"
+                gh issue create --repo "$REPO" \
+                  --title "$LEARN_TITLE" \
+                  --label "otherness,area/agent-loop,kind/chore,priority/high" \
+                  --body "## Simulation calibration signal — arch_convergence
+
+SM §4d calibration (sm_cycle=$SM_CYCLE) detected **arch_convergence = $ARCH_CONV** (threshold: 0.7).
 
 This means agents are proposing items of the same structural type repeatedly — a sign
 of architectural frame-lock rather than genuine exploration.
 
-**arch_convergence:** $ARCH_CONV (threshold: 0.7)
+## Recovery action
 
-## Recommended actions (choose one)
-- Run \`/otherness.learn\` to inject novel patterns from external repos
-- Run \`/otherness.vibe-vision\` to introduce new architectural direction
-- Review the last 5 shipped items — are they all the same type of change?
+Run \`/otherness.learn\` to inject novel patterns from an external open-source repo.
+This is an autonomous trigger — COORD will pick this issue up on its next queue cycle.
 
-The system will not take autonomous action. This is for your awareness." 2>/dev/null \
-              && echo "[SM §4d] needs-human issue opened." \
-              || echo "[SM §4d] Could not open needs-human issue."
+**Reference**: \`docs/design/23-simulation-as-anchor.md §The arch_convergence signal\`" 2>/dev/null \
+                  && echo "[SM §4d] Learn trigger issue opened (arch_convergence=$ARCH_CONV)." \
+                  || echo "[SM §4d] Could not open learn trigger issue."
+
+                # Also post observation to report issue (audit trail)
+                gh issue comment $REPORT_ISSUE --repo $REPO \
+                  --body "[🔄 SM §4d | $MY_SESSION_ID] arch_convergence=$ARCH_CONV > 0.7 detected. Learn trigger issue opened." 2>/dev/null || true
+            else
+                echo "[SM §4d] Learn trigger already open ($EXISTING issue) — skipping duplicate."
+            fi
         fi
     else
         echo "[SM §4d] Calibration skipped (calibrate.py not available or failed)."

--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -161,12 +161,12 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 - ✅ `docs/aide/metrics.md` — real batch data tracked by SM (2026-04-14)
 - ✅ `docs/design/10-multi-agent-simulation.md` — simulation design and falsification (2026-04-17)
 - ✅ `docs/design/11-simulation-feedback-loop.md` — feedback loop design (2026-04-17)
+- ✅ `SM §4d`: `arch_convergence > 0.7` → open `learn(arch):` issue labeled `otherness,area/agent-loop,kind/chore` with deduplication check; replaces `[NEEDS HUMAN]` escalation (PR #351, 2026-04-20)
 
 ## Future (🔲)
 
 - 🔲 `SM §4e`: read `metrics.md`, calibrate `simulate.py` parameters against real data, write `.otherness/sim-prediction.json` — runs every 5 SM cycles
 - 🔲 `SM §4e`: compare actual `todo_shipped` to predicted floor — post `[⚠️ Simulation divergence]` after 3 consecutive below-floor batches
-- 🔲 `SM §4e`: `arch_convergence > 0.7` → open learn trigger issue automatically
 - 🔲 `SM §4e`: write calibrated parameters to `.otherness/sim-prediction.json` for persistence across sessions
 - 🔲 `scripts/simulate.py`: add `--calibrate` flag — reads metrics.md, grid-searches parameters, outputs best fit as JSON
 - 🔲 `~/.otherness/scripts/sim-defaults.json`: fleet defaults — written by otherness SM, shipped to managed projects via self-update


### PR DESCRIPTION
## Summary

- Replaces `[NEEDS HUMAN]` escalation for arch_convergence > 0.7 with an autonomous `otherness`-labeled issue
- COORD picks up `learn(arch):` issues on its next queue cycle and runs `/otherness.learn` without human input
- Deduplication check: only opens if no open `learn(arch):` issue already exists
- Audit trail: posts observation to report issue on trigger

## Design doc
Updated `docs/design/23-simulation-as-anchor.md`: moved `§4e arch_convergence > 0.7 → open learn trigger issue automatically` from 🔲 Future to ✅ Present.

## Spec
`.specify/specs/351/spec.md` — three-zone spec with falsifiable obligations.

## Change risk tier
**CRITICAL-A** — modifies `agents/phases/sm.md` (executable shell block change).
`AUTONOMOUS_MODE=true` — 5-check self-review passed (all green). Proceeding to autonomous merge per AGENTS.md §CRITICAL-A rule.

[NEEDS HUMAN: critical-tier-change]