### PR TITLE
feat(validate): check [7/7] — ⚠️ Inferred/Observed items source attribution

### DIFF
--- a/.specify/specs/issue-559/spec.md
+++ b/.specify/specs/issue-559/spec.md
@@ -1,0 +1,38 @@
+# Spec: validate.sh — ⚠️ Inferred item source attribution check
+
+## Design reference
+- **Design doc**: `docs/design/00-marker-conventions.md`
+- **Section**: `§ Future`
+- **Implements**: validate.sh check for ⚠️ Inferred item source attribution format (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+**O1** — `scripts/validate.sh` adds a new check [7/N] that scans all `docs/design/*.md` files for lines matching `^- 🔲 ⚠️ Inferred:` or `^- 🔲 ⚠️ Observed:`.
+
+**O2** — Each such line must end with a parenthetical attribution matching the pattern `(source, YYYY-MM-DD)` where source is one of: `autonomous-vision`, `pm-§5c`, `pm-§5h`, or any non-empty string. A violation is: the line does not end with `(<something>, <date>)`.
+
+**O3** — If any ⚠️ Inferred/Observed item lacks source attribution, `validate.sh` exits with code 1 and prints `ERROR: ⚠️ Inferred item missing attribution: <file>:<item>`.
+
+**O4** — If no ⚠️ Inferred/Observed items are found (or all have attribution), the check exits 0 and prints `OK: all ⚠️ Inferred items have source attribution`.
+
+**O5** — Items inside fenced code blocks (``` ``` ```) are NOT checked — they are documentation examples (e.g., in `00-marker-conventions.md` Future section template). Only real list items outside code blocks are checked.
+
+**O6** — `bash scripts/validate.sh` and `bash scripts/test.sh` both exit 0 after this change.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to use Python or bash for the check: Python is preferred (consistent with other checks in validate.sh).
+- The exact attribution pattern: `\(.*,\s*\d{4}-\d{2}-\d{2}\)` at end of line. Flexible enough for any source name.
+- Whether the check is [7/6] or [7/7]: update the check numbering to reflect total.
+
+---
+
+## Zone 3 — Scoped out
+
+- Checking ⚠️ Observed items in docs/aide/ (not in scope — only docs/design/)
+- Retroactively adding attribution to any existing items (zero such items exist as of 2026-04-20)
+- Checking attribution format in PROVENANCE.md or other non-design docs

--- a/docs/design/00-marker-conventions.md
+++ b/docs/design/00-marker-conventions.md
@@ -57,12 +57,13 @@ COORD skips all 🚫 items. They remain for history.
 
 ## Present (✅)
 
+- ✅ `scripts/validate.sh` check [7/7]: ⚠️ Inferred/Observed items must have source attribution `(source, YYYY-MM-DD)` — items in code blocks exempt (PR #559, 2026-04-20)
+
 - ✅ ✅/🔲 markers — original design doc vocabulary (introduced in Stage 3, 2026-04-14)
 - ✅ 🚫 Deprecated marker — COORD queue-gen skips deprecated items (PR #209, 2026-04-17)
 - ✅ ⚠️ Inferred marker — PM §5c writes competitive gap stubs with this prefix (PR #311, 2026-04-19)
 - ✅ ⚠️ Observed marker — PM §5h writes emergent pattern stubs with this prefix (PR #311, 2026-04-19)
 
 ## Future (🔲)
-- 🔲 ⚠️ Inferred: validate.sh check for ⚠️ Inferred item source attribution — each ⚠️ Inferred item in docs/design/ should follow the format `(autonomous-vision|pm-§5c, YYYY-MM-DD)` to preserve provenance. (autonomous-vision, 2026-04-20)
 
 *(All marker conventions defined. Future refinements should be opened as new issues.)*

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -17,7 +17,7 @@ echo "=== otherness validate ==="
 #             <owner>/<X> that isn't <owner>/otherness. Falls back gracefully.
 #   Rule 2 — reads fleet project names from otherness-config.yaml monitor.projects
 #             and catches them in project-reference context.
-echo "[1/5] Checking for hardcoded project paths in agent files..."
+echo "[1/7] Checking for hardcoded project paths in agent files..."
 
 # Resolve owner from config (used in Rule 1)
 OWNER=$(python3 -c "
@@ -94,7 +94,7 @@ done
 # Skill paths use ~/.otherness/agents/skills/<name>.md — on a CI runner ~/.otherness
 # doesn't exist, but the files are present in the repo at agents/skills/<name>.md.
 # We resolve both locations: prefer the expanded ~ path, fall back to repo-local.
-echo "[2/5] Checking skill references..."
+echo "[2/7] Checking skill references..."
 MISSING=0
 while IFS= read -r line; do
   # Extract path after "Load skill: read `" up to closing backtick
@@ -116,7 +116,7 @@ done < <(grep "Load skill: read" "$AGENTS_DIR/standalone.md" "$AGENTS_DIR/phases
 [ $MISSING -eq 0 ] && echo "  OK: all skill refs resolve" || exit 1
 
 # 3. Check required files exist
-echo "[3/5] Checking required files..."
+echo "[3/7] Checking required files..."
 REQUIRED=(
   "$AGENTS_DIR/standalone.md"
   "$AGENTS_DIR/bounded-standalone.md"
@@ -164,7 +164,7 @@ done
 [ $MISSING_FILES -eq 0 ] && echo "  OK: all required files present" || exit 1
 
 # 4. Check self-update is present in standalone.md
-echo "[4/5] Checking self-update mechanism..."
+echo "[4/7] Checking self-update mechanism..."
 if ! grep -q "git -C ~/.otherness pull" "$AGENTS_DIR/standalone.md"; then
   echo "  ERROR: standalone.md missing self-update (git pull) mechanism"
   exit 1
@@ -174,7 +174,7 @@ echo "  OK: self-update present"
 # 5. Check all spec.md files contain ## Design reference
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SPECS_DIR="$ROOT_DIR/.specify/specs"
-echo "[5/5] Checking spec files for ## Design reference..."
+echo "[5/7] Checking spec files for ## Design reference..."
 if [ ! -d "$SPECS_DIR" ]; then
   echo "  OK: no .specify/specs/ directory — skipping spec lint"
 else
@@ -189,7 +189,7 @@ else
 fi
 
 # 6. Check every agent file has a ## MODE block
-echo "[6/6] Checking agent files for ## MODE block..."
+echo "[6/7] Checking agent files for ## MODE block..."
 MISSING_MODE=0
 for agent_file in "$AGENTS_DIR"/*.md "$AGENTS_DIR/phases"/*.md; do
   [ -f "$agent_file" ] || continue
@@ -260,6 +260,55 @@ except:
     fi
   fi
 fi
+
+# 7. Check ⚠️ Inferred and ⚠️ Observed items have source attribution
+# Each such item must end with a parenthetical attribution: (source, YYYY-MM-DD)
+# Items inside fenced code blocks are excluded (they are documentation examples).
+echo "[7/7] Checking ⚠️ Inferred/Observed items have source attribution..."
+python3 - <<'INFERRED_CHECK'
+import re, os, sys
+
+DESIGN_DIR = os.path.join(os.getcwd(), 'docs', 'design')
+DESIGN_DIR = os.path.normpath(DESIGN_DIR)
+
+# Attribution pattern: ends with (anything, YYYY-MM-DD) or (anything, YYYY-MM-DD).
+ATTRIBUTION_RE = re.compile(r'\([^()]+,\s*\d{4}-\d{2}-\d{2}\)\.?\s*$')
+
+errors = []
+
+if not os.path.isdir(DESIGN_DIR):
+    print("  OK: docs/design/ not found — skipping ⚠️ attribution check")
+    sys.exit(0)
+
+for fname in sorted(os.listdir(DESIGN_DIR)):
+    if not fname.endswith('.md'):
+        continue
+    filepath = os.path.join(DESIGN_DIR, fname)
+    try:
+        content = open(filepath).read()
+    except Exception:
+        continue
+
+    # Remove fenced code blocks to avoid false positives in examples
+    content_no_code = re.sub(r'```.*?```', '', content, flags=re.DOTALL)
+
+    for lineno, line in enumerate(content_no_code.splitlines(), 1):
+        # Check for ⚠️ Inferred or ⚠️ Observed items
+        if not re.search(r'^- 🔲 ⚠️ (Inferred|Observed):', line):
+            continue
+        # Must have source attribution
+        if not ATTRIBUTION_RE.search(line):
+            errors.append(f"  ERROR: {fname}: ⚠️ Inferred/Observed item missing attribution: {line.strip()[:80]}")
+
+if errors:
+    for e in errors:
+        print(e)
+    print(f"  {len(errors)} item(s) missing source attribution.")
+    print("  Format required: (source, YYYY-MM-DD) at end of item")
+    sys.exit(1)
+else:
+    print("  OK: all ⚠️ Inferred/Observed items have source attribution")
+INFERRED_CHECK
 
 echo ""
 echo "=== validate: PASSED ==="


### PR DESCRIPTION
## Summary

Adds `scripts/validate.sh` check [7/7] that verifies all `⚠️ Inferred` and `⚠️ Observed` items in `docs/design/*.md` have source attribution in the format `(source, YYYY-MM-DD)`.

## What changed

- **`scripts/validate.sh`**: New check [7/7] scans `docs/design/*.md` for `🔲 ⚠️ Inferred:` and `🔲 ⚠️ Observed:` lines, verifies each ends with `(source, YYYY-MM-DD)` attribution. Items in fenced code blocks are excluded.
- Check numbering updated throughout validate.sh from N/5 and N/6 to N/7.

## Why this matters

Items synthesized by the autonomous vision agent (SM §4h, `agents/autonomous-vision.md`) and PM §5c competitive observations should be traceable to their source. Without attribution, the human cannot tell whether a Future item came from human intent or machine synthesis — the `⚠️` marker is the only signal.

## Test results

```
[7/7] Checking ⚠️ Inferred/Observed items have source attribution...
  OK: all ⚠️ Inferred/Observed items have source attribution
=== validate: PASSED ===
```

## Design doc
Updated `docs/design/00-marker-conventions.md`: moved validate.sh ⚠️ attribution check from 🔲 Future to ✅ Present.