### PR TITLE
feat(coord): §1c anchor-growth gate — skip feature queue when anchor items pending

### DIFF
--- a/.specify/specs/356/spec.md
+++ b/.specify/specs/356/spec.md
@@ -1,0 +1,46 @@
+# Spec: feat(coord): anchor-growth gate
+
+## Design reference
+- **Design doc**: `docs/design/24-project-anchor-framework.md`
+- **Section**: `§ Zone 1 — O1 Anchor growth precedes feature growth`
+- **Implements**: COORD §1c anchor-growth gate — when coverage < coverage_target, generate anchor-growth items before feature items (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1** — During queue generation (§1c), check anchor coverage before generating feature items.
+Read `anchor.coverage_target` from `otherness-config.yaml` (default: 80 if not set).
+Check open `anchor:` issues AND AGENTS.md §Anchor section to determine if coverage is below target.
+
+Violation: feature items generated when `open anchor: issues > 0` (already-queued anchor-growth items exist).
+
+**O2** — If uncovered anchor-growth issues already exist in the queue (open issues with `anchor:` prefix),
+log `[COORD §1c-anchor] Anchor-growth items in queue — skipping feature generation.` and skip feature generation this cycle.
+
+Violation: feature items generated alongside open anchor-growth issues.
+
+**O3** — If no anchor config exists in `otherness-config.yaml` (no `anchor:` section), skip the gate.
+
+Violation: gate fires on projects without anchor config, blocking feature queue.
+
+**O4** — The gate only fires if `anchor:` section exists in config AND coverage_target is set.
+If `coverage_target` is 0 or absent: gate is disabled.
+
+Violation: gate fires with coverage_target unset/zero.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How to measure current coverage from COORD without running SM: check count of open `anchor:` issues.
+  If open anchor-growth issues exist, coverage is below target. This is a proxy, not exact.
+- The gate checks at queue-gen time, not at claim time. This is correct behavior.
+
+---
+
+## Zone 3 — Scoped out
+
+- Computing exact coverage ratio (that is SM §4g-anchor's job)
+- Stagnation sessions check (future item 356b)
+- Interleaving anchor and feature items (just blocking for now)

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -289,6 +289,34 @@ except: print(0)
   fi
 
   if [ "$QUEUE_GEN_WINNER" = "true" ]; then
+    # Anchor-growth gate (design doc 24 §O1): if anchor config exists AND open anchor-growth
+    # issues exist, skip feature generation this cycle and let anchor items be worked first.
+    ANCHOR_TARGET=$(python3 -c "
+import re
+section = None
+try:
+    for line in open('otherness-config.yaml'):
+        s = re.match(r'^(\w[\w_]*):', line)
+        if s: section = s.group(1)
+        if section == 'anchor':
+            m = re.match(r'\s+coverage_target:\s*(\d+)', line)
+            if m: print(m.group(1)); exit()
+except: pass
+print('0')
+" 2>/dev/null || echo "0")
+
+    if [ "${ANCHOR_TARGET:-0}" -gt 0 ]; then
+      OPEN_ANCHOR_ITEMS=$(gh issue list --repo "$REPO" --state open \
+        --search "anchor: cover" --json number --jq 'length' 2>/dev/null || echo "0")
+      if [ "${OPEN_ANCHOR_ITEMS:-0}" -gt 0 ]; then
+        echo "[COORD §1c-anchor] ${OPEN_ANCHOR_ITEMS} anchor-growth items in queue (coverage_target=${ANCHOR_TARGET}%) — skipping feature generation."
+        git push origin --delete "$QUEUE_LOCK_BRANCH" 2>/dev/null || true
+        QUEUE_GEN_WINNER=false
+      fi
+    fi
+  fi
+
+  if [ "$QUEUE_GEN_WINNER" = "true" ]; then
     # Queue generation: design docs are the PRIMARY source, roadmap is SECONDARY.
     # Read 🔲 Future items from docs/design/ files first.
     # Fall back to roadmap.md deliverables for stages without design docs yet.

--- a/docs/design/24-project-anchor-framework.md
+++ b/docs/design/24-project-anchor-framework.md
@@ -159,6 +159,7 @@ toward completeness rather than claiming completeness it doesn't have.
 - ✅ kro-ui E2E workflow — runs on push/PR, Playwright-based (2026-04-14)
 - ✅ `otherness-config.yaml`: `anchor:` section added (commented-out, for projects with anchor workflows) — fields: workflow, score_pattern, coverage_target, stagnation_sessions (PR #357, 2026-04-20)
 - ✅ `SM §4g-anchor`: feature→anchor gap detection — reads ✅ Present items from docs/design/*.md, diffs against AGENTS.md §Anchor matrix, opens anchor-growth issues for uncovered features; posts `[ANCHOR] coverage: N/M (X%)` to report issue every 10 SM cycles; graceful skip if no §Anchor section (PR #355, 2026-04-20)
+- ✅ `COORD §1c`: anchor-growth gate — when `anchor.coverage_target > 0` AND open `anchor: cover` issues exist, skips feature queue generation; anchor-growth items worked first (PR #356, 2026-04-20)
 
 ## Future (🔲)
 


### PR DESCRIPTION
## Summary

- Adds anchor-growth gate in COORD §1c queue generation
- Reads `anchor.coverage_target` from `otherness-config.yaml` (0 = gate disabled)
- If `coverage_target > 0` AND open `anchor: cover` issues exist: log and skip feature generation
- Graceful no-op when no `anchor:` config section present

## CRITICAL-A self-review (all 5 pass)
1. SPEC: O1 (skip feature gen when anchor items in queue) ✓, O2 (log message) ✓, O3 (no config = skip) ✓, O4 (coverage_target=0 = disabled) ✓
2. FAILURE MODES: no anchor config → ANCHOR_TARGET=0, gate skipped ✓ | gh fails → 0 anchor items counted, gate not fired ✓
3. GLOBAL DEPLOYMENT: all paths have fallbacks; `2>/dev/null || echo "0"` ✓
4. SIMPLICITY: 20-line gate inserted before existing PYEOF block ✓
5. VISION: anchor coverage precedes feature growth — product quality as primary signal ✓

[NEEDS HUMAN: critical-tier-change]