### PR TITLE
docs(design): scenarios 13-15 added to kardinal-promoter PDCA — update design doc 25

### DIFF
--- a/.specify/specs/issue-518/spec.md
+++ b/.specify/specs/issue-518/spec.md
@@ -1,0 +1,36 @@
+# Spec: Scenarios 13-15 — policy gate completeness
+
+## Design reference
+- **Design doc**: `docs/design/25-anchor-kardinal-promoter.md`
+- **Section**: `§ Future`
+- **Implements**: Scenarios 13-15: policy gate completeness (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Scenarios 13, 14, 15 added to kardinal-promoter PDCA workflow.**
+Each scenario must have a dedicated section with pass/fail tracking and RESULTS entry.
+- S13: policy simulate on prod/weekend returns BLOCKED (multiple gates enforced)
+- S14: policy simulate with custom expression returns deterministic output
+- S15: `kardinal override` command executes and creates audit record
+Violation: any of S13/S14/S15 missing from PDCA after merge.
+
+**O2 — Design doc 25 marks item as ✅ Present.**
+The 🔲 Future item must be moved to ✅ Present.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- S13 reuses the weekend simulation time (same as S3) — different assertion
+- S14: "deterministic output" is the test (not specific BLOCKED/PASS since soak time varies)
+- S15: `kardinal override` may fail if pipeline not in right state — non-fatal (⚠️ not ❌)
+- Implementation in kardinal-promoter PR #874
+
+---
+
+## Zone 3 — Scoped out
+
+- Testing the actual gate override effectiveness (would need specific cluster state)
+- S16-18 (health adapter coverage) — separate issue

--- a/docs/design/25-anchor-kardinal-promoter.md
+++ b/docs/design/25-anchor-kardinal-promoter.md
@@ -211,10 +211,10 @@ The agent reads this pattern to track coverage ratio across sessions.
 - ✅ Scenario 8: full multi-stage assertion — test+uat Verified check (S8 in PDCA, 2026-04-20; design doc corrected PR #533)
 - ✅ Scenario 9: health check failure blocks promotion — PromotionStep shows HealthCheck/Failed state (S9 in PDCA, 2026-04-20; design doc corrected PR #533)
 - ✅ Scenarios 10-12: CLI completeness — `kardinal get bundles` (S10), `kardinal delete bundle` (S11), `kardinal get steps` (S12) all in PDCA (2026-04-20; design doc corrected PR #533)
+- ✅ Scenarios 13-15: policy gate completeness — S13 (multiple gates, prod blocked on weekend), S14 (custom expression soak gate simulate), S15 (emergency override K-09 command) added to kardinal-promoter PDCA (PR #874, 2026-04-20)
 
 ## Future (🔲)
 
-- 🔲 Scenarios 13-15: policy gate completeness — multiple gates, custom expression, emergency override
 - 🔲 Scenarios 16-18: health adapter coverage — explicit HTTP, Prometheus, and custom adapter scenarios
 - 🔲 Scenarios 19-21: real-world complexity — 3+ concurrent bundles, app readiness failure, SRE rollback+explain flow
 - 🔲 Scenarios 22-24: persona journeys — developer full lifecycle, platform engineer pipeline setup, SRE incident response


### PR DESCRIPTION
## Summary

- Scenarios 13-15 (policy gate completeness) added to kardinal-promoter PDCA in [PR #874](https://github.com/pnz1990/kardinal-promoter/pull/874)
- S13: multiple gates (prod blocked on weekend), S14: custom expression soak gate, S15: emergency K-09 override
- Design doc 25 updated to reflect completion (🔲 → ✅)

## Design doc
Updated `docs/design/25-anchor-kardinal-promoter.md`: scenarios 13-15 item from 🔲 Future to ✅ Present.

## Risk tier
**LOW** — documentation only.

Closes #518