### PR TITLE
feat(coord): queue refusal guard — enrich chore-only queues before claiming

### DIFF
--- a/.specify/specs/issue-614/spec.md
+++ b/.specify/specs/issue-614/spec.md
@@ -1,0 +1,36 @@
+# Spec: coord.md §1c Queue Refusal Guard
+
+## Design reference
+- **Design doc**: `docs/design/35-quality-of-output-gaps.md`
+- **Section**: `§ Future`
+- **Implements**: `coord.md §1c`: queue refusal guard — when all items in the queue are `kind/chore` or `kind/docs` (no `kind/enhancement` or `kind/bug`), trigger a minimum queue depth refresh from roadmap or autonomous vision before claiming the next item; a session that starts on a chore-only queue should inject ≥1 vision item first
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: When `§1e` selects the next item to claim, if ALL remaining `state=todo` items have labels in `{kind/chore, kind/docs}` (and none have `kind/enhancement` or `kind/bug`), the queue refusal guard MUST trigger before claiming any item.
+
+**O2**: The guard triggers queue-gen from the next available source (design docs `🔲 Future` → roadmap → autonomous vision), creating ≥1 `kind/enhancement` item before the claim proceeds.
+
+**O3**: The guard fires at `§1c` — not at `§1e`. It is a pre-claim enrichment gate that runs as part of queue generation when the queue is chore-only.
+
+**O4**: The guard must not block indefinitely. If no enrichment source produces `kind/enhancement` items after one attempt, the guard logs a warning and allows claiming a chore item to avoid stalling.
+
+**O5**: A comment is posted on the report issue when the guard fires, indicating it enriched the queue.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Implementation location: within `coord.md §1c`, after queue-gen determines the current queue composition, before the `§1e` claim step.
+- Detection method: check `labels` field in `state.json` todo items; items without a `labels` array are treated as `kind/enhancement` (unknown = not chore).
+- Enrichment source sequence follows `docs/design/22-queue-richness.md`: design docs first, roadmap second, then autonomous vision.
+
+---
+
+## Zone 3 — Scoped out
+
+- Changing the priority ordering of chore items (handled separately in §1e).
+- Queue refusal for other label conditions (only chore/docs purity triggers this).
+- Blocking or cancelling chore items — they remain in the queue and are claimed after a `kind/enhancement` item is injected.

--- a/agents/phases/coord.md
+++ b/agents/phases/coord.md
@@ -539,6 +539,149 @@ ISSUE_GEN
       --body "[🎯 COORD | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] Queue generated." 2>/dev/null
   fi
 fi
