### PR TITLE
security(p1): M7 — protect _state branches on all repos

### DIFF
--- a/.specify/specs/359/spec.md
+++ b/.specify/specs/359/spec.md
@@ -1,0 +1,39 @@
+# Spec: security(p1): protect _state branches on all 3 repos
+
+## Design reference
+- **Design doc**: `docs/design/27-security-model.md §M7`
+- **Section**: `§ Mitigations — M7`
+- **Implements**: M7: `_state` branch protection applied on all repos (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1** — `_state` branch on `pnz1990/otherness` must have branch protection that
+prevents force-pushes (`allow_force_pushes: false`) and branch deletion (`allow_deletions: false`).
+
+Violation: force-push to _state succeeds for any authenticated user.
+
+**O2** — Same protection applied to all repos in `monitor.projects` that have a `_state` branch.
+
+Violation: protection only on otherness, not on managed projects.
+
+**O3** — Agent direct-push to `_state` continues to work (no PR requirement, no required reviews).
+
+Violation: agent cannot push state.json updates (breaks the distributed lock).
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- PR requirement for _state was not added — agent writes state.json directly without creating PRs.
+  Adding require_pull_request_reviews would break the agent. Deferred until M3 (GitHub App).
+- The protection via API call is a one-time setup action, not repeated on every SM cycle.
+
+---
+
+## Zone 3 — Scoped out
+
+- Restricting push to specific users/apps (M3 — GitHub App — is the proper fix)
+- CODEOWNERS for _state (GitHub does not apply CODEOWNERS to non-main branches by default)
+- Cross-project enforcement via SM every batch (the protection is idempotent; checking/re-applying is O(3 API calls) and can be added to SM later)

--- a/docs/design/27-security-model.md
+++ b/docs/design/27-security-model.md
@@ -533,7 +533,7 @@ The following are accepted design tradeoffs, not failures:
 - 🔲 M2: Set `agent_version` in all 3 `otherness-config.yaml` files to pin otherness clone
 - 🔲 M4: Remove `actions:write` from all 3 workflow job permissions
 - 🔲 M6: Add `agents_path` allowlist validation in workflow prompt section (1 line bash check)
-- 🔲 M7: Add branch protection to `_state` branches on all 3 repos (restrict to App push after M3)
+- ✅ M7: `_state` branch protection applied on all 3 repos (otherness, alibi, kardinal-promoter, kro-ui): `allow_force_pushes: false`, `allow_deletions: false` — prevents state poisoning via force-push (direct-push by agent still allowed; PR requirement deferred until M3) (2026-04-20)
 - 🔲 M8: AGENTS.md change detection CI check — block non-collaborator AGENTS.md modifications
 - ✅ M5: AWS Budget alert at $50/day Bedrock spend — posted to rrroizma@amazon.com (2026-04-20)
 - 🔲 M5b: Restrict Bedrock Resource to specific ARNs — DEFERRED. opencode uses cross-region inference profile ARNs (arn:aws:bedrock:<region>:<acct>:inference-profile/*) that vary by model version. Resource:* with Budget alert is the current mitigaton. Revisit when ARN patterns stabilize.


### PR DESCRIPTION
## Summary

Applied branch protection to `_state` on all 4 monitored repos:
- `pnz1990/otherness`: ✅ `allow_force_pushes: false`, `allow_deletions: false`
- `pnz1990/alibi`: ✅ same
- `pnz1990/kardinal-promoter`: ✅ same
- `pnz1990/kro-ui`: ✅ same

Protection prevents state poisoning via force-push or branch deletion. Agent direct-push preserved (no PR requirement — deferred to M3 GitHub App milestone).

## Design doc
Updated `docs/design/27-security-model.md`: M7 marked ✅ (was 🔲).

## Change tier: LOW — docs and config only, no agents/phases touched.