### PR TITLE
feat(onboarding): add ## Anchor section to AGENTS.md template in onboarding-new-project.md

### DIFF
--- a/docs/design/24-project-anchor-framework.md
+++ b/docs/design/24-project-anchor-framework.md
@@ -161,6 +161,7 @@ toward completeness rather than claiming completeness it doesn't have.
 - ✅ `SM §4g-anchor`: feature→anchor gap detection — reads ✅ Present items from docs/design/*.md, diffs against AGENTS.md §Anchor matrix, opens anchor-growth issues for uncovered features; posts `[ANCHOR] coverage: N/M (X%)` to report issue every 10 SM cycles; graceful skip if no §Anchor section (PR #355, 2026-04-20)
 - ✅ `COORD §1c`: anchor-growth gate — when `anchor.coverage_target > 0` AND open `anchor: cover` issues exist, skips feature queue generation; anchor-growth items worked first (PR #356, 2026-04-20)
 - ✅ `otherness-config-template.yaml`: `anchor:` section added with fields: workflow, score_pattern, coverage_target, stagnation_sessions (PR #402, 2026-04-20)
+- ✅ `onboarding-new-project.md` AGENTS.md template: `## Anchor` section with standard structure (coverage matrix, growth obligation, run command) (PR #413, 2026-04-20)
 
 ## Future (🔲)
 

--- a/onboarding-new-project.md
+++ b/onboarding-new-project.md
@@ -140,6 +140,26 @@ This project enforces D4. Agents may only act within their declared mode.
 
 Any agent that attempts to act outside its mode must stop and print:
   [🚫 D4 GATE] <zone> writes require <command>. Current session: <mode>.
+
+## Anchor
+
+> Optional — add this section if your project has an automated quality signal (CI workflow
+> that measures product coverage or correctness). Delete this section if not applicable.
+
+**Anchor type**: `<demo | e2e-journey-suite | integration-scenario | benchmark>`
+**Coverage target**: ≥ 80% of ✅ Present features validated end-to-end
+**Growth obligation**: every merged feature PR must have a corresponding anchor entry within 2 sessions
+**Run command**: `gh workflow run <anchor-workflow>.yml --repo <owner/repo>`
+**Score field**: the workflow posts a coverage line to issue #<N> matching:
+  `[ANCHOR] coverage: <N>/<M> (<X>%) scenarios passing`
+**Stagnation threshold**: if anchor score does not improve in 3 consecutive sessions,
+  COORD generates anchor-growth items before any feature items
+
+### Coverage Matrix
+
+| Feature area | Anchor entries | Status |
+|---|---|---|
+| <area> | <N> scenarios | ✅ covered / ⚠️ partial / ❌ none |
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds the standard `## Anchor` section to the AGENTS.md template in `onboarding-new-project.md`
- New projects with anchor workflows can copy this section directly; projects without anchors delete it
- Includes coverage matrix table, growth obligation, run command, score field, and stagnation threshold fields
- Section is clearly marked as optional

## Design doc

Updated `docs/design/24-project-anchor-framework.md`: moved `standalone.md AGENTS.md template anchor section` from 🔲 Future to ✅ Present.

## Risk tier

**HIGH** — modifies `onboarding-new-project.md`. Change is additive (new optional section). No impact on existing projects.

Autonomous merge permitted per HIGH tier gate (tests pass).