+
+# §1c-guard: Queue refusal guard — design doc 35 §O1-O3
+# If ALL todo items are kind/chore or kind/docs (no kind/enhancement or kind/bug),
+# inject ≥1 enhancement item before claiming any work.
+# Design ref: docs/design/35-quality-of-output-gaps.md
+python3 - <<'GUARD_EOF'
+import json, subprocess, re, os
+
+REPO = os.environ.get('REPO', '')
+REPORT_ISSUE = os.environ.get('REPORT_ISSUE', '1')
+MY_SESSION_ID = os.environ.get('MY_SESSION_ID', 'sess-unknown')
+OTHERNESS_VERSION = os.environ.get('OTHERNESS_VERSION', 'unknown')
+
+try:
+    with open('.otherness/state.json') as f: s = json.load(f)
+except Exception:
+    raise SystemExit(0)
+
+features = s.get('features', {})
+todo_items = [(k, v) for k, v in features.items() if v.get('state') == 'todo']
+
+if not todo_items:
+    raise SystemExit(0)
+
+CHORE_KINDS = {'kind/chore', 'kind/docs'}
+FEATURE_KINDS = {'kind/enhancement', 'kind/bug'}
+
+# items with no labels are treated as enhancement (unknown = not chore)
+has_feature = any(
+    any(l in FEATURE_KINDS for l in v.get('labels', ['kind/enhancement']))
+    for _, v in todo_items
+)
+
+if has_feature:
+    raise SystemExit(0)  # mixed or feature-rich queue — no guard needed
+
+# Chore-only queue detected
+chore_count = len(todo_items)
+print(f"[COORD §1c-guard] Chore-only queue detected ({chore_count} items — no kind/enhancement or kind/bug).")
+print("[COORD §1c-guard] Enriching queue from design docs before claiming...")
+
+# Enrichment: scan design docs for unclaimed 🔲 Future items
+done_titles = set(
+    v.get('title', '').lower() for v in features.values()
+    if v.get('state') == 'done' and v.get('title')
+)
+try:
+    merged_prs = subprocess.check_output(
+        ['gh', 'pr', 'list', '--repo', REPO, '--state', 'merged', '--limit', '100',
+         '--json', 'title', '--jq', '.[].title'], text=True).lower().splitlines()
+except Exception:
+    merged_prs = []
+
+def is_done(desc):
+    d = desc.lower().strip()
+    d = re.sub(r'^⚠️\s*(inferred|observed):\s*', '', d)
+    if d in done_titles: return True
+    key = d[:60]
+    return any(key in pr for pr in merged_prs)
+
+def open_if_absent(title, labels, body):
+    r = subprocess.run(['gh', 'issue', 'list', '--repo', REPO, '--state', 'open',
+                        '--search', title[:60], '--json', 'number', '--jq', 'length'],
+                       capture_output=True, text=True)
+    if int(r.stdout.strip() or '0') == 0:
+        r2 = subprocess.run(['gh', 'issue', 'create', '--repo', REPO,
+                             '--title', title, '--label', labels, '--body', body],
+                            capture_output=True, text=True)
+        if r2.returncode == 0:
+            return r2.stdout.strip().split('/')[-1]
+    return None
+
+injected = 0
+design_dir = 'docs/design'
+if os.path.isdir(design_dir):
+    for fname in sorted(os.listdir(design_dir)):
+        if not fname.endswith('.md') or injected >= 3: break
+        try:
+            content = open(f'{design_dir}/{fname}').read()
+            m = re.search(r'^## Future.*?\n(.*?)(?=^## |\Z)', content, re.MULTILINE | re.DOTALL)
+            if m:
+                items = re.findall(r'^- 🔲 (?!.*🚫)(.+)', m.group(1), re.MULTILINE)
+                for item in items:
+                    if injected >= 3: break
+                    desc = re.sub(r'\s*—.*$', '', item).strip()
+                    if is_done(desc): continue
+                    title = f"feat: {desc[:90]}"
+                    body = (f"## Design reference\n"
+                            f"- **Design doc**: `docs/design/{fname}`\n"
+                            f"- **Section**: `§ Future`\n"
+                            f"- **Implements**: {desc} (🔲 → ✅)\n\n"
+                            f"## Summary\n\n"
+                            f"Queue refusal guard injected: chore-only queue enriched with vision item.\n\n"
+                            f"Full item: {item}")
+                    result = open_if_absent(
+                        title,
+                        'otherness,kind/enhancement,area/agent-loop,size/s,priority/medium',
+                        body)
+                    if result:
+                        injected += 1
+                        print(f"[COORD §1c-guard] Injected issue #{result}: {title[:60]}")
+        except Exception as e:
+            print(f"[COORD §1c-guard] scan error for {fname}: {e}")
+
+if injected == 0:
+    # Fallback: roadmap deliverables
+    try:
+        roadmap = open('docs/aide/roadmap.md').read()
+        stages = re.split(r'^## Stage', roadmap, flags=re.MULTILINE)
+        for stage in stages[1:]:
+            deliverables = re.findall(r'^- (.+)', stage, re.MULTILINE)
+            for d in deliverables:
+                if injected >= 3: break
+                if is_done(d.strip()): continue
+                title = f"feat: {d.strip()[:90]}"
+                body = (f"## Design reference\n"
+                        f"- **Design doc**: `docs/aide/roadmap.md`\n"
+                        f"- **Section**: `§ Stage {stage.strip().split(chr(10))[0].strip()}`\n"
+                        f"- **Implements**: {d.strip()[:80]} (roadmap deliverable)\n\n"
+                        f"## Summary\n\n"
+                        f"Queue refusal guard injected: chore-only queue enriched from roadmap.\n\n"
+                        f"Full item: {d.strip()}")
+                result = open_if_absent(
+                    title,
+                    'otherness,kind/enhancement,area/agent-loop,size/s,priority/low',
+                    body)
+                if result:
+                    injected += 1
+                    print(f"[COORD §1c-guard] Injected roadmap issue #{result}: {title[:60]}")
+            if injected > 0: break
+    except Exception as e:
+        print(f"[COORD §1c-guard] roadmap fallback error (non-fatal): {e}")
+
+if injected > 0:
+    print(f"[COORD §1c-guard] Enriched queue with {injected} enhancement item(s).")
+    subprocess.run(['gh', 'issue', 'comment', REPORT_ISSUE, '--repo', REPO,
+                    '--body', f"[COORD §1c-guard | {MY_SESSION_ID} | otherness@{OTHERNESS_VERSION}] "
+                              f"Chore-only queue detected ({chore_count} items). "
+                              f"Injected {injected} enhancement item(s) from design docs/roadmap."],
+                   capture_output=True)
+else:
+    print("[COORD §1c-guard] No enhancement sources found — allowing chore claim to avoid stall (design doc 35 §O2).")
+GUARD_EOF
 ```
 
 ---

--- a/docs/design/06-command-surface.md
+++ b/docs/design/06-command-surface.md
@@ -60,7 +60,8 @@ operation. They should be documented as internal/advanced.
 
 ## Future (🔲)
 
-*(All planned command surface items have been shipped.)*
+- 🔲 `/otherness.status` single-page health summary that a human can read in 30 seconds: the current command output is too verbose and technical — it lists state.json fields and raw branch names. A human looking at GitHub right now should be able to answer in one glance: (1) is the system healthy, (2) what did it ship today, (3) is it moving toward the vision or spinning. Required output format: 3-line summary (health signal, last-shipped item, queue depth), then optional detail. Report issue comments must be condensed to the same 3-line format. Everything else is noise. ⚠️ Inferred from visibility lens: no clean single-page health dashboard; report issue comments too verbose and technical.
+- 🔲 Automated `docs/aide/progress.md` update in SM §4f: `progress.md` currently reflects the state at the time a human last wrote it. SM must update it automatically every batch to reflect: current stage, last-shipped PR title and date, queue depth, health signal. A human who reads `progress.md` should see reality, not history. ⚠️ Inferred from visibility lens: human cannot quickly tell if system is moving toward vision or spinning in circles.
 
 ---
 

--- a/docs/design/21-session-throughput.md
+++ b/docs/design/21-session-throughput.md
@@ -129,6 +129,8 @@ need for Fix D sooner.
 - ✅ `coord.md`: minimum queue depth guard — trigger vision synthesis when queue drops below 5 and no design doc items remain
 - ✅ `otherness-config.yaml` + `otherness-config-template.yaml`: add `maqa.session_item_limit` field (default: 10) — pre-shipped
 - ✅ `docs/design/22-queue-richness.md`: design doc for Fix C — richer queue sources (2026-04-20)es)
+- 🔲 Session defect diagnosis: when a session completes with 0 meaningful items (only metrics commits, chores, or SM/PM housekeeping), SM §4b must open a `kind/bug` issue with the diagnosed root cause — queue source exhausted / all items blocked / vision pressure too low / etc. A housekeeping-only session is not an acceptable outcome; it is a measurable defect that the system must self-diagnose and self-heal. ⚠️ Inferred from reliability lens: sessions still fail silently or produce housekeeping PRs with no real feature content.
+- 🔲 Meaningful-work rate tracked as a first-class metric: `docs/aide/metrics.md` must add a `meaningful_prs` column (PRs that advance a 🔲 Future → ✅ Present transition or fix a validated regression). SM §4b fills this column each batch. PM §5 stagnation check triggers AMBER when `meaningful_prs = 0` for 2 consecutive batches. This makes the throughput principle from `docs/aide/vision.md` measurable, not aspirational. ⚠️ Inferred from honesty lens: metrics collected but not acting on the meaningful/housekeeping split.
 
 ---
 

--- a/docs/design/23-simulation-as-anchor.md
+++ b/docs/design/23-simulation-as-anchor.md
@@ -173,6 +173,8 @@ docs/aide/metrics.md             — existing batch log (SM already writes this)
 
 
 - 🚫 `scripts/simulate.py`: add `--calibrate` flag — DEPRECATED: `scripts/calibrate.py` provides this functionality as a standalone script. No duplication needed.
+- 🔲 Simulation predictions must visibly change agent behavior: today the simulation runs, produces predictions, and posts divergence signals — but the agent loop does not demonstrably adjust its behavior in the following batch based on those signals. SM §4e must write a `recovery_action` field to `sim-prediction.json` (one of: `trigger_learn`, `escalate_oldest_needs_human`, `prioritize_ci_fix`, `trigger_vision_synthesis`), and `coord.md §1b` must read this field at session start and adjust claim priority accordingly. The prediction is useless if no one acts on it. ⚠️ Inferred from honesty lens: simulation exists but its predictions are not visibly changing agent behavior.
+- 🔲 SM health signal must distinguish real GREEN from stall-GREEN: the current GREEN health signal fires when the batch completed and CI passed — it does not verify that meaningful work shipped. A batch where only a metrics commit merged is currently reported as GREEN. The health signal must be two-axis: `progress_signal` (ADVANCING / STALLING / STALLED) × `health_signal` (GREEN / AMBER / RED). ADVANCING requires ≥1 meaningful PR (Future→Present transition or validated fix). STALLING means 2 consecutive batches with 0 meaningful PRs. STALLED means 3+. The human should never see GREEN on a stalling system. ⚠️ Inferred from honesty lens: SM health signal says GREEN but products not advancing fast enough.
 
 ---
 

--- a/docs/design/31-stage-2-skills-expansion.md
+++ b/docs/design/31-stage-2-skills-expansion.md
@@ -23,7 +23,8 @@ improve decision quality across all projects.
 
 ## Future (🔲)
 
-*(Stage 2 is complete. All deliverables shipped.)*
+- 🔲 Autonomous `/otherness.learn` cadence enforcement with measurable trigger: SM §4c must check PROVENANCE.md date of last learn session every batch. If last entry is >14 days ago, SM queues a learn session immediately — not as a suggestion but as a `priority/high` issue claiming the next session. The monoculture risk identified in `docs/aide/vision.md §What the simulation proved` requires active countermeasures, not passive availability of the command. Target: learn session runs at least once every 14 days, measured in PROVENANCE.md. ⚠️ Inferred from self-improvement lens: /otherness.learn runs rarely, agents not meaningfully smarter than two weeks ago.
+- 🔲 Architectural monoculture breakout mechanism: the simulation identified that all agents share `standalone.md` — the same reasoning framework — regardless of how diverse their skill sets are. Skill diversity ≠ conceptual diversity. The only current break is `/otherness.learn` importing foreign patterns. This must be made systematic: every learn session must explicitly target a repo from a different paradigm (functional, event-sourced, actor-model, etc.) than the last session. SM §4c must record the `paradigm_category` of each PROVENANCE.md entry and reject back-to-back sessions in the same category. This is the highest-priority investment for breaking frame-lock. ⚠️ Inferred from self-improvement lens: monoculture problem has not been addressed architecturally.
 
 ---
 

--- a/docs/design/32-stage-3-onboarding-quality.md
+++ b/docs/design/32-stage-3-onboarding-quality.md
@@ -25,7 +25,8 @@ any human corrections to the generated files.
 
 ## Future (🔲)
 
-*(Stage 3 is complete. All deliverables shipped.)*
+- 🔲 End-to-end onboarding smoke test on a live fresh repo: `scripts/check-onboarding.sh` validates structural completeness of generated docs but does NOT verify that `/otherness.run` actually starts cleanly after onboarding. Stage 3 declared complete based on structural checks only. The true acceptance test — run `/otherness.onboard` on a repo that has never seen otherness, then run `/otherness.run` and confirm the first batch ships ≥1 meaningful PR with zero `[NEEDS HUMAN]` posts — has not been performed. This test must be run and any gaps found in `agents/onboard.md` must be fixed before Stage 3 can be considered genuinely complete. ⚠️ Inferred from onboarding lens: new project added today would still require significant human intervention to get running.
+- 🔲 `onboarding-existing-project.md` first-run smoke test section: the onboarding guides for existing projects are missing a "verify the loop is working" section that a human can run in <5 minutes after setup to confirm: (1) `_state` branch updated in last 24h, (2) at least one PR opened or merged in last 7 days, (3) no `[NEEDS HUMAN]` issues older than 48h. Without this, a human completing onboarding has no clear signal that it worked. `/otherness.status` should serve this purpose but its output is not yet actionable enough. ⚠️ Inferred from onboarding lens: setup guide is incomplete for first-run confidence.
 
 ---
 

--- a/docs/design/35-quality-of-output-gaps.md
+++ b/docs/design/35-quality-of-output-gaps.md
@@ -1,0 +1,79 @@
+# 35: Quality of Output Gaps — Ensuring Sessions Ship Meaningful Work
+
+> Status: Active | Created: 2026-04-20
+> Applies to: all projects using otherness
+
+---
+
+## The problem
+
+An autonomous session that processes only `kind/chore` or `kind/docs` items ships
+no user-visible improvements. The queue can drift toward chore-only composition when:
+
+- Design doc `🔲 Future` items are exhausted mid-session
+- PM/SM-derived hygiene items accumulate faster than vision items are written
+- A session inherits a queue that was already chore-heavy
+
+A session that starts on a chore-only queue is executing in low-value mode. The
+agent should recognize this and inject vision-derived items before claiming work.
+
+---
+
+## The queue refusal guard
+
+**Trigger condition**: when all `state=todo` items in the queue have labels in
+`{kind/chore, kind/docs}` — and none have `kind/enhancement` or `kind/bug` —
+the session must enrich the queue before claiming the next item.
+
+**Enrichment sequence** (from `docs/design/22-queue-richness.md`):
+1. Re-scan `docs/design/` for unclaimed `🔲 Future` items
+2. If none: pull from earliest incomplete roadmap stage
+3. If none: trigger autonomous vision synthesis inline
+4. If none after synthesis: log warning, allow chore claim to avoid stalling
+
+The guard fires at `coord.md §1c` (queue generation), not at `§1e` (item claim).
+This keeps the claim logic clean and ensures enrichment happens before the session
+commits to a specific item.
+
+---
+
+## Present (✅)
+
+- ✅ `coord.md §1c`: queue refusal guard — when all todo items are `kind/chore` or `kind/docs`, trigger enrichment before claiming; enrichment follows design doc → roadmap → vision sequence; posts report comment when triggered (PR #TBD, 2026-04-20) — implemented in this PR
+
+## Future (🔲)
+
+- 🔲 `coord.md §1c`: track guard-firing frequency in session metrics (metrics.md schema — see docs/design/33-stage-4-self-improvement-metrics.md)
+- 🔲 `SM §4b`: session outcome classification — label sessions as "chore-only", "mixed", or "feature-rich" based on item type distribution
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Guard fires on chore-only queues, never on mixed queues.**
+If ≥1 `kind/enhancement` or `kind/bug` item exists in the queue, no guard action
+is taken. The guard is a quality floor, not a priority gate.
+
+**O2 — Guard does not block sessions.**
+If enrichment produces no new items, the guard logs and allows claiming the next
+chore item. An indefinitely stalled session is worse than a chore-only session.
+
+**O3 — Guard-triggered enrichment posts a comment on the report issue.**
+The operator must be able to observe that the guard fired and what was injected.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to re-use the existing `§1c` queue-gen Python block or add a separate
+  guard check: preference is a separate, clearly-labeled guard block for readability.
+- How to detect chore-only: check `labels` array in state.json features; items
+  without labels are treated as `kind/enhancement` (unknown = not chore).
+
+---
+
+## Zone 3 — Scoped out
+
+- Changing chore item priority relative to feature items (handled in §1e sort key)
+- Auto-labeling issues that lack labels — separate hygiene concern
+- Cross-session queue contamination analysis


### PR DESCRIPTION
## Summary

- Adds `§1c-guard` block to `coord.md` that detects chore-only queues and enriches them with `kind/enhancement` items before claiming
- Creates design doc `docs/design/35-quality-of-output-gaps.md` covering queue output quality
- Enrichment sequence: design docs 🔲 Future items → roadmap deliverables → (fallback: allow chore claim)
- Posts a report issue comment when the guard fires so the operator can observe it

## Design doc

Created `docs/design/35-quality-of-output-gaps.md`: documents queue refusal guard pattern (🔲 → ✅).

## CRITICAL tier

This PR touches `agents/phases/coord.md`. Per AGENTS.md change risk tier rules:

```
[NEEDS HUMAN: critical-tier-change]
```

Awaiting human review before merge.

## Tests

- `bash scripts/validate.sh` — PASSED
- `bash scripts/test.sh` — PASSED  
- `bash scripts/lint.sh` — PASSED