### PR TITLE
feat(sm): fleet defaults — write sim-defaults.json to otherness repo, ship via self-update

### DIFF
--- a/.specify/specs/353/spec.md
+++ b/.specify/specs/353/spec.md
@@ -1,0 +1,52 @@
+# Spec: feat(sm): fleet defaults — write sim-defaults.json, ship via self-update
+
+## Design reference
+- **Design doc**: `docs/design/23-simulation-as-anchor.md`
+- **Section**: `§ Per-project calibration and fleet defaults`
+- **Implements**: `~/.otherness/scripts/sim-defaults.json` — fleet defaults written by otherness SM, shipped to managed projects via self-update (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1** — After each successful calibration run in SM §4d, if the current repo is the
+otherness repo (detected by matching `repo` field from `otherness-config.yaml` against
+a pattern containing `otherness`), copy `scripts/sim-params.json` to
+`scripts/sim-defaults.json` in the same directory and commit+push to main.
+
+Violation: sim-defaults.json written on managed projects (not just otherness repo).
+
+**O2** — The write uses the pull-rebase-retry pattern (same as metrics.md updates) to
+ensure parallel session safety.
+
+Violation: direct push without pull-rebase retry.
+
+**O3** — The sim-defaults.json file is a copy of sim-params.json with an added
+`fleet_calibrated_at` field and `source: "otherness"`.
+
+Violation: sim-defaults.json missing the fleet metadata fields.
+
+**O4** — If the repo is not the otherness repo, or if calibration failed, the step is
+silently skipped. No error output.
+
+Violation: error or [NEEDS HUMAN] when skipping on managed project.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How to detect "this is the otherness repo": check if `REPO` env var ends with `/otherness`
+  OR if `otherness-config.yaml` has `name: otherness`. The REPO check is simpler.
+- Whether to create a PR for sim-defaults.json or push directly to main: direct push
+  with pull-rebase-retry (same pattern as metrics.md) is appropriate for this data file.
+- Whether to update `~/.otherness/scripts/sim-defaults.json` directly or ship via the
+  normal git pull self-update: ship via git commit+push to the otherness repo; managed
+  projects pick it up on their next `git -C ~/.otherness pull` (startup self-update).
+
+---
+
+## Zone 3 — Scoped out
+
+- Managed projects reading sim-defaults.json at startup — that is a separate future item
+- The calibration_cycles config field — separate issue, not this PR
+- Cross-project comparison of calibration params — out of scope

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -327,6 +327,57 @@ subprocess.run(['git','worktree','prune'], capture_output=True)
 PARAMS_EOF
         fi
 
+        # Fleet defaults: if this is the otherness repo, write sim-defaults.json
+        # to scripts/ and push to main. Managed projects pick it up on next git pull.
+        # O4: skip silently on managed projects.
+        IS_OTHERNESS=$(python3 -c "
+import re, os
+try:
+    for line in open('otherness-config.yaml'):
+        m = re.match(r'^\s+repo:\s*(.+)', line)
+        if m:
+            print('true' if m.group(1).strip().endswith('/otherness') else 'false')
+            exit()
+except: pass
+print('false')
+" 2>/dev/null || echo "false")
+
+        if [ "$IS_OTHERNESS" = "true" ] && [ -f "scripts/sim-params.json" ]; then
+            python3 - <<'FLEETEOF'
+import subprocess, json, os, datetime, shutil
+
+sm_cycle = os.environ.get('SM_CYCLE', '0')
+try:
+    params = json.load(open('scripts/sim-params.json'))
+    defaults = dict(params)
+    defaults['fleet_calibrated_at'] = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    defaults['source'] = 'otherness'
+    json.dump(defaults, open('scripts/sim-defaults.json', 'w'), indent=2)
+    print(f"[SM §4d] sim-defaults.json written (sm_cycle={sm_cycle})")
+
+    # Commit and push to main — managed projects pick up on next git pull startup
+    subprocess.run(['git','add','scripts/sim-defaults.json'], capture_output=True)
+    r = subprocess.run(['git','commit','-m',f'chore(sm): update sim-defaults.json (sm_cycle={sm_cycle})'],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        print("[SM §4d] sim-defaults.json: no changes to commit")
+    else:
+        for attempt in range(3):
+            subprocess.run(['git','pull','--rebase','origin','main','--quiet'],
+                           capture_output=True)
+            push_r = subprocess.run(['git','push','origin','HEAD:main'],
+                                    capture_output=True, text=True)
+            if push_r.returncode == 0:
+                print("[SM §4d] sim-defaults.json pushed to main (fleet update)")
+                break
+            import time; time.sleep(2 * (attempt + 1))
+        else:
+            print("[SM §4d] sim-defaults.json push failed after 3 attempts — non-fatal")
+except Exception as e:
+    print(f"[SM §4d] sim-defaults.json error (non-fatal): {e}")
+FLEETEOF
+        fi
+
         # Phase 2c: write sim-results.json to _state branch
         python3 - <<'SIMRES_EOF'
 import subprocess, json, os, tempfile, datetime, shutil

--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -164,12 +164,11 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 - ✅ `SM §4d`: `arch_convergence > 0.7` → open `learn(arch):` issue labeled `otherness,area/agent-loop,kind/chore` with deduplication check; replaces `[NEEDS HUMAN]` escalation (PR #351, 2026-04-20)
 - ✅ `SM §4e`: compare actual `todo_shipped` to predicted floor from `scripts/sim-params.json`; track consecutive below-floor count in `_state:.otherness/divergence_count.json`; post `[⚠️ Simulation divergence]` after 3 consecutive below-floor batches (PR #350, 2026-04-20)
 - ✅ `SM §4d`: write `sim-prediction.json` to `_state` after each calibration — fields: `prs_next_batch_floor`, `prs_next_batch_ceiling`, `arch_convergence_score`, `skill_growth_rate`, `calibrated_params`, `calibrated_at` (PR #349, 2026-04-20)
+- ✅ `scripts/sim-defaults.json`: fleet defaults — written by otherness SM §4d after calibration (otherness-repo-only gate); shipped to managed projects via `git -C ~/.otherness pull` self-update (PR #353, 2026-04-20)
 
 ## Future (🔲)
 
 - 🔲 `SM §4e`: read `metrics.md`, calibrate `simulate.py` parameters against real data, write `.otherness/sim-prediction.json` — runs every 5 SM cycles (NOTE: calibration runs every 10; sim-prediction.json written by SM §4d after calibration)
-- 🚫 `scripts/simulate.py`: add `--calibrate` flag — DEPRECATED: \`scripts/calibrate.py\` provides this functionality as a standalone script. No duplication needed.
-- 🔲 `~/.otherness/scripts/sim-defaults.json`: fleet defaults — written by otherness SM, shipped to managed projects via self-update
 - 🔲 `otherness-config.yaml`: `simulation.calibration_cycles` field (default: 5) — how often SM re-calibrates
 - 🔲 Managed project adoption: kardinal-promoter and kro-ui SM inherit otherness defaults, re-calibrate after ≥5 batches
 

--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -168,7 +168,7 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 ## Future (🔲)
 
 - 🔲 `SM §4e`: read `metrics.md`, calibrate `simulate.py` parameters against real data, write `.otherness/sim-prediction.json` — runs every 5 SM cycles (NOTE: calibration runs every 10; sim-prediction.json written by SM §4d after calibration)
-- 🔲 `scripts/simulate.py`: add `--calibrate` flag — reads metrics.md, grid-searches parameters, outputs best fit as JSON
+- 🚫 `scripts/simulate.py`: add `--calibrate` flag — DEPRECATED: \`scripts/calibrate.py\` provides this functionality as a standalone script. No duplication needed.
 - 🔲 `~/.otherness/scripts/sim-defaults.json`: fleet defaults — written by otherness SM, shipped to managed projects via self-update
 - 🔲 `otherness-config.yaml`: `simulation.calibration_cycles` field (default: 5) — how often SM re-calibrates
 - 🔲 Managed project adoption: kardinal-promoter and kro-ui SM inherit otherness defaults, re-calibrate after ≥5 batches

--- a/scripts/sim-defaults.json
+++ b/scripts/sim-defaults.json
@@ -1,0 +1,13 @@
+{
+  "decay_rate": 0.9,
+  "jump_multiplier": 1.3,
+  "skill_boldness_coefficient": 0.018,
+  "calibrated_at": "2026-04-18T17:58:24Z",
+  "source": "otherness",
+  "n_batches": 26,
+  "rmse": 0.292433,
+  "observed_completion_rate": 1.1558,
+  "observed_nh_rate": 0.0321,
+  "skills_growth_per_batch": 0.2692,
+  "fleet_calibrated_at": "2026-04-20T04:35:08Z"
+}


### PR DESCRIPTION
## Summary

- After calibration in SM §4d, if running on the otherness repo (detected via `repo` field ending with `/otherness`), writes `scripts/sim-defaults.json` with calibrated params + `fleet_calibrated_at`
- Commits + pushes to main using pull-rebase-retry pattern
- Managed projects inherit fleet defaults on their next `git -C ~/.otherness pull` startup
- Creates initial `scripts/sim-defaults.json` from current calibrated params (decay_rate=0.9, rmse=0.292)

## Design doc
Updated `docs/design/23-simulation-as-anchor.md`: moved fleet defaults from 🔲 Future to ✅ Present.

## CRITICAL-A self-review
1. SPEC: O1 (only-otherness gate) ✓, O2 (pull-rebase-retry) ✓, O3 (fleet metadata fields) ✓, O4 (silent skip) ✓
2. FAILURE MODES: no sim-params.json → exit(0) ✓ | not otherness repo → skip ✓ | push fails → non-fatal ✓
3. GLOBAL DEPLOYMENT: try/except everywhere, no blocking ✓
4. SIMPLICITY: follows metrics.md push pattern exactly ✓  
5. VISION: closes fleet calibration propagation chain ✓

[NEEDS HUMAN: critical-tier-change]