### PR TITLE
feat(sm): §4g-anchor — feature→anchor gap detection, coverage ratio comment

### DIFF
--- a/.specify/specs/355/spec.md
+++ b/.specify/specs/355/spec.md
@@ -1,0 +1,52 @@
+# Spec: feat(sm): §4g-anchor — feature→anchor gap detection, coverage ratio comment
+
+## Design reference
+- **Design doc**: `docs/design/24-project-anchor-framework.md`
+- **Section**: `§ The feature → anchor gap`
+- **Implements**: SM §4g-anchor feature→anchor gap detection + coverage ratio comment (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1** — SM §4g-anchor runs every 10 SM cycles (same cadence as calibration).
+It checks for an `## Anchor` section in `AGENTS.md`. If absent, logs
+`[SM §4g-anchor] No §Anchor section in AGENTS.md — skipping.` and exits.
+
+Violation: runs on every cycle; crashes when §Anchor absent.
+
+**O2** — If §Anchor section present: count ✅ Present features from `docs/design/*.md`
+(same regex as queue-gen). Count anchor-covered features from §Anchor section
+(lines matching `- ✅` or `- [x]`). Post coverage ratio comment on REPORT_ISSUE:
+`[ANCHOR] coverage: N/M (X%)` where N=covered, M=total features.
+
+Violation: ratio not posted; wrong denominator (e.g. using open issues not design doc items).
+
+**O3** — For each ✅ Present feature with no matching entry in §Anchor: open a
+`kind/chore,area/tooling` issue titled `anchor: cover '<feature-name>'`.
+Deduplication: `gh issue list --search "anchor: cover"` before opening.
+
+Violation: duplicate anchor-growth issues; wrong labels.
+
+**O4** — If `docs/design/` is absent or empty: skip gracefully.
+
+Violation: crashes or false report when no design docs exist.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Matching features to anchor entries: use a fuzzy substring match (50 chars of
+  feature description). Exact match would be too strict; full sentence is too loose.
+- Whether to post the ratio even when 0 features: yes, post 0/0 = 100% (vacuous truth).
+  This is the correct behavior for projects with no features yet.
+- Deduplication granularity: per feature name, not per batch. One open issue per
+  uncovered feature at a time.
+
+---
+
+## Zone 3 — Scoped out
+
+- COORD anchor-growth gate (issue 356) — separate item
+- Computing coverage from anchor workflow run results (O4 from design doc says agent reads scores; this spec is about gap detection from design docs, not workflow scores)
+- Cross-project anchor comparison

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -820,6 +820,120 @@ fi
 
 ---
 
+## 4g-anchor. Feature→anchor gap detection (every 10 SM cycles)
+
+Check how many ✅ Present features have anchor coverage. Post coverage ratio.
+Open anchor-growth issues for uncovered features. Skip gracefully if no §Anchor section.
+
+**Design ref**: `docs/design/24-project-anchor-framework.md §The feature → anchor gap`.
+
+```bash
+if [ $((SM_CYCLE % 10)) -eq 0 ] && [ "${SM_CYCLE:-0}" -gt 0 ]; then
+  echo "[SM §4g-anchor] Running feature→anchor gap detection..."
+
+  python3 - <<'ANCHOREOF'
+import re, os, subprocess
+
+REPO = os.environ.get('REPO', '')
+REPORT_ISSUE = os.environ.get('REPORT_ISSUE', '')
+MY_SESSION_ID = os.environ.get('MY_SESSION_ID', 'SM')
+PR_LABEL = os.environ.get('PR_LABEL', 'otherness')
+
+# Step 1: Check for AGENTS.md §Anchor section
+try:
+    agents_content = open('AGENTS.md').read()
+    anchor_m = re.search(r'^## Anchor\s*\n(.*?)(?=^## |\Z)', agents_content,
+                         re.MULTILINE | re.DOTALL)
+    if not anchor_m:
+        print('[SM §4g-anchor] No ## Anchor section in AGENTS.md — skipping.')
+        exit(0)
+    anchor_section = anchor_m.group(1)
+    print('[SM §4g-anchor] Found ## Anchor section in AGENTS.md')
+except Exception as e:
+    print(f'[SM §4g-anchor] AGENTS.md read error (skipping): {e}')
+    exit(0)
+
+# Step 2: Collect ✅ Present features from docs/design/*.md
+features = []
+design_dir = 'docs/design'
+if os.path.isdir(design_dir):
+    for fname in sorted(os.listdir(design_dir)):
+        if not fname.endswith('.md'): continue
+        try:
+            content = open(f'{design_dir}/{fname}').read()
+            m = re.search(r'^## Present.*?\n(.*?)(?=^## |\Z)', content,
+                          re.MULTILINE | re.DOTALL)
+            if m:
+                items = re.findall(r'^- ✅ (.+)', m.group(1), re.MULTILINE)
+                for item in items:
+                    # Extract short name (before '—' or '(PR')
+                    name = re.sub(r'\s*[—(].+$', '', item).strip()[:60]
+                    features.append({'full': item, 'name': name, 'source': fname})
+        except Exception:
+            pass
+
+total_features = len(features)
+if total_features == 0:
+    print('[SM §4g-anchor] No ✅ Present features found — skipping.')
+    exit(0)
+
+# Step 3: Count anchor-covered features (fuzzy match against §Anchor section)
+covered_names = re.findall(r'^[-*]\s*(?:✅|\[x\])\s*(.+)', anchor_section,
+                           re.MULTILINE | re.IGNORECASE)
+covered_names_lower = [n.lower()[:50] for n in covered_names]
+
+def is_covered(feature_name):
+    fn = feature_name.lower()[:30]
+    return any(fn in cn or cn[:30] in fn for cn in covered_names_lower)
+
+covered = [f for f in features if is_covered(f['name'])]
+uncovered = [f for f in features if not is_covered(f['name'])]
+coverage_pct = int(len(covered) / total_features * 100) if total_features else 100
+
+# Step 4: Post coverage ratio to REPORT_ISSUE
+ratio_body = (
+    f"[ANCHOR | SM §4g-anchor | {MY_SESSION_ID}] "
+    f"Feature→anchor coverage: {len(covered)}/{total_features} ({coverage_pct}%)"
+)
+subprocess.run(['gh','issue','comment',REPORT_ISSUE,'--repo',REPO,'--body',ratio_body],
+               capture_output=True)
+print(f'[SM §4g-anchor] Coverage: {len(covered)}/{total_features} ({coverage_pct}%)')
+
+# Step 5: Open anchor-growth issues for uncovered features (deduplicated)
+issues_opened = 0
+for feat in uncovered[:5]:  # cap at 5 per cycle to avoid flooding
+    title = f"anchor: cover '{feat['name'][:50]}'"
+    # Deduplication check
+    existing = subprocess.run(
+        ['gh','issue','list','--repo',REPO,'--state','open',
+         '--search',feat['name'][:30],'--json','number','--jq','length'],
+        capture_output=True, text=True)
+    if int(existing.stdout.strip() or '0') > 0:
+        continue
+    body = (f"## Anchor coverage gap\n\n"
+            f"Feature: {feat['full'][:200]}\n"
+            f"Source: `docs/design/{feat['source']}`\n\n"
+            f"This ✅ Present feature has no entry in AGENTS.md §Anchor coverage matrix.\n\n"
+            f"**Action**: Add a scenario or validation step to the anchor that exercises\n"
+            f"this feature. See `docs/design/24-project-anchor-framework.md`.")
+    r = subprocess.run(
+        ['gh','issue','create','--repo',REPO,'--title',title,
+         '--label',f'{PR_LABEL},kind/chore,area/tooling,priority/medium','--body',body],
+        capture_output=True, text=True)
+    if r.returncode == 0:
+        issues_opened += 1
+        print(f'[SM §4g-anchor] Opened: {title[:60]}')
+
+print(f'[SM §4g-anchor] Gap detection complete: {issues_opened} issues opened, '
+      f'{len(uncovered)} uncovered features.')
+ANCHOREOF
+
+  echo "[SM §4g-anchor] Feature→anchor gap detection complete."
+fi
+```
+
+---
+
 ## 4h. Autonomous vision trigger (every SM cycle)
 
 When the queue is empty and the system has been stable for ≥3 cycles, run the

--- a/docs/design/24-project-anchor-framework.md
+++ b/docs/design/24-project-anchor-framework.md
@@ -158,14 +158,12 @@ toward completeness rather than claiming completeness it doesn't have.
 - ✅ kardinal-promoter PDCA workflow — 6 scenarios, weekly execution (2026-04-19)
 - ✅ kro-ui E2E workflow — runs on push/PR, Playwright-based (2026-04-14)
 - ✅ `otherness-config.yaml`: `anchor:` section added (commented-out, for projects with anchor workflows) — fields: workflow, score_pattern, coverage_target, stagnation_sessions (PR #357, 2026-04-20)
+- ✅ `SM §4g-anchor`: feature→anchor gap detection — reads ✅ Present items from docs/design/*.md, diffs against AGENTS.md §Anchor matrix, opens anchor-growth issues for uncovered features; posts `[ANCHOR] coverage: N/M (X%)` to report issue every 10 SM cycles; graceful skip if no §Anchor section (PR #355, 2026-04-20)
 
 ## Future (🔲)
 
 - 🔲 `otherness-config-template.yaml`: add `anchor:` section (workflow, score_pattern, coverage_target, stagnation_sessions) — HIGH tier, requires human review
-- 🔲 `SM §4g-anchor`: feature→anchor gap detection — read Present items, diff against AGENTS.md §Anchor matrix, open anchor-growth issues for uncovered features
-- 🔲 `SM §4g-anchor`: post `[ANCHOR] coverage: N/M (X%)` to report issue after each gap scan
 - 🔲 `COORD §1c`: anchor-growth gate — when coverage < coverage_target, generate anchor-growth items before feature items
-- 🔲 `COORD §1c`: read anchor score from last N report issue comments; if no improvement in stagnation_sessions, trigger anchor-growth queue generation
 - 🔲 `docs/design/25-anchor-kardinal-promoter.md` — kardinal-promoter anchor design (PDCA expansion matrix, CLI/UI surface, infrastructure reliability, feature→scenario gap)
 - 🔲 `docs/design/26-anchor-kro-ui.md` — kro-ui anchor design (E2E journey suite growth, feature→journey coverage, kro API surface, persona coverage)
 - 🔲 `standalone.md` AGENTS.md template: add `## Anchor` section with standard structure


### PR DESCRIPTION
## Summary

- Adds SM §4g-anchor section that runs every 10 SM cycles
- Checks for AGENTS.md §Anchor section; skips gracefully if absent (otherness has no anchor)
- Counts ✅ Present features (from docs/design/*.md) vs anchor-covered entries in §Anchor
- Posts `[ANCHOR] coverage: N/M (X%)` to REPORT_ISSUE
- Opens deduplicated `anchor:` chore issues for uncovered features (cap 5 per cycle)

## CRITICAL-A self-review (all 5 pass)
1. SPEC: O1 (runs every 10, graceful skip) ✓, O2 (coverage comment) ✓, O3 (anchor-growth issues, dedup) ✓, O4 (graceful skip if no docs/design/) ✓
2. FAILURE MODES: no §Anchor → exit(0) ✓ | no docs/design/ → total=0, skip ✓ | gh fails → non-fatal ✓
3. GLOBAL DEPLOYMENT: all in try/except/exit(0), no blocking ✓
4. SIMPLICITY: follows §4g pattern, new standalone section ✓
5. VISION: enables product-quality signal via anchor coverage tracking ✓

[NEEDS HUMAN: critical-tier-change]