### PR TITLE
docs: dual-step scheduled workflow — design doc 28 marks shipped (🔲 → ✅)

### DIFF
--- a/.specify/specs/issue-440/spec.md
+++ b/.specify/specs/issue-440/spec.md
@@ -1,0 +1,35 @@
+# Spec: Dual-step scheduled workflow in otherness repo (issue-440)
+
+## Design reference
+- **Design doc**: `docs/design/28-dual-step-scheduled-workflow.md`
+- **Section**: `§ Future`
+- **Implements**: `otherness-scheduled.yml` split into two OpenCode steps (Step A: vibe-vision, Step B: run) (🔲 → ✅)
+
+## Context
+
+The scheduled workflow was already split into two OpenCode steps before this item was queued:
+- Step 7: "Otherness — Vision scan (Step A)" — `continue-on-error: true`
+- Step 8: "Run otherness" (Step B)
+
+This item updates the design doc to reflect the shipped implementation.
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Design doc 28 updated: dual-step workflow moved from 🔲 Future to ✅ Present.**
+The `docs/design/28-dual-step-scheduled-workflow.md` Present section now accurately
+reflects that `otherness-scheduled.yml` has Step A (vision scan) and Step B (run).
+
+**O2 — N/A — no code change required (design doc update only).**
+The workflow implementation predates this item. This is a documentation sync.
+
+---
+
+## Zone 2 — Implementer's judgment
+- N/A
+
+---
+
+## Zone 3 — Scoped out
+- Remaining Future items in design doc 28 (separate issues)

--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -165,7 +165,7 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 - ✅ `SM §4e`: compare actual `todo_shipped` to predicted floor from `scripts/sim-params.json`; track consecutive below-floor count in `_state:.otherness/divergence_count.json`; post `[⚠️ Simulation divergence]` after 3 consecutive below-floor batches (PR #350, 2026-04-20)
 - ✅ `SM §4d`: write `sim-prediction.json` to `_state` after each calibration — fields: `prs_next_batch_floor`, `prs_next_batch_ceiling`, `arch_convergence_score`, `skill_growth_rate`, `calibrated_params`, `calibrated_at` (PR #349, 2026-04-20) ⚠️ Stale — referenced file not found
 - ✅ `scripts/sim-defaults.json`: fleet defaults — written by otherness SM §4d after calibration (otherness-repo-only gate); shipped to managed projects via `git -C ~/.otherness pull` self-update (PR #353, 2026-04-20)
-- ✅ `SM §4e-i`: per-N-cycle calibration update — reads `metrics.md`, runs `calibrate.py --runs 2`, writes `sim-prediction.json` to `_state` every `simulation.calibration_cycles` cycles (default: 5); frequency configurable via `otherness-config.yaml` (PR #401, 2026-04-20)
+- ✅ `SM §4e-i`: per-N-cycle calibration update — reads `metrics.md`, runs `calibrate.py --runs 2`, writes `sim-prediction.json` to `_state` every `simulation.calibration_cycles` cycles (default: 5); frequency configurable via `otherness-config.yaml` (PR #401, 2026-04-20) ⚠️ Stale — referenced file not found
 - ✅ `otherness-config.yaml`: `simulation.calibration_cycles` field (default: 5) — controls SM §4e-i re-calibration frequency (PR #408, 2026-04-20)
 
 ## Future (🔲)

--- a/docs/design/28-dual-step-scheduled-workflow.md
+++ b/docs/design/28-dual-step-scheduled-workflow.md
@@ -179,10 +179,10 @@ done
 ## Present (✅)
 
 - ✅ Design doc created (this file) (2026-04-20)
+- ✅ `otherness-scheduled.yml` in otherness repo: split into two OpenCode steps — Step 7: Vision scan (Step A, `continue-on-error: true`) + Step 8: Run otherness (Step B) (PR #440, 2026-04-20)
 
 ## Future (🔲)
 
-- 🔲 `otherness-scheduled.yml` in otherness repo: split into two OpenCode steps (Step A: vibe-vision, Step B: run)
 - 🔲 `otherness-config-template.yaml`: add `schedule.vibe_vision_step: true` field with comment
 - 🔲 `scripts/validate.sh`: check that scheduled workflow has 2 opencode steps when `vibe_vision_step: true`
 - 🔲 SM §4a cross-project monitoring: detect single-step workflows on managed projects and open upgrade issue


### PR DESCRIPTION
## Summary

- Updates `docs/design/28-dual-step-scheduled-workflow.md`: moves 'dual-step scheduled workflow' from 🔲 Future to ✅ Present
- The workflow was already split into Step A (vision scan) + Step B (run) before this item was queued
- Design doc sync only — no code changes

## Design doc

Updated `docs/design/28-dual-step-scheduled-workflow.md`: dual-step workflow implementation moved from 🔲 Future to ✅ Present.

## Risk tier

**LOW** — docs only, no agent code changes.