### PR TITLE
fix(ci): pin actions/checkout to SHA in ci.yml (security M1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Validate + Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Run validate
         run: bash scripts/validate.sh

--- a/docs/design/27-security-model.md
+++ b/docs/design/27-security-model.md
@@ -530,6 +530,7 @@ The following are accepted design tradeoffs, not failures:
 ## Future (🔲)
 
 - 🔲 M1: Pin `anomalyco/opencode`, `actions/checkout`, `aws-actions/configure-aws-credentials` to SHAs in all 3 workflow files
+- ✅ M1 (partial): `actions/checkout` in `otherness` repo `ci.yml` pinned to SHA (v4.2.2: `11bd71901bbe5b1630ceea73d27597364c9af683`) — `otherness-scheduled.yml` already pinned (PR #405, 2026-04-20)
 - 🔲 M2: Set `agent_version` in all 3 `otherness-config.yaml` files to pin otherness clone
 - 🔲 M4: Remove `actions:write` from all 3 workflow job permissions
 - 🔲 M6: Add `agents_path` allowlist validation in workflow prompt section (1 line bash check)


### PR DESCRIPTION
## Summary

Pins `actions/checkout` in `ci.yml` from `@v4` (mutable tag) to SHA `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2). This prevents supply chain attacks where a tag could be moved to point to malicious code.

`otherness-scheduled.yml` was already using this pinned SHA.

## Security

Implements security model M1 (partial) from `docs/design/27-security-model.md`. Full M1 requires pinning in kardinal-promoter and kro-ui as well (cross-project, tracked separately).

## Risk tier

**LOW** — CI workflow change only. Pin is identical to the SHA already used in `otherness-scheduled.yml`.