### PR TITLE
docs(design): journey 063-066 error state coverage — update design doc 26

### DIFF
--- a/.specify/specs/issue-511/spec.md
+++ b/.specify/specs/issue-511/spec.md
@@ -1,0 +1,41 @@
+# Spec: Journey depth — error state coverage for journeys 063-070
+
+## Design reference
+- **Design doc**: `docs/design/26-anchor-kro-ui.md`
+- **Section**: `§ Future`
+- **Implements**: Journey depth: add error state coverage to journeys 063-070 (kro v0.9.1 features) (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Error state test added to journeys 063, 064, 065, 066.**
+Each of these 4 journey files must have an "Error resilience" describe block that:
+(a) mocks the primary API to return 503, (b) navigates to the page, (c) asserts no raw error strings,
+(d) asserts layout renders.
+Violation: any of these 4 journeys missing the error block after merge.
+
+**O2 — Design doc 26 marks item as ✅ Present.**
+The 🔲 Future item for journey depth coverage must be moved to ✅ Present.
+Violation: 🔲 marker still present in design doc 26 after merge.
+
+**O3 — No test anti-patterns introduced.**
+Tests must follow kro-ui §XIV E2E discipline: no waitForTimeout, no HTTP status assertions for SPA routes.
+page.route() mocking is explicitly permitted.
+Violation: test uses waitForTimeout or HTTP status check for page existence.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Journeys 067, 068 do not exist in the current test suite — skip them
+- Journeys 069, 070 already have error-aware tests — skip them
+- Pattern: page.route() 503 mock + layout chrome assertion
+
+---
+
+## Zone 3 — Scoped out
+
+- PR to kro-ui is tracked by reference (pnz1990/kro-ui#504)
+- Adding error tests to journeys 069, 070 (already error-aware)
+- Running E2E tests locally (they run in kro-ui CI)

--- a/docs/design/26-anchor-kro-ui.md
+++ b/docs/design/26-anchor-kro-ui.md
@@ -189,10 +189,10 @@ Until depth scoring is implemented, use:
 - ✅ Constitution §XIV E2E standards — anti-patterns documented (PR #311, 2026-04-15)
 - ✅ Anchor score comment format defined: `[ANCHOR | kro-ui | DATE] journeys: J | pass: A fail: B` — SM §4g-anchor-score reads via `anchor.score_pattern` in `otherness-config.yaml` (PR #448, 2026-04-20)
 - ✅ Feature→journey parity check: SM §4g-anchor-parity reads AGENTS.md §Anchor spec inventory, diffs against `anchor.journeys_dir` files, opens anchor-growth issues for specs with no journey (PR #455, 2026-04-20)
+- ✅ Journey depth — error resilience tests added to journeys 063, 064, 065, 066: each file gets an "Error resilience" describe block that mocks the primary API to return 503 and asserts no crash + layout renders (kro-ui PR #504, 2026-04-20; journeys 067/068 absent, 069/070 already error-aware)
 
 ## Future (🔲)
 
-- 🔲 Journey depth: add error state coverage to journeys 063-070 (kro v0.9.1 features)
 - 🔲 Journey depth: add error + empty state to all Tier 1 journeys (001-007)
 - 🔲 First persona journey: Operator — deploy RGD via designer, verify instances appear, check health indicators
 - 🔲 Accessibility: run axe assertions on Tier 1 pages (RGD list, DAG, instance list, context switcher)


### PR DESCRIPTION
## Summary

- Added error resilience tests to kro-ui journeys 063, 064, 065, 066 via [pnz1990/kro-ui#504](https://github.com/pnz1990/kro-ui/pull/504)
- Updated design doc 26 to reflect completed item (🔲 → ✅)

## Design doc
Updated `docs/design/26-anchor-kro-ui.md`: moved journey depth error state item from 🔲 Future to ✅ Present.

## Risk tier
**LOW** — documentation only.

Closes #511