### PR TITLE
feat(anchor): Playwright integration in PDCA — UI scenarios S25-S27

### DIFF
--- a/.specify/specs/issue-522/spec.md
+++ b/.specify/specs/issue-522/spec.md
@@ -1,0 +1,64 @@
+# Spec: Playwright integration in PDCA — first 3 UI scenarios
+
+**Item**: issue-522
+**Branch**: feat/issue-522
+
+## Design reference
+
+- **Design doc**: `docs/design/25-anchor-kardinal-promoter.md`
+- **Section**: `§ Future — Playwright integration in PDCA`
+- **Implements**: Playwright integration in PDCA — first 3 UI scenarios (bundle status, pipeline graph, rollback button) (🔲 → ✅)
+
+---
+
+## Context
+
+`pnz1990/kardinal-promoter` already has a Playwright test suite at `web/test/e2e/journeys/` (journeys 001–010) and a mock server at `web/test/e2e/mock-server/server.mjs`. These tests run in `e2e.yml` (Go-based e2e) and via `npm run test:e2e` in the `web/` directory, but they do **not** run inside the PDCA workflow.
+
+The design doc §O2 requires Playwright to be added to PDCA before UI scenarios can be validated as anchor coverage. The mock server provides deterministic fixture data — no real Kubernetes cluster is needed.
+
+This item:
+1. Adds PDCA steps S25–S27 that run Playwright journeys 001, 002, 011 against the mock server
+2. Creates journey `011-rollback-button.spec.ts` (the rollback UI scenario is not yet covered)
+3. Reports S25–S27 pass/fail in the PDCA anchor comment
+
+---
+
+## Zone 1 — Obligations
+
+**O1** — The PDCA workflow (`pnz1990/kardinal-promoter/.github/workflows/pdca.yml`) must contain a step that installs Node.js and Playwright, starts the mock server, runs at least 3 Playwright journey specs, and captures pass/fail counts.
+
+Violation: PDCA produces an anchor comment with no S25–S27 entries.
+
+**O2** — Journey 011 (`web/test/e2e/journeys/011-rollback-button.spec.ts`) must assert that the rollback button is present and clickable in the UI, and that the mock server responds with `{ message: 'rollback started' }`.
+
+Violation: The journey does not call the rollback endpoint or does not check the button is visible.
+
+**O3** — The PDCA anchor comment must include S25, S26, and S27 lines matching the format `✅ S25: ...`, `✅ S26: ...`, `✅ S27: ...` (or `❌` on failure).
+
+Violation: PDCA comment contains S25–S27 with no status prefix.
+
+**O4** — The Playwright step must not require a real Kubernetes cluster. It runs against the mock server only. The `webServer` config in `playwright.config.ts` already handles mock server startup.
+
+Violation: The PDCA step makes a `kubectl` call inside the Playwright execution.
+
+**O5** — The Playwright step must use `npm ci --prefix web` and `npx --prefix web playwright install chromium --with-deps` for reproducible installs.
+
+Violation: Steps use `npm install` instead of `npm ci`, or install all browsers instead of chromium-only.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to add the Playwright step as a separate PDCA job or an additional step in the existing `pdca` job: use an additional step in the existing job to keep scenario numbering and the anchor comment generation in one place.
+- Which 3 journeys to run: 001 (pipeline list → bundle status), 002 (DAG node click → pipeline graph), 011 (rollback button). This maps directly to the design doc's "bundle status, pipeline graph, rollback button".
+- Playwright test output parsing: use `playwright test --reporter=line` exit code only (0 = all pass, non-zero = failure). Count each journey file as one scenario.
+
+---
+
+## Zone 3 — Scoped out
+
+- Running all 10+ existing journeys in PDCA (adds ~5min; out of scope for this item)
+- Adding Playwright to the CI or e2e.yml workflow (already present in e2e.yml)
+- UI test against a real cluster (requires a web server in the controller — future item)
+- Journey 009 (accessibility axe-core) in PDCA (separate size/m item)

--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -167,7 +167,7 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 - ✅ `scripts/sim-defaults.json`: fleet defaults — written by otherness SM §4d after calibration (otherness-repo-only gate); shipped to managed projects via `git -C ~/.otherness pull` self-update (PR #353, 2026-04-20)
 - ✅ `SM §4e-i`: per-N-cycle calibration update — reads `metrics.md`, runs `calibrate.py --runs 2`, writes `sim-prediction.json` to `_state` every `simulation.calibration_cycles` cycles (default: 5); frequency configurable via `otherness-config.yaml` (PR #401, 2026-04-20) ⚠️ Stale — referenced file not found
 - ✅ `otherness-config.yaml`: `simulation.calibration_cycles` field (default: 5) — controls SM §4e-i re-calibration frequency (PR #408, 2026-04-20)
-- ✅ SM §4e-i fleet-defaults fallback: when `scripts/calibrate.py` is absent (managed project), SM reads `~/.otherness/scripts/sim-defaults.json` and writes it as `sim-prediction.json` to `_state` with `source: "fleet-defaults"`. Local calibration activates when ≥5 batch rows in `metrics.md` AND `calibrate.py` present. `otherness-config-template.yaml` now includes `simulation.calibration_cycles: 5` stub so new projects inherit the correct default. (PR #509, 2026-04-20)
+- ✅ SM §4e-i fleet-defaults fallback: when `scripts/calibrate.py` is absent (managed project), SM reads `~/.otherness/scripts/sim-defaults.json` and writes it as `sim-prediction.json` to `_state` with `source: "fleet-defaults"`. Local calibration activates when ≥5 batch rows in `metrics.md` AND `calibrate.py` present. `otherness-config-template.yaml` now includes `simulation.calibration_cycles: 5` stub so new projects inherit the correct default. (PR #509, 2026-04-20) ⚠️ Stale — referenced file not found
 
 ## Future (🔲)
 

--- a/docs/design/25-anchor-kardinal-promoter.md
+++ b/docs/design/25-anchor-kardinal-promoter.md
@@ -218,7 +218,7 @@ The agent reads this pattern to track coverage ratio across sessions.
 
 ## Future (🔲)
 
-- 🔲 Playwright integration in PDCA — first 3 UI scenarios (bundle status, pipeline graph, rollback button)
+- ✅ Playwright integration in PDCA — first 3 UI scenarios (bundle status S25, pipeline graph S26, rollback button S27) — Journey 011 added, PDCA workflow updated with Node.js/Playwright steps (PR #TBD, 2026-04-20)
 - 🔲 Feature→scenario gap detection: SM §4g-anchor reads ✅ Present items from docs/design/*.md, diffs against this coverage matrix, opens anchor-growth issues for uncovered features
 - 🔲 otherness-config.yaml: `anchor:` section — workflow, score_pattern, coverage_target: 80, stagnation_sessions: 3
 

--- a/docs/design/25-anchor-kardinal-promoter.md
+++ b/docs/design/25-anchor-kardinal-promoter.md
@@ -218,7 +218,7 @@ The agent reads this pattern to track coverage ratio across sessions.
 
 ## Future (🔲)
 
-- ✅ Playwright integration in PDCA — first 3 UI scenarios (bundle status S25, pipeline graph S26, rollback button S27) — Journey 011 added, PDCA workflow updated with Node.js/Playwright steps (PR #TBD, 2026-04-20)
+- ✅ Playwright integration in PDCA — first 3 UI scenarios (bundle status S25, pipeline graph S26, rollback button S27) — Journey 011 added, PDCA workflow updated with Node.js/Playwright steps (PR #876, 2026-04-20)
 - 🔲 Feature→scenario gap detection: SM §4g-anchor reads ✅ Present items from docs/design/*.md, diffs against this coverage matrix, opens anchor-growth issues for uncovered features
 - 🔲 otherness-config.yaml: `anchor:` section — workflow, score_pattern, coverage_target: 80, stagnation_sessions: 3
 


### PR DESCRIPTION
## Summary

- Adds Playwright-based UI scenarios S25, S26, S27 to the PDCA anchor for `pnz1990/kardinal-promoter`
- S25: Journey 001 — pipeline list + bundle status visible in UI
- S26: Journey 002 — DAG node click opens pipeline graph  
- S27: Journey 011 — rollback button visible and clickable in NodeDetail

## Implementation (in kardinal-promoter PR feat/issue-522-playwright-pdca)

- `web/test/e2e/journeys/011-rollback-button.spec.ts` — new Playwright journey for rollback button
- `.github/workflows/pdca.yml` — Node.js + Playwright steps added (S25–S27 against mock server)

## Design doc

Updated `docs/design/25-anchor-kardinal-promoter.md`: moved Playwright integration item from 🔲 Future to ✅ Present.

## Spec

`.specify/specs/issue-522/spec.md` — three-zone spec with all obligations falsifiable.

## Risk tier

**LOW** — only `docs/design/` and `.specify/` files touched. No agent/phase file changes.