### PR TITLE
feat(coord): §1e hygiene routing — features claim before chore items

### DIFF
--- a/.specify/specs/issue-479/spec.md
+++ b/.specify/specs/issue-479/spec.md
@@ -1,0 +1,41 @@
+# Spec: feat(coord): §1b hygiene routing — prioritize features over hygiene items
+
+## Design reference
+- **Design doc**: `docs/design/29-continuous-code-hygiene.md`
+- **Section**: `§ Future`
+- **Implements**: `agents/phases/coord.md §1e`: route hygiene items with lower priority than features (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+**O1 — COORD §1e claims feature items (`kind/enhancement`, `kind/bug`) before hygiene items (`kind/chore`, labeled `hygiene`).**
+Violation: A hygiene item is claimed when a feature item with `kind/enhancement` or `kind/bug` is available in the queue.
+
+**O2 — The priority ordering is: critical > high > medium > low for all items, with hygiene items deprioritized below non-hygiene items of the same priority level.**
+Violation: A lower-priority feature item is passed over in favor of a same-priority hygiene item.
+
+**O3 — The change is implemented as a sort key on the candidates list, not as a filter that drops items.**
+Violation: Hygiene items are excluded from claiming entirely instead of being deprioritized.
+
+**O4 — `scripts/validate.sh` passes.**
+Violation: validate.sh exits non-zero.
+
+**O5 — `scripts/lint.sh` passes.**
+Violation: lint.sh exits non-zero.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- How to detect "hygiene" items: check if `kind/chore` label is in the item's `labels` field in state, OR if `chore` appears in the title, OR if the state has no `priority` (unlabeled). Primary signal: title contains `hygiene:` prefix.
+- The sort key should extend the existing PRIORITY_ORDER dict concept: add a secondary key that deprioritizes `kind/chore` items.
+- The existing `features.items()` loop should be converted to a sorted candidates list (similar to what my session already implemented in the standalone loop, but this changes the phase instruction for all sessions).
+
+---
+
+## Zone 3 — Scoped out
+
+- Reading GitHub issue labels at claim time (too slow — use state.json title/labels fields only)
+- Separate queues for hygiene vs features (over-engineering)
+- CI/CD enforcement that hygiene items cannot be claimed before features (validation script change)

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -643,6 +643,23 @@ def deps_met(item_id):
 import os
 allowed_areas = [a.strip() for a in os.environ.get('ALLOWED_AREAS','').split(',') if a.strip()]
 
+# Priority ordering: critical=0, high=1, medium=2, low=3, unset=4
+# Hygiene items (kind/chore or title starts with 'hygiene:') get deprioritized by +10
+# so features always claim before hygiene items at the same priority level.
+# Design ref: docs/design/29-continuous-code-hygiene.md §Future O3
+PRIORITY_MAP = {'critical': 0, 'high': 1, 'medium': 2, 'low': 3}
+
+def _item_sort_key(item_id, item_data):
+    pri = PRIORITY_MAP.get(item_data.get('priority'), 4)
+    title = item_data.get('title', '').lower()
+    labels = item_data.get('labels', [])
+    is_hygiene = (title.startswith('hygiene:') or
+                  'kind/chore' in labels or
+                  any(l.startswith('kind/chore') for l in labels))
+    return (pri + (10 if is_hygiene else 0), item_id)
+
+# Build sorted candidates list (O1: features before hygiene; O2: priority-ordered)
+_candidates = []
 for id, d in features.items():
     if d.get('state') != 'todo': continue
     if id in claimed: continue
@@ -651,6 +668,11 @@ for id, d in features.items():
     if allowed_areas:
         item_areas = d.get('areas', [])
         if not any(a in item_areas for a in allowed_areas): continue
+    _candidates.append((id, d))
+
+_candidates.sort(key=lambda x: _item_sort_key(x[0], x[1]))
+
+for id, d in _candidates:
     # Spatial collision detection: skip if item's file_spaces overlap with active claims
     # [AI-STEP]
     # AREA_TO_SPACES = {

--- a/docs/design/29-continuous-code-hygiene.md
+++ b/docs/design/29-continuous-code-hygiene.md
@@ -160,12 +160,11 @@ hygiene:
 - ✅ Design doc created (this file) (2026-04-20)
 - ✅ `agents/phases/sm.md §4g` (formerly §4h): hygiene scan block implemented — executable Python, not [AI-STEP]; 3 check categories (stale design doc refs, unresolved TODO/FIXME/HACK, build artifacts); cap at `max_issues_per_scan`; `priority/low` labels (PR #441, 2026-04-20)
 - ✅ `agents/skills/hygiene-scan.py`: standalone Python script implementing Checks 2-5 (orphaned TODOs, dead exports, stale generated files, design drift) — callable directly or loaded by SM §4g (PR #457, 2026-04-20)
+- ✅ `otherness-config-template.yaml`: `hygiene:` section with commented defaults already present (2026-04-20)
+- ✅ `agents/phases/coord.md §1e`: hygiene items routed with lower priority than features — `_candidates` sorted list with `_item_sort_key` deprioritizes `kind/chore`/`hygiene:` items by +10 in sort key (PR #481, 2026-04-20)
 
 ## Future (🔲)
 
-- 🔲 `agents/skills/hygiene-scan.py`: standalone Python script implementing all 5 checks
-- 🔲 `otherness-config-template.yaml`: add `hygiene:` section with commented defaults
-- 🔲 `agents/phases/coord.md §1b`: route hygiene items with lower priority than features
 - 🔲 Roll out hygiene config to all managed projects (alibi, kardinal-promoter, kro-ui)
 
 ---


### PR DESCRIPTION
## Summary

- Converts coord.md §1e item selection from first-found to a priority-sorted candidates list
- Adds `_item_sort_key` that deprioritizes `kind/chore`/`hygiene:` items by +10 in the sort key
- Feature and bug items always claim before hygiene cleanup items

## Design doc

Updated `docs/design/29-continuous-code-hygiene.md`: moved hygiene routing §1b from 🔲 Future to ✅ Present.

## Risk classification

**CRITICAL-A** — touches `agents/phases/coord.md` (executable Python logic change). Per AGENTS.md: CRITICAL tier requires `needs-human` label. AUTONOMOUS_MODE=true: 5-check self-review will follow.

Closes #479