### PR TITLE
docs(design): add docs/design/34-stage-9-autonomous-vision.md — stage-level doc

### DIFF
--- a/docs/design/18-autonomous-vision-synthesis.md
+++ b/docs/design/18-autonomous-vision-synthesis.md
@@ -133,12 +133,13 @@ This distinction matters because:
 
 ## Present (✅)
 
+- ✅ `docs/design/34-stage-9-autonomous-vision.md` — stage-level design doc: deliverables, completion threshold, present/future sections (PR #561, 2026-04-20)
+
 - ✅ `docs/aide/definition-of-done.md` Journey 9 — autonomous vision synthesis loop: SM §4h triggers, agent produces ⚠️ Inferred items, COORD picks up without human restart (PR #560, 2026-04-20)
 
 - ✅ COORD queue gen: `✅ ⚠️ Inferred` items matched by existing regex (no change needed); `is_done()` strips `⚠️ Inferred/Observed:` prefix before deduplication (PR #316, 2026-04-19)
 
 ## Future (🔲)
-- 🔲 ⚠️ Inferred: docs/design/34-stage-9-autonomous-vision.md — stage-level design doc for Stage 9 (Autonomous Vision Synthesis), mirroring the pattern of docs/design/30-33 for Stages 0-4. (autonomous-vision, 2026-04-20)
 
 - ✅ `agents/autonomous-vision.md` — MODE: VISION, no dialogue; 4-phase batch process: read corpus, synthesize (5 patterns), write 🔲 ⚠️ Inferred items, commit (PR #313, 2026-04-19)
 - ✅ SM phase trigger — SM §4h checks all 4 conditions; creates vision/auto-<date> branch; runs agents/autonomous-vision.md when deployed; records last_auto_vision_cycle in state.json (PR #314, 2026-04-19)

--- a/docs/design/34-stage-9-autonomous-vision.md
+++ b/docs/design/34-stage-9-autonomous-vision.md
@@ -1,0 +1,86 @@
+# 34: Stage 9 — Autonomous Vision Synthesis
+
+> Status: Active | Created: 2026-04-20
+> Mirrors: docs/design/30-stage-0-scaffolding.md pattern (one doc per completed stage)
+> Applies to: otherness itself
+
+---
+
+## Stage goal
+
+`/otherness.run` is perpetually self-sustaining when no human is present. When the queue empties and no human runs `/otherness.vibe-vision`, an autonomous vision agent reads the system's own knowledge corpus and synthesizes new `🔲 ⚠️ Inferred` Future items. The loop restarts itself.
+
+The human remains the highest-fidelity source of direction — but between human sessions, the system maintains its own momentum.
+
+From `docs/aide/roadmap.md` §Stage 9:
+
+> **Goal**: The loop never stalls waiting for a human to bring new direction. When the queue empties and no human is present, an autonomous vision agent reads the system's own knowledge corpus and synthesizes new `🔲 ⚠️ Inferred` Future items. The loop restarts itself.
+
+---
+
+## Deliverables
+
+| Deliverable | Status | PR | Date |
+|---|---|---|---|
+| `agents/autonomous-vision.md` — MODE: VISION, no dialogue; 4-phase batch process | ✅ Shipped | #313 | 2026-04-19 |
+| SM §4h trigger — queue empty + conditions + rate limit: create vision branch, run agent | ✅ Shipped | #314 | 2026-04-19 |
+| PM §5m: `⚠️ Inferred` ratio check — posts vibe-vision suggestion when >80% machine-generated | ✅ Shipped | #315, #318 | 2026-04-20 |
+| COORD queue gen: strips `⚠️ Inferred/Observed:` prefix before dedup | ✅ Shipped | #316 | 2026-04-19 |
+| Journey 9 in definition-of-done | ✅ Shipped | #563 | 2026-04-20 |
+| State tracking: `last_auto_vision_cycle` persisted to `state.json` | ✅ Shipped | #314 | 2026-04-19 |
+
+---
+
+## Stage completion threshold
+
+From `docs/aide/roadmap.md` §Stage 9:
+
+> The queue empties. No human runs `/otherness.vibe-vision`. Within one SM cycle, the autonomous vision agent produces at least 3 `🔲 ⚠️ Inferred` items. COORD picks them up. A new batch runs. The loop never entered true standby.
+
+**Status: ✅ VALIDATED** — Batch 87 (2026-04-20): queue emptied, SM §4h triggered, 4 ⚠️ Inferred items synthesized (PR #558), COORD queued 3 as GitHub issues (#559, #560, #561), 2 shipped in same batch (#559, #560).
+
+---
+
+## Present (✅)
+
+- ✅ `agents/autonomous-vision.md` — MODE: VISION, no dialogue; corpus reading, rule-based synthesis (5 patterns), ⚠️ Inferred item writing, commit (PR #313, 2026-04-19)
+- ✅ SM §4h trigger — checks 4 conditions (queue empty, no ⚠️ stubs, health GREEN/AMBER, ≥3 cycles since last run); creates `vision/auto-<date>` branch; runs autonomous-vision.md (PR #314, 2026-04-19)
+- ✅ `state.json` `last_auto_vision_cycle` — persisted so rate limit tracks across sessions (PR #314, 2026-04-19)
+- ✅ COORD queue gen — `is_done()` strips `⚠️ Inferred/Observed:` prefix before deduplication (PR #316, 2026-04-19)
+- ✅ PM §5m — `⚠️ Inferred` ratio check: if >80% Future items are machine-generated, posts vibe-vision suggestion on report issue (PR #315, PR #318 header, 2026-04-20)
+- ✅ Journey 9 in `docs/aide/definition-of-done.md` — automated check commands + pass criteria (PR #563, 2026-04-20)
+- ✅ validate.sh check [7/7] — ⚠️ Inferred/Observed items must have source attribution `(source, YYYY-MM-DD)` (PR #562, 2026-04-20)
+
+## Future (🔲)
+
+*(No unimplemented items — Stage 9 is complete.)*
+
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — The autonomous vision agent writes only `🔲 ⚠️ Inferred` items, never plain `🔲`.**
+Plain `🔲` is reserved for human-scoped intent. The marker distinction is the only signal the human has about provenance.
+
+**O2 — The SM §4h trigger has a rate limit: at least 3 batches between autonomous runs.**
+Without this, the agent floods the queue with machine-generated items.
+
+**O3 — The `⚠️ Inferred` ratio is tracked and surfaced to the human when >80%.**
+PM §5m reports the ratio. The system never silently becomes purely machine-directed.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- First version: rule-based synthesis (5 patterns). LLM-assisted synthesis is a future evolution.
+- Items synthesized per run: 3–5 maximum. Never flood.
+- PR lifecycle for vision synthesis: open PR from `vision/auto-<date>` branch, CI passes, autonomous merge. No CRITICAL tier gatekeeping for DOCS zone changes.
+
+---
+
+## Zone 3 — Scoped out
+
+- LLM-assisted synthesis in first version
+- Cross-project autonomous vision (Stage 9 is otherness-self only)
+- Autonomous modification of `vision.md` or `roadmap.md`


### PR DESCRIPTION
## Summary

Creates `docs/design/34-stage-9-autonomous-vision.md` — the stage-level design doc for Stage 9 (Autonomous Vision Synthesis), mirroring the pattern established by docs/design/30-33 for Stages 0-4.

## What changed

- **`docs/design/34-stage-9-autonomous-vision.md`**: New file. Stage goal, deliverables table with ✅/🔲 status, completion threshold, Present/Future sections, Zone 1/2/3 structure.
- **`docs/design/18-autonomous-vision-synthesis.md`**: Moved stage-doc-gap item from 🔲 Future → ✅ Present.

## Stage 9 completion documented

| Deliverable | Status |
|---|---|
| autonomous-vision.md (MODE: VISION) | ✅ #313 |
| SM §4h trigger | ✅ #314 |
| PM §5m ratio check | ✅ #315, #318 |
| COORD dedup stripping | ✅ #316 |
| Journey 9 in definition-of-done | ✅ #563 |
| state.json tracking | ✅ #314 |
| validate.sh [7/7] check | ✅ #562 |

**Stage validation**: Batch 87 (2026-04-20) — queue emptied, SM §4h fired, 4 ⚠️ Inferred items produced, 3 issued, 2 shipped. Threshold met.

## Design doc
Updated `docs/design/18-autonomous-vision-synthesis.md`: moved stage-doc-gap item from 🔲 Future to ✅ Present.