### PR TITLE
Vision scan: 1 stale ref flagged, committed.

### DIFF
--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -165,7 +165,7 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 - ✅ `SM §4e`: compare actual `todo_shipped` to predicted floor from `scripts/sim-params.json`; track consecutive below-floor count in `_state:.otherness/divergence_count.json`; post `[⚠️ Simulation divergence]` after 3 consecutive below-floor batches (PR #350, 2026-04-20)
 - ✅ `SM §4d`: write `sim-prediction.json` to `_state` after each calibration — fields: `prs_next_batch_floor`, `prs_next_batch_ceiling`, `arch_convergence_score`, `skill_growth_rate`, `calibrated_params`, `calibrated_at` (PR #349, 2026-04-20) ⚠️ Stale — referenced file not found
 - ✅ `scripts/sim-defaults.json`: fleet defaults — written by otherness SM §4d after calibration (otherness-repo-only gate); shipped to managed projects via `git -C ~/.otherness pull` self-update (PR #353, 2026-04-20)
-- ✅ `SM §4e-i`: per-N-cycle calibration update — reads `metrics.md`, runs `calibrate.py --runs 2`, writes `sim-prediction.json` to `_state` every `simulation.calibration_cycles` cycles (default: 5); frequency configurable via `otherness-config.yaml` (PR #401, 2026-04-20)
+- ✅ `SM §4e-i`: per-N-cycle calibration update — reads `metrics.md`, runs `calibrate.py --runs 2`, writes `sim-prediction.json` to `_state` every `simulation.calibration_cycles` cycles (default: 5); frequency configurable via `otherness-config.yaml` (PR #401, 2026-04-20) ⚠️ Stale — referenced file not found
 - ✅ `otherness-config.yaml`: `simulation.calibration_cycles` field (default: 5) — controls SM §4e-i re-calibration frequency (PR #408, 2026-04-20)
 
 ## Future (🔲)


### PR DESCRIPTION
[VIBE-VISION-AUTO] Step A complete.

**Autonomous vision scan results:**

| Scan | Result |
|---|---|
| Scan 1: Promote shipped Future → Present | No items to promote (no matching merged PRs) |
| Scan 2: Flag stale Present items | **1 item flagged** — `docs/design/23-simulation-as-anchor.md`: `metrics.md` ref not found |
| Scan 3: Infer Future from code TODOs | No untracked TODO/FIXME markers found |
| Scan 4: Deprecate stale Future (90d+, no issue) | 0 items deprecated |

**Commit:** `5daff4d` — 1 file changed, flagging the stale `metrics.md` reference in `23-simulation-as-anchor.md`.

Progress posted to issue [#2](https://github.com/pnz1990/otherness/issues/2#issuecomment-4278489364). Step B (run) will pick up updated docs.

Triggered by scheduled workflow

<a href="https://opencode.ai/s/4ptlNM4k"><img width="200" alt="New%20session%20-%202026-04-20T06%3A55%3A05.910Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTIwVDA2OjU1OjA1LjkxMFo=.png?model=amazon-bedrock/global.anthropic.claude-sonnet-4-6&version=1.14.18&id=4ptlNM4k" /></a>
[opencode session](https://opencode.ai/s/4ptlNM4k)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/pnz1990/otherness/actions/runs/24652752995)