### PR TITLE
feat(config): add simulation.calibration_cycles to otherness-config.yaml

### DIFF
--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -166,12 +166,12 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 - ✅ `SM §4d`: write `sim-prediction.json` to `_state` after each calibration — fields: `prs_next_batch_floor`, `prs_next_batch_ceiling`, `arch_convergence_score`, `skill_growth_rate`, `calibrated_params`, `calibrated_at` (PR #349, 2026-04-20) ⚠️ Stale — referenced file not found
 - ✅ `scripts/sim-defaults.json`: fleet defaults — written by otherness SM §4d after calibration (otherness-repo-only gate); shipped to managed projects via `git -C ~/.otherness pull` self-update (PR #353, 2026-04-20)
 - ✅ `SM §4e-i`: per-N-cycle calibration update — reads `metrics.md`, runs `calibrate.py --runs 2`, writes `sim-prediction.json` to `_state` every `simulation.calibration_cycles` cycles (default: 5); frequency configurable via `otherness-config.yaml` (PR #401, 2026-04-20)
+- ✅ `otherness-config.yaml`: `simulation.calibration_cycles` field (default: 5) — controls SM §4e-i re-calibration frequency (PR #408, 2026-04-20)
 
 ## Future (🔲)
 
 
 - 🚫 `scripts/simulate.py`: add `--calibrate` flag — DEPRECATED: `scripts/calibrate.py` provides this functionality as a standalone script. No duplication needed.
-- 🔲 `otherness-config.yaml`: `simulation.calibration_cycles` field (default: 5) — how often SM re-calibrates
 - 🔲 Managed project adoption: kardinal-promoter and kro-ui SM inherit otherness defaults, re-calibrate after ≥5 batches
 
 ---

--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -76,6 +76,13 @@ hygiene:
   max_issues_per_scan: 3
   cycle_interval: 3
 
+# ── Simulation calibration ─────────────────────────────────────────────────────
+# Controls how often SM §4e re-calibrates simulation parameters against real batch
+# history and writes .otherness/sim-prediction.json to the _state branch.
+# See docs/design/23-simulation-as-anchor.md for the full design.
+simulation:
+  calibration_cycles: 5             # re-calibrate every N SM cycles (default: 5)
+
 # ── Anchor framework ──────────────────────────────────────────────────────────
 # Optional: configure when this project has an anchor workflow (automated quality signal).
 # An anchor is a CI workflow that runs on a schedule and posts a score to a GitHub issue.


### PR DESCRIPTION
## Summary

Adds `simulation.calibration_cycles` field (default: 5) to `otherness-config.yaml`. This field was already being read by `agents/phases/sm.md §4e-i` (added in PR #421) but was absent from the config file itself. Projects that don't configure it get the default of 5 cycles.

## Design doc

Updated `docs/design/23-simulation-as-anchor.md`: moved `otherness-config.yaml: simulation.calibration_cycles` from 🔲 Future to ✅ Present.

## Risk tier

**LOW** — config file change only. No agent instruction files modified.