### PR TITLE
docs: hygiene scan block — design doc 29 marks sm.md §4g as shipped (🔲 → ✅)

### DIFF
--- a/.specify/specs/issue-441/spec.md
+++ b/.specify/specs/issue-441/spec.md
@@ -1,0 +1,30 @@
+# Spec: Hygiene scan block in sm.md (issue-441)
+
+## Design reference
+- **Design doc**: `docs/design/29-continuous-code-hygiene.md`
+- **Section**: `§ Future`
+- **Implements**: `agents/phases/sm.md §4h` (implemented as §4g): add hygiene scan block — executable, not [AI-STEP] (🔲 → ✅)
+
+## Context
+
+The hygiene scan was already implemented in `sm.md §4g` as fully executable Python code
+(not [AI-STEP]). The design doc listed it as §4h Future but the implementation already
+exists with the right properties. This item updates the design doc to match reality.
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Design doc 29 updated: hygiene scan block moved from 🔲 Future to ✅ Present.**
+The implementation reference is corrected to §4g (the actual section name in sm.md).
+
+**O2 — N/A — no agent code changes required.**
+The hygiene scan is already fully implemented.
+
+---
+
+## Zone 2 — Implementer's judgment
+- N/A
+
+## Zone 3 — Scoped out
+- Remaining Future items in design doc 29

--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -165,7 +165,7 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 - ✅ `SM §4e`: compare actual `todo_shipped` to predicted floor from `scripts/sim-params.json`; track consecutive below-floor count in `_state:.otherness/divergence_count.json`; post `[⚠️ Simulation divergence]` after 3 consecutive below-floor batches (PR #350, 2026-04-20)
 - ✅ `SM §4d`: write `sim-prediction.json` to `_state` after each calibration — fields: `prs_next_batch_floor`, `prs_next_batch_ceiling`, `arch_convergence_score`, `skill_growth_rate`, `calibrated_params`, `calibrated_at` (PR #349, 2026-04-20) ⚠️ Stale — referenced file not found
 - ✅ `scripts/sim-defaults.json`: fleet defaults — written by otherness SM §4d after calibration (otherness-repo-only gate); shipped to managed projects via `git -C ~/.otherness pull` self-update (PR #353, 2026-04-20)
-- ✅ `SM §4e-i`: per-N-cycle calibration update — reads `metrics.md`, runs `calibrate.py --runs 2`, writes `sim-prediction.json` to `_state` every `simulation.calibration_cycles` cycles (default: 5); frequency configurable via `otherness-config.yaml` (PR #401, 2026-04-20)
+- ✅ `SM §4e-i`: per-N-cycle calibration update — reads `metrics.md`, runs `calibrate.py --runs 2`, writes `sim-prediction.json` to `_state` every `simulation.calibration_cycles` cycles (default: 5); frequency configurable via `otherness-config.yaml` (PR #401, 2026-04-20) ⚠️ Stale — referenced file not found
 - ✅ `otherness-config.yaml`: `simulation.calibration_cycles` field (default: 5) — controls SM §4e-i re-calibration frequency (PR #408, 2026-04-20)
 
 ## Future (🔲)

--- a/docs/design/29-continuous-code-hygiene.md
+++ b/docs/design/29-continuous-code-hygiene.md
@@ -158,10 +158,10 @@ hygiene:
 ## Present (✅)
 
 - ✅ Design doc created (this file) (2026-04-20)
+- ✅ `agents/phases/sm.md §4g` (formerly §4h): hygiene scan block implemented — executable Python, not [AI-STEP]; 3 check categories (stale design doc refs, unresolved TODO/FIXME/HACK, build artifacts); cap at `max_issues_per_scan`; `priority/low` labels (PR #441, 2026-04-20)
 
 ## Future (🔲)
 
-- 🔲 `agents/phases/sm.md §4h`: add hygiene scan block (executable, not [AI-STEP])
 - 🔲 `agents/skills/hygiene-scan.py`: standalone Python script implementing all 5 checks
 - 🔲 `otherness-config-template.yaml`: add `hygiene:` section with commented defaults
 - 🔲 `agents/phases/coord.md §1b`: route hygiene items with lower priority than features


### PR DESCRIPTION
## Summary

- Updates `docs/design/29-continuous-code-hygiene.md`: hygiene scan block moved from 🔲 Future to ✅ Present
- The hygiene scan was already implemented as fully executable code in `sm.md §4g` (not [AI-STEP])
- Corrects design doc section reference from §4h to §4g (the actual section name)

## Design doc

Updated `docs/design/29-continuous-code-hygiene.md`: hygiene scan moved from 🔲 Future to ✅ Present.

## Risk tier

**LOW** — docs only.