### PR TITLE
docs(anchor): add kro-ui design docs for major feature areas (28-31)

### DIFF
--- a/.specify/specs/issue-568/spec.md
+++ b/.specify/specs/issue-568/spec.md
@@ -1,0 +1,43 @@
+# Spec: kro-ui design docs for major feature areas
+
+## Design reference
+- **Design doc**: `docs/design/26-anchor-kro-ui.md`
+- **Section**: `§ Future`
+- **Implements**: docs/design/: add design docs for major feature areas (RGD display, instance management, health system, designer) to enable generic gap detection (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: kro-ui's `docs/design/` MUST have at minimum 4 new design docs covering:
+1. RGD display (list, DAG, detail, diff)
+2. Instance management (list, detail, health, deletion debugger)
+3. Health system (rollup badges, error patterns, state machine)
+4. RGD designer (authoring, generate form, YAML preview)
+
+Each doc MUST follow the structure: ## Present (✅) / ## Future (🔲) / ## Zone 1 Obligations.
+
+**O2**: Each design doc MUST list at least 3 ✅ Present items referencing actual merged PRs (using the same PRs from AGENTS.md spec inventory table) so the gap detection algorithm has real signal to work with.
+
+**O3**: Each design doc MUST include at least 1 🔲 Future item so COORD can generate queue items from them going forward.
+
+**O4**: `docs/design/26-anchor-kro-ui.md` in kro-ui MUST be updated: move the "add design docs" Future item from 🔲 to ✅ Present.
+
+**O5**: The corresponding `docs/design/26-anchor-kro-ui.md` in otherness (this repo) MUST also be updated to reflect ✅ Present.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Number of docs: minimum 4, one per feature area. Combining areas into fewer docs is acceptable if coverage is maintained.
+- Depth of Present items: 3-5 per doc is sufficient; exhaustive coverage is out of scope.
+- Future items: 1-3 per doc; lean toward concrete, implementable items.
+- Design doc numbering: kro-ui currently has 26 and 27 in docs/design/. New docs: 28, 29, 30, 31.
+
+---
+
+## Zone 3 — Scoped out
+
+- Implementing any of the Future items in the new docs
+- Creating the gap detection algorithm itself (already in SM §4g)
+- Design docs for testing infrastructure or CI tooling

--- a/docs/design/26-anchor-kro-ui.md
+++ b/docs/design/26-anchor-kro-ui.md
@@ -198,7 +198,7 @@ Until depth scoring is implemented, use:
 - ✅ Accessibility: run axe assertions on Tier 1 pages (RGD list, DAG, instance list, context switcher) — journey 074 added with @axe-core/playwright, WCAG 2.1 AA, critical/serious violations block CI (kro-ui PR #512, 2026-04-20)
 - ✅ kro upstream tracking: when kro version bumps, SM §4g-anchor-upstream opens anchor-growth issue for new API surface — configurable via anchor.upstream_version_file + anchor.upstream_version_pattern (PR #545, 2026-04-20)
 - ✅ otherness-config.yaml: `anchor:` section — score_pattern for `[ANCHOR | kro-ui]` journeys/pass/fail format, coverage_target: 60, stagnation_sessions: 5, journeys_dir: test/e2e/journeys (kro-ui PR #526, 2026-04-20)
-- 🔲 docs/design/: add design docs for major feature areas (RGD display, instance management, health system, designer) to enable generic gap detection
+- ✅ docs/design/: add design docs for major feature areas (RGD display, instance management, health system, designer) to enable generic gap detection — design docs 28-31 added to kro-ui (kro-ui PR #528, 2026-04-20)
 
 ---
 


### PR DESCRIPTION
## Summary

Creates 4 design docs in kro-ui covering major feature areas, unblocking the generic gap detection algorithm (SM §4g) which reads ✅ Present / 🔲 Future markers from `docs/design/`.

## Changes

### kro-ui (PR #528)
New design docs:
- `docs/design/28-rgd-display.md` — RGD list, catalog, detail, DAG, schema docs (11 Present, 3 Future)
- `docs/design/29-instance-management.md` — instance list, detail, health, deletion (12 Present, 3 Future)
- `docs/design/30-health-system.md` — health states, error patterns, SRE dashboard (10 Present, 3 Future)
- `docs/design/31-rgd-designer.md` — authoring, generate form, YAML editor, optimization (9 Present, 3 Future)

### otherness (this PR)
- `docs/design/26-anchor-kro-ui.md`: moved `docs/design/: add design docs for major feature areas` from 🔲 Future → ✅ Present (kro-ui PR #528)

## Design doc
Updated `docs/design/26-anchor-kro-ui.md`: moved design docs Future item from 🔲 to ✅ Present.

## Closes
Closes #568