### PR TITLE
feat(anchor): add anchor: section to kro-ui otherness-config.yaml

### DIFF
--- a/.specify/specs/issue-567/spec.md
+++ b/.specify/specs/issue-567/spec.md
@@ -1,0 +1,39 @@
+# Spec: anchor: section in kro-ui otherness-config.yaml
+
+## Design reference
+- **Design doc**: `docs/design/26-anchor-kro-ui.md`
+- **Section**: `§ Future`
+- **Implements**: otherness-config.yaml: `anchor:` section — score_pattern for `[ANCHOR | kro-ui]`, coverage_target: 60, stagnation_sessions: 5 (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: `kro-ui/otherness-config.yaml` MUST contain an `anchor:` section with the following fields:
+- `score_pattern`: regex that matches `[ANCHOR | kro-ui | <date>]` lines posted to issue #439
+- `coverage_target`: integer `60` (minimum depth score % for kro-ui)
+- `stagnation_sessions`: integer `5` (sessions without anchor growth before COORD prioritizes)
+
+**O2**: The `score_pattern` MUST match the format defined in docs/design/26-anchor-kro-ui.md:
+`[ANCHOR | kro-ui | YYYY-MM-DD] journeys: J | pass: A fail: B`
+A pattern that does not match this format violates O2.
+
+**O3**: `docs/design/26-anchor-kro-ui.md` MUST have the `anchor:` section Future item moved from 🔲 to ✅ Present, with PR reference and date.
+
+**O4**: `otherness-config-template.yaml` MUST include the `journeys_dir` field in its anchor section comment since kro-ui uses it — ensuring the template stays current with real usage.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- The `score_pattern` regex may use either the full anchor format or the simplified one (journeys/pass/fail); the simplified format is what's currently posted so use it.
+- Whether to add `journeys_dir` to kro-ui's config: the SM §4g-anchor-parity reads this field. Add it pointing to `test/e2e/journeys/`.
+- The `anchor.workflow` field: kro-ui uses `e2e.yml`. Set it.
+
+---
+
+## Zone 3 — Scoped out
+
+- Implementing the anchor workflow itself (already exists in kro-ui)
+- Changes to SM §4g-anchor logic
+- Updating other managed project configs (kardinal-promoter, alibi)

--- a/.specify/specs/issue-567/tasks.md
+++ b/.specify/specs/issue-567/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: issue-567 — anchor: section in kro-ui otherness-config.yaml
+
+- [CMD] Read kro-ui/otherness-config.yaml current state (verify anchor: section is absent)
+- [AI] Determine correct score_pattern regex for `[ANCHOR | kro-ui | YYYY-MM-DD]` format
+- [CMD] Create PR on kro-ui repo: add anchor: section to otherness-config.yaml
+- [AI] Update docs/design/26-anchor-kro-ui.md: move 🔲 → ✅ for anchor config item
+- [CMD] Verify otherness-config-template.yaml has journeys_dir comment
+- [CMD] Run validate.sh and test.sh from worktree
+- [CMD] Commit and push feat/issue-567 branch
+- [CMD] Open PR on otherness repo

--- a/docs/design/26-anchor-kro-ui.md
+++ b/docs/design/26-anchor-kro-ui.md
@@ -197,7 +197,7 @@ Until depth scoring is implemented, use:
 - ✅ First persona journey: Operator — deploy RGD via designer, verify instances appear, check health indicators — implemented as `test/e2e/journeys/071-operator-persona-journey.spec.ts` in kro-ui (design doc corrected PR #543, 2026-04-20)
 - ✅ Accessibility: run axe assertions on Tier 1 pages (RGD list, DAG, instance list, context switcher) — journey 074 added with @axe-core/playwright, WCAG 2.1 AA, critical/serious violations block CI (kro-ui PR #512, 2026-04-20)
 - ✅ kro upstream tracking: when kro version bumps, SM §4g-anchor-upstream opens anchor-growth issue for new API surface — configurable via anchor.upstream_version_file + anchor.upstream_version_pattern (PR #545, 2026-04-20)
-- 🔲 otherness-config.yaml: `anchor:` section — score_pattern for `[ANCHOR | kro-ui]`, coverage_target: 60, stagnation_sessions: 5
+- ✅ otherness-config.yaml: `anchor:` section — score_pattern for `[ANCHOR | kro-ui]` journeys/pass/fail format, coverage_target: 60, stagnation_sessions: 5, journeys_dir: test/e2e/journeys (kro-ui PR #526, 2026-04-20)
 - 🔲 docs/design/: add design docs for major feature areas (RGD display, instance management, health system, designer) to enable generic gap detection
 
 ---


### PR DESCRIPTION
## Summary

Implements the design doc Future item: adds the `anchor:` section to kro-ui's `otherness-config.yaml`, enabling SM §4g-anchor to read kro-ui's E2E anchor score and detect stagnation.

## Changes

### kro-ui/otherness-config.yaml (kro-ui PR #526)
Added `anchor:` section:
- `workflow: e2e.yml` — kro-ui's Playwright E2E workflow  
- `score_pattern`: regex matching `[ANCHOR | kro-ui | DATE] journeys: J | pass: A fail: B`
- `coverage_target: 60` — minimum depth score % per design doc 26
- `stagnation_sessions: 5` — sessions without anchor growth before COORD prioritizes
- `journeys_dir: test/e2e/journeys` — for SM §4g-anchor-parity feature→journey gap detection

### docs/design/26-anchor-kro-ui.md
Moved `otherness-config.yaml: anchor: section` from 🔲 Future → ✅ Present with kro-ui PR #526 reference.

## Design doc
Updated `docs/design/26-anchor-kro-ui.md`: moved anchor config item from 🔲 Future to ✅ Present.

## Closes
Closes #567