### PR TITLE
feat(config): add anchor: section to otherness-config.yaml

### DIFF
--- a/.specify/specs/357/spec.md
+++ b/.specify/specs/357/spec.md
@@ -1,0 +1,45 @@
+# Spec: feat(config): add anchor: section to otherness-config.yaml and template
+
+## Design reference
+- **Design doc**: `docs/design/24-project-anchor-framework.md`
+- **Section**: `§ otherness-config.yaml anchor fields`
+- **Implements**: `otherness-config.yaml` + template: add `anchor:` section (workflow, score_pattern, coverage_target, stagnation_sessions) (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1** — `otherness-config.yaml` gains an `anchor:` section with these fields (commented-out
+by default, since otherness itself has no anchor workflow):
+- `workflow`: filename of the workflow that runs the anchor
+- `score_pattern`: regex to extract pass/fail counts from issue comment
+- `coverage_target`: integer, minimum % coverage
+- `stagnation_sessions`: integer, sessions without growth before anchor prioritization
+
+Violation: any of the 4 fields missing from the section.
+
+**O2** — `otherness-config-template.yaml` gains the same `anchor:` section (also commented-out,
+since new projects start without an anchor), with documentation comments explaining each field.
+
+Violation: template not updated.
+
+**O3** — The existing fields in both files are not modified. Only additive changes.
+
+Violation: any existing field removed or changed.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to include `report_issue` field: the design doc shows it but it defaults to the
+  project's main REPORT_ISSUE. Omit from the config to avoid duplication.
+- Comment style: use `#` comments, consistent with existing config style.
+- Placement: add after `monitor:` section in both files.
+
+---
+
+## Zone 3 — Scoped out
+
+- SM §4g-anchor (gap detection) — separate issue 355
+- COORD §1c anchor-growth gate — separate issue 356
+- Implementing the anchor workflow itself — out of scope for this project

--- a/docs/design/24-project-anchor-framework.md
+++ b/docs/design/24-project-anchor-framework.md
@@ -157,10 +157,11 @@ toward completeness rather than claiming completeness it doesn't have.
 - ✅ SM §4g — codebase hygiene scan, surfaces undocumented files (2026-04-20, PR #347)
 - ✅ kardinal-promoter PDCA workflow — 6 scenarios, weekly execution (2026-04-19)
 - ✅ kro-ui E2E workflow — runs on push/PR, Playwright-based (2026-04-14)
+- ✅ `otherness-config.yaml`: `anchor:` section added (commented-out, for projects with anchor workflows) — fields: workflow, score_pattern, coverage_target, stagnation_sessions (PR #357, 2026-04-20)
 
 ## Future (🔲)
 
-- 🔲 `otherness-config.yaml` + template: add `anchor:` section (workflow, score_pattern, coverage_target, stagnation_sessions)
+- 🔲 `otherness-config-template.yaml`: add `anchor:` section (workflow, score_pattern, coverage_target, stagnation_sessions) — HIGH tier, requires human review
 - 🔲 `SM §4g-anchor`: feature→anchor gap detection — read Present items, diff against AGENTS.md §Anchor matrix, open anchor-growth issues for uncovered features
 - 🔲 `SM §4g-anchor`: post `[ANCHOR] coverage: N/M (X%)` to report issue after each gap scan
 - 🔲 `COORD §1c`: anchor-growth gate — when coverage < coverage_target, generate anchor-growth items before feature items

--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -68,3 +68,16 @@ schedule:
   cron: "0 * * * *"         # HOURLY — locked. Do not change to */6 or slower.
   model: "amazon-bedrock/global.anthropic.claude-sonnet-4-6"
   api_key_secret: "ANTHROPIC_API_KEY"   # GitHub Actions secret name containing the API key
+
+# ── Anchor framework ──────────────────────────────────────────────────────────
+# Optional: configure when this project has an anchor workflow (automated quality signal).
+# An anchor is a CI workflow that runs on a schedule and posts a score to a GitHub issue.
+# otherness SM §4g-anchor reads the score to detect feature→anchor coverage gaps.
+#
+# See docs/design/24-project-anchor-framework.md for the full design.
+#
+# anchor:
+#   workflow: ""                          # workflow filename that runs the anchor (e.g. pdca.yml)
+#   score_pattern: "PASS=([0-9]+) FAIL=([0-9]+)"  # regex to extract pass/fail from issue comment
+#   coverage_target: 80                   # minimum % of features that must have anchor coverage
+#   stagnation_sessions: 3                # sessions without anchor growth before COORD prioritizes it


### PR DESCRIPTION
## Summary

Adds commented-out `anchor:` section to `otherness-config.yaml` with fields:
- `workflow`: filename of the anchor CI workflow
- `score_pattern`: regex to extract pass/fail counts from issue comments
- `coverage_target`: minimum % anchor coverage
- `stagnation_sessions`: sessions without growth before COORD prioritizes anchor

Commented-out by default — otherness has no anchor workflow. Managed projects with PDCA/E2E workflows can activate by uncommenting.

Note: `otherness-config-template.yaml` was NOT modified (HIGH tier, agent must not modify per AGENTS.md rules). Opening a follow-up issue.

## Design doc
Updated `docs/design/24-project-anchor-framework.md`: moved config anchor section from 🔲 Future to ✅ Present.

## Change tier: LOW — config file only, no agents/phases touched.