### PR TITLE
docs(security): mark M5b as 🚫 DEFERRED so queue-gen skips it

### DIFF
--- a/.specify/specs/issue-594/spec.md
+++ b/.specify/specs/issue-594/spec.md
@@ -1,0 +1,23 @@
+# Spec: Mark M5b as explicitly DEFERRED in design doc
+
+## Design reference
+- **Design doc**: `docs/design/27-security-model.md`
+- **Section**: `§ Future`
+- **Implements**: M5b: Add 🚫 marker to DEFERRED items so queue-gen skips them (🔲 → annotated)
+
+## Zone 1 — Obligations
+
+**O1**: The M5b line in `docs/design/27-security-model.md` must contain `🚫` so queue-gen
+regex `🔲 (?!.*🚫)` skips it on future runs.
+
+**O2**: No new GitHub issues are created for M5b on next queue-gen run.
+
+## Zone 2 — Implementer's judgment
+
+Which exact annotation format to use: the design doc already says "DEFERRED" in the
+body. Adding `🚫` to the start after `🔲` satisfies queue-gen's skip regex.
+
+## Zone 3 — Scoped out
+
+- No implementation of Bedrock ARN restriction itself (explicitly DEFERRED)
+- No changes to queue-gen logic

--- a/docs/design/27-security-model.md
+++ b/docs/design/27-security-model.md
@@ -537,7 +537,7 @@ The following are accepted design tradeoffs, not failures:
 
 ## Future (🔲)
 
-- 🔲 M5b: Restrict Bedrock Resource to specific ARNs — DEFERRED. opencode uses cross-region inference profile ARNs (arn:aws:bedrock:<region>:<acct>:inference-profile/*) that vary by model version. Resource:* with Budget alert is the current mitigaton. Revisit when ARN patterns stabilize.
+- 🔲 🚫 M5b: Restrict Bedrock Resource to specific ARNs — DEFERRED. opencode uses cross-region inference profile ARNs (arn:aws:bedrock:<region>:<acct>:inference-profile/*) that vary by model version. Resource:* with Budget alert is the current mitigaton. Revisit when ARN patterns stabilize.
 - 🔲 M3: Replace GH_TOKEN PAT with GitHub App — per-repo scoped, non-exportable, auditable (issue #361)
 
 ---


### PR DESCRIPTION
## Summary

Adds 🚫 marker to M5b (Restrict Bedrock Resource to specific ARNs) in the security design doc.
This item is explicitly deferred — the current ARN patterns for cross-region inference profiles
are unstable. The queue-gen regex skips items matching `🔲 (?!.*🚫)`, so this prevents the
item from being re-queued on every session.

## Design doc
Updated `docs/design/27-security-model.md`: M5b line now reads `🔲 🚫 M5b: ...` — will be skipped by queue-gen.

## Customer doc
N/A — internal queue management only.