### PR TITLE
docs(template): add journeys_dir to anchor: section

### DIFF
--- a/.specify/specs/issue-572/spec.md
+++ b/.specify/specs/issue-572/spec.md
@@ -1,0 +1,26 @@
+# spec: issue-572 — add journeys_dir to anchor: section in template
+
+## Design reference
+- N/A — infrastructure change with no user-visible behavior
+
+## Zone 1 — Obligations
+
+O1: `otherness-config-template.yaml` `anchor:` section MUST include a commented-out `journeys_dir` field.
+- Violation: anchor: section exists but does not contain `journeys_dir`.
+
+O2: The comment text MUST explain what `journeys_dir` is used for (SM §4g-anchor-parity).
+- Violation: field is present but has no explanatory comment.
+
+O3: The field MUST be commented out (prefixed with `#`) so it does not affect projects that don't use it.
+- Violation: field is uncommented and would be active by default.
+
+## Zone 2 — Implementer's judgment
+
+- Exact wording and indentation is up to the implementer, following the pattern of existing commented-out fields.
+- Placement: after the existing `# upstream_version_file` and `# upstream_version_pattern` lines.
+
+## Zone 3 — Scoped out
+
+- Changing any other template fields
+- Updating otherness-config.yaml for any project
+- Documenting journeys_dir beyond the inline comment

--- a/otherness-config-template.yaml
+++ b/otherness-config-template.yaml
@@ -216,3 +216,4 @@ anchor:
   stagnation_sessions: 3                               # sessions without anchor growth before COORD prioritizes it
   # upstream_version_file: go.mod                       # file to grep for upstream version (e.g. go.mod)
   # upstream_version_pattern: "github.com/awslabs/kro"  # pattern to find in the file (e.g. kro dependency line)
+  # journeys_dir: "test/e2e/journeys"                   # path to journey files; used by SM §4g-anchor-parity


### PR DESCRIPTION
## Summary

Adds commented-out `journeys_dir` field to the `anchor:` section in `otherness-config-template.yaml`.

Projects with E2E suites (e.g. kro-ui after PR #526) use `journeys_dir` for SM §4g-anchor-parity spec→journey parity checks. The template should reflect all configurable anchor fields so new projects can discover it without manual research.

## Change

Single line added to `otherness-config-template.yaml`:
```yaml
  # journeys_dir: "test/e2e/journeys"  # path to journey files; used by SM §4g-anchor-parity
```

## Design doc

- N/A — infrastructure/documentation change with no user-visible behavior

## Risk tier

HIGH — `otherness-config-template.yaml` requires human review before autonomous merge per AGENTS.md §Change Risk Tiers.

Closes #572