### PR TITLE
docs(design): scenarios 22-24 persona journeys — update design doc 25

### DIFF
--- a/.specify/specs/issue-521/spec.md
+++ b/.specify/specs/issue-521/spec.md
@@ -1,0 +1,25 @@
+# Spec: Scenarios 22-24 — persona journeys
+
+## Design reference
+- **Design doc**: `docs/design/25-anchor-kardinal-promoter.md`
+- **Section**: `§ Future`
+- **Implements**: Scenarios 22-24: persona journeys (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Scenarios 22, 23, 24 added to kardinal-promoter PDCA.**
+- S22: developer journey (create bundle → status check → rollback)
+- S23: platform engineer journey (pipeline describe + policy gates visible)
+- S24: SRE incident response (audit/history + explain)
+All three must have PDCA sections with RESULTS entries.
+
+**O2 — Design doc 25 ✅ Present for item.**
+
+---
+
+## Zone 3 — Scoped out
+
+- Full persona journey validation requiring specific cluster state
+- UI surface coverage (that's Playwright, a separate issue)

--- a/docs/design/25-anchor-kardinal-promoter.md
+++ b/docs/design/25-anchor-kardinal-promoter.md
@@ -214,10 +214,10 @@ The agent reads this pattern to track coverage ratio across sessions.
 - ✅ Scenarios 13-15: policy gate completeness — S13 (multiple gates, prod blocked on weekend), S14 (custom expression soak gate simulate), S15 (emergency override K-09 command) added to kardinal-promoter PDCA (PR #874, 2026-04-20)
 - ✅ Scenarios 16-18: health adapter coverage — S16 (pipeline stages API structural check), S17 (MetricCheck CRD presence for Prometheus adapter), S18 (pipeline spec dry-run validation for custom health config) added to kardinal-promoter PDCA (PR #874, 2026-04-20)
 - ✅ Scenarios 19-21: real-world complexity — S19 (3+ concurrent bundles), S20 (app with bad image / readiness failure), S21 (SRE explain+rollback full flow) added to kardinal-promoter PDCA (PR #874, 2026-04-20)
+- ✅ Scenarios 22-24: persona journeys — S22 (developer: create→status→rollback), S23 (platform engineer: pipeline describe + policy gates), S24 (SRE: audit+explain flow) added to kardinal-promoter PDCA (PR #874, 2026-04-20)
 
 ## Future (🔲)
 
-- 🔲 Scenarios 22-24: persona journeys — developer full lifecycle, platform engineer pipeline setup, SRE incident response
 - 🔲 Playwright integration in PDCA — first 3 UI scenarios (bundle status, pipeline graph, rollback button)
 - 🔲 Feature→scenario gap detection: SM §4g-anchor reads ✅ Present items from docs/design/*.md, diffs against this coverage matrix, opens anchor-growth issues for uncovered features
 - 🔲 otherness-config.yaml: `anchor:` section — workflow, score_pattern, coverage_target: 80, stagnation_sessions: 3


### PR DESCRIPTION
## Summary
- Scenarios 22-24 added to PDCA in [PR #874](https://github.com/pnz1990/kardinal-promoter/pull/874)
- Design doc 25 updated (🔲 → ✅)
## Risk tier: **LOW**
Closes #521