### PR TITLE
fix(ci): fix YAML syntax error in security-checks workflow

### DIFF
--- a/.github/workflows/otherness-security-checks.yml
+++ b/.github/workflows/otherness-security-checks.yml
@@ -57,27 +57,13 @@ jobs:
             --jq '.permission' 2>/dev/null || echo "none")
 
           if [[ "$PERM" == "admin" || "$PERM" == "write" || "$PERM" == "maintain" ]]; then
-            echo "✅ AGENTS.md modified by collaborator ($AUTHOR, $PERM) — permitted."
-            gh pr comment $PR_NUMBER --repo $REPO \
-              --body "⚠️ **Security notice**: \`AGENTS.md\` was modified in this PR.
-
-This file is read by the autonomous agent on every scheduled run. Changes to it affect how the agent behaves — effectively changing the agent's instructions.
-
-**Reviewer checklist:**
-- [ ] No instructions that redirect \`agents_path\` to an external location
-- [ ] No instructions that exfiltrate environment variables or secrets
-- [ ] No instructions that push to repos outside \`pnz1990/\`
-- [ ] Changes are consistent with the project's documented SDLC process
-
-See \`docs/design/27-security-model.md §2A\` for the full threat model." 2>/dev/null || true
+            echo "AGENTS.md modified by collaborator ($AUTHOR, $PERM) — permitted."
+            NOTICE_BODY="Security notice: AGENTS.md was modified in this PR."$'\n\n'"This file is read by the autonomous agent on every scheduled run. Changes to it affect how the agent behaves."$'\n\n'"Reviewer checklist:"$'\n'"- No instructions that redirect agents_path to an external location"$'\n'"- No instructions that exfiltrate environment variables or secrets"$'\n'"- No instructions that push to repos outside pnz1990/"$'\n'"- Changes are consistent with the project documented SDLC process"$'\n\n'"See docs/design/27-security-model.md S2A for the full threat model."
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$NOTICE_BODY" 2>/dev/null || true
           else
             echo "::error::AGENTS.md modified by non-collaborator ($AUTHOR, permission=$PERM). This is a security risk."
-            gh pr comment $PR_NUMBER --repo $REPO \
-              --body "🚫 **Security block**: \`AGENTS.md\` was modified by \`$AUTHOR\` who does not have collaborator access.
-
-\`AGENTS.md\` is read by the autonomous agent on every run. Modifications by external contributors could inject malicious instructions that run with full repository credentials.
-
-This check must pass before this PR can be merged. See \`docs/design/27-security-model.md §M8\`." 2>/dev/null || true
+            BLOCK_BODY="Security block: AGENTS.md was modified by $AUTHOR who does not have collaborator access."$'\n\n'"AGENTS.md is read by the autonomous agent on every run. Modifications by external contributors could inject malicious instructions that run with full repository credentials."$'\n\n'"This check must pass before this PR can be merged. See docs/design/27-security-model.md SM8."
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BLOCK_BODY" 2>/dev/null || true
             exit 1
           fi
 
@@ -104,10 +90,10 @@ This check must pass before this PR can be merged. See \`docs/design/27-security
             --jq '.permission' 2>/dev/null || echo "none")
 
           if [[ "$PERM" == "admin" || "$PERM" == "write" || "$PERM" == "maintain" ]]; then
-            echo "✅ otherness label applied by collaborator ($ACTOR, $PERM)"
+            echo "otherness label applied by collaborator ($ACTOR, $PERM)"
           else
-            echo "⚠️ otherness label applied by non-collaborator ($ACTOR, $PERM) — removing."
-            gh issue edit $ISSUE_NUMBER --repo $REPO --remove-label "otherness" 2>/dev/null || true
-            gh issue comment $ISSUE_NUMBER --repo $REPO \
-              --body "The \`otherness\` label can only be applied by repository collaborators. It has been removed. This label controls which issues enter the autonomous agent's work queue." 2>/dev/null || true
+            echo "otherness label applied by non-collaborator ($ACTOR, $PERM) — removing."
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "otherness" 2>/dev/null || true
+            REMOVE_MSG="The otherness label can only be applied by repository collaborators. It has been removed. This label controls which issues enter the autonomous agent work queue."
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$REMOVE_MSG" 2>/dev/null || true
           fi


### PR DESCRIPTION
## Summary

Fixes a YAML syntax error in `.github/workflows/otherness-security-checks.yml` that caused every push to `main` to show a workflow failure with **"This run likely failed because of a workflow file issue"**.

## Root cause

Multiline `--body "..."` strings inside `run: |` blocks contained bare newlines. YAML's literal block scalar (`|`) handles newlines in the literal content correctly, but when a multi-line string spans across what YAML sees as new document entries (e.g., lines starting at column 1 without indentation), the parser fails.

Specifically, lines 64, 66 of the original file were at column 1 inside what should have been a bash string argument — YAML saw them as top-level keys.

## Fix

Replace multiline bash string literals with `$'\n'`-escaped single-line strings. All functionality preserved; only formatting changed.

## Test

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/otherness-security-checks.yml').read()); print('YAML valid')"
```

**Risk tier**: LOW (CI/tooling fix, no agent instruction changes)