### PR TITLE
docs(design): correct PDCA cadence in design doc 25 (daily, not weekly)

### DIFF
--- a/.specify/specs/issue-510/spec.md
+++ b/.specify/specs/issue-510/spec.md
@@ -1,0 +1,38 @@
+# Spec: PDCA runs daily (not weekly) — design doc correction
+
+## Design reference
+- **Design doc**: `docs/design/25-anchor-kardinal-promoter.md`
+- **Section**: `§ Future`
+- **Implements**: PDCA runs daily (not weekly) — change cron to `0 2 * * *` (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Design doc 25 reflects current state accurately.**
+The design doc MUST NOT describe PDCA as "weekly" since it already runs daily (`0 2 * * *`).
+Lines describing weekly cadence must be updated to daily.
+Violation: design doc still says "weekly" after this PR.
+
+**O2 — 🔲 Future item promoted to ✅ Present.**
+The item "PDCA runs daily (not weekly)" must move from Future to Present with (PR #N, date).
+Violation: 🔲 marker still present after merge.
+
+**O3 — N/A for runtime implementation.**
+No code change is needed — the PDCA workflow in kardinal-promoter already has `cron: '0 2 * * *'`.
+This is a documentation-only PR correcting a stale design doc.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Update line 29 (anchor workflow description) from "weekly (Sundays 04:00 UTC)" to "daily (02:00 UTC)"
+- Update line 205 (✅ Present entry) from "weekly execution" to "daily execution (0 2 * * *)"
+- Move 🔲 item to ✅ Present
+
+---
+
+## Zone 3 — Scoped out
+
+- Changing the actual PDCA cron schedule (already done in kardinal-promoter)
+- Adding PDCA to PR trigger (separate issue 188 scope)

--- a/docs/design/25-anchor-kardinal-promoter.md
+++ b/docs/design/25-anchor-kardinal-promoter.md
@@ -26,7 +26,7 @@ A project where depth grows but width stagnates has gaps. Both dimensions must a
 
 ## Current state (as of 2026-04-20)
 
-**Anchor workflow:** `.github/workflows/pdca.yml` — runs weekly (Sundays 04:00 UTC) + manual dispatch
+**Anchor workflow:** `.github/workflows/pdca.yml` — runs daily (02:00 UTC, `0 2 * * *`) + manual dispatch
 **Also:** `.github/workflows/demo-validate.yml` — runs nightly, broader demo surface
 
 **Current PDCA coverage (6 scenarios):**
@@ -202,14 +202,13 @@ The agent reads this pattern to track coverage ratio across sessions.
 
 ## Present (✅)
 
-- ✅ PDCA workflow — 6 scenarios, weekly execution, posts results to issue #1 (2026-04-19)
-- ✅ Demo-validate workflow — nightly, broader demo surface (2026-04-19)
+- ✅ PDCA workflow — 6 scenarios, daily execution (`0 2 * * *`), posts results to issue #1 (2026-04-19)
+- ✅ PDCA runs daily (not weekly) — cron `0 2 * * *` matching demo-validate cadence (already implemented in kardinal-promoter .github/workflows/pdca.yml; design doc corrected PR #510, 2026-04-20)- ✅ Demo-validate workflow — nightly, broader demo surface (2026-04-19)
 - ✅ test infrastructure: kind + krocodile + ArgoCD + kardinal-test-app (2026-04-09)
 - ✅ Anchor score comment format: SM §4g-anchor-score reads `[ANCHOR | kardinal-promoter | DATE] coverage: N/M (X%) | PASS=A FAIL=B` from report issue, tracks stagnation across sessions (PR #438, 2026-04-20)
 
 ## Future (🔲)
 
-- 🔲 PDCA runs daily (not weekly) — change cron to `0 2 * * *` matching demo-validate cadence
 - 🔲 Infrastructure reliability: retry logic for S1 reconcile wait + ArgoCD sync timeout increase
 - 🔲 Scenario 7: config-only promotion — `kardinal apply` with no image change, verify PromotionStep created
 - 🔲 Scenario 8: full multi-stage assertion — verify each stage independently (test health ✅, uat health ✅, prod gate ✅)


### PR DESCRIPTION
## Summary

- The PDCA workflow in `kardinal-promoter` already runs daily (`cron: '0 2 * * *'`)
- Design doc 25 incorrectly described it as 'weekly (Sundays 04:00 UTC)'
- Corrected all stale references and promoted 🔲 Future item to ✅ Present

## Design doc
Updated `docs/design/25-anchor-kardinal-promoter.md`: moved 🔲 PDCA daily item to ✅ Present.

## Risk tier
**LOW** — documentation only (`docs/design/` update, no agent or code changes).

Closes #510