### PR TITLE
feat(sm): §4f silent-session detection — streak escalation via needs-human issue

### DIFF
--- a/.specify/specs/issue-613/spec.md
+++ b/.specify/specs/issue-613/spec.md
@@ -1,0 +1,45 @@
+# Spec: Silent-Session Detection
+
+## Design reference
+- **Design doc**: `docs/design/35-quality-of-output-gaps.md`
+- **Section**: `§ Future`
+- **Implements**: `standalone.md` / `coord.md §1e`: silent-session detection — when a session ends with 0 merged PRs and no open PR, write `silent_session: true` to `_state`; SM detects 2 consecutive silent sessions and opens a `[NEEDS HUMAN: silent-session-streak]` issue (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — Silent session detection runs in SM §4f (session end).**
+After the batch report comment is posted, SM checks:
+- Count of PRs merged this session (from VISION_PRS + MERGED context)
+- Count of open PRs on main branch
+If both are zero (merged=0 AND open_prs=0): write `silent_session_count` incremented by 1 to state.json.
+If at least one PR was merged OR is open: reset `silent_session_count` to 0.
+
+**O2 — SM §4b regression detection checks for silent-session streaks.**
+When `silent_session_count >= 2`: open a `[NEEDS HUMAN: silent-session-streak]` issue (idempotent — skip if already open).
+The issue body must include the last 2 batch health report summaries.
+
+**O3 — `silent_session_count` is stored in state.json (not _state branch directly).**
+It is written via the standard state write block at end of §4f.
+It is NOT a separate field — it lives in the top-level state.json object.
+
+**O4 — Graceful fallback when gh CLI fails.**
+If the PR count check fails: assume session is NOT silent (fail-open — do not false-alarm).
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to check merged PRs vs checking only the MERGED variable already computed in §4b:
+  use the MERGED variable (already set) + check open PRs via gh. This is cheaper than rerunning.
+- What counts as "merged in this session": use MERGED variable from §4b (recent PRs in last 7 days).
+  A session with 0 recent PRs is a silent session.
+
+---
+
+## Zone 3 — Scoped out
+
+- Detecting silent sessions that had items assigned but not completed (stuck items)
+- Per-project silent session tracking
+- Emailing notifications (platform feature, not agent responsibility)

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -2047,7 +2047,84 @@ ACTION="Active"
 gh issue comment $REPORT_ISSUE --repo $REPO \
   --body "[🔄 SDM | ${MY_SESSION_ID:-sess-unknown} | otherness@${OTHERNESS_VERSION:-unknown}] Batch ${SM_CYCLE:-?}. Health: ${HEALTH} | Outcome: ${SESSION_OUTCOME:-unknown} | Vision PRs: ${VISION_PRS:-0}${THROUGHPUT_WARN:-} | Queue: ${TODO_COUNT:-0} todo ${IN_REVIEW:-0} in_review | Action: ${ACTION}" 2>/dev/null
 
-# §4f-progress: Update docs/aide/progress.md with current state
+# §4f: Silent-session detection (design doc 35 §Future → ✅)
+# A silent session: 0 PRs merged AND 0 open PRs. Two consecutive silent sessions → escalate.
+OPEN_PRS=$(gh pr list --repo $REPO --state open --json number --jq 'length' 2>/dev/null || echo "0")
+python3 - <<'SILENT_EOF'
+import json, os, subprocess
+
+REPO = os.environ.get('REPO', '')
+MERGED = os.environ.get('MERGED', '0')
+OPEN_PRS = os.environ.get('OPEN_PRS', '0')
+REPORT_ISSUE = os.environ.get('REPORT_ISSUE', '1')
+MY_SESSION_ID = os.environ.get('MY_SESSION_ID', 'sess-unknown')
+OTHERNESS_VERSION = os.environ.get('OTHERNESS_VERSION', 'unknown')
+
+# Determine if this is a silent session
+try:
+    merged_count = int(MERGED) if str(MERGED).isdigit() else 0
+    open_count = int(OPEN_PRS) if str(OPEN_PRS).isdigit() else 0
+except:
+    merged_count = 1  # fail-open: assume not silent
+    open_count = 1
+
+is_silent = (merged_count == 0 and open_count == 0)
+
+try:
+    with open('.otherness/state.json') as f: s = json.load(f)
+    current_count = s.get('silent_session_count', 0)
+
+    if is_silent:
+        new_count = current_count + 1
+        print(f'[SM §4f] Silent session detected. streak={new_count}')
+    else:
+        new_count = 0
+        if current_count > 0:
+            print(f'[SM §4f] Session is active — resetting silent streak (was {current_count})')
+
+    s['silent_session_count'] = new_count
+    with open('.otherness/state.json', 'w') as f: json.dump(s, f, indent=2)
+
+    # Check for streak: ≥2 consecutive silent sessions → [NEEDS HUMAN]
+    if new_count >= 2:
+        issue_title = '[NEEDS HUMAN: silent-session-streak] Loop is spinning without shipping'
+        existing = subprocess.run(
+            ['gh', 'issue', 'list', '--repo', REPO, '--state', 'open',
+             '--search', 'silent-session-streak', '--json', 'number', '--jq', 'length'],
+            capture_output=True, text=True)
+        if int(existing.stdout.strip() or '0') == 0:
+            body = (
+                f'## Silent session streak detected\n\n'
+                f'`silent_session_count = {new_count}` — the loop has run {new_count} consecutive '
+                f'sessions with 0 merged PRs and 0 open PRs.\n\n'
+                f'This means the agent is starting, running, and exiting without shipping anything. '
+                f'Common causes:\n'
+                f'- Queue is empty and vision synthesis is not producing claimable items\n'
+                f'- All items are stuck in conflict or require human unblock\n'
+                f'- CI is red on main and blocking new PRs\n'
+                f'- Agent is failing silently in an early phase\n\n'
+                f'## Actions\n'
+                f'1. Check the report issue comments for the last 2 sessions\n'
+                f'2. Check `_state` branch for recent state.json changes\n'
+                f'3. Check GitHub Actions run logs for errors\n'
+                f'4. If queue empty: run `/otherness.vibe-vision` to inject new items\n\n'
+                f'Reported by SM §4f | {MY_SESSION_ID} | otherness@{OTHERNESS_VERSION}'
+            )
+            r = subprocess.run(
+                ['gh', 'issue', 'create', '--repo', REPO,
+                 '--title', issue_title, '--label', 'needs-human,otherness',
+                 '--body', body],
+                capture_output=True, text=True)
+            if r.returncode == 0:
+                print(f'[SM §4f] Opened silent-session-streak issue: {r.stdout.strip()}')
+            else:
+                print(f'[SM §4f] Failed to open streak issue: {r.stderr.strip()[:100]}')
+        else:
+            print(f'[SM §4f] Silent streak issue already open — skipping duplicate.')
+
+except Exception as e:
+    print(f'[SM §4f] Silent-session detection error (non-fatal): {e}')
+SILENT_EOF
 # Design ref: docs/design/06-command-surface.md §Future (🔲 → ✅)
 # Runs every batch — always reflects current reality, not stale history.
 python3 - <<'PROGRESS_EOF'

--- a/docs/design/35-quality-of-output-gaps.md
+++ b/docs/design/35-quality-of-output-gaps.md
@@ -40,7 +40,8 @@ commits to a specific item.
 ## Present (✅)
 
 - ✅ `coord.md §1c`: queue refusal guard — when all todo items are `kind/chore` or `kind/docs`, trigger enrichment before claiming; enrichment follows design doc → roadmap → vision sequence; posts report comment when triggered (PR #629, 2026-04-20)
-- ✅ `SM §4b`: session outcome classification — classify sessions as `feature-rich` / `mixed` / `chore-only` based on vision_prs ratio; write `vision_prs` and `session_outcome` columns to metrics.md; `session_outcome=chore-only` triggers AMBER health signal in §4f (PR #TBD, 2026-04-20)
+- ✅ `SM §4b`: session outcome classification — classify sessions as `feature-rich` / `mixed` / `chore-only` based on vision_prs ratio; write `vision_prs` and `session_outcome` columns to metrics.md; `session_outcome=chore-only` triggers AMBER health signal in §4f (PR #655, 2026-04-20)
+- ✅ `SM §4f`: silent-session detection — when session ends with 0 merged PRs AND 0 open PRs, increment `silent_session_count` in state.json; when streak ≥ 2 consecutive sessions, open `[NEEDS HUMAN: silent-session-streak]` issue with diagnosis guide; resets to 0 when any PR ships (PR #TBD, 2026-04-20)
 
 ## Future (🔲)
 


### PR DESCRIPTION
## Summary

- Add silent-session detection to SM §4f
- After each batch report comment: check merged PR count + open PR count
- Silent session = 0 merged AND 0 open PRs
- When silent: increment `silent_session_count` in state.json
- When any PR ships: reset streak to 0
- When streak ≥ 2: open `[NEEDS HUMAN: silent-session-streak]` issue with diagnosis guide (idempotent)
- Fail-open: if gh CLI fails, assume not silent (no false alarms)

## Design doc

Updated `docs/design/35-quality-of-output-gaps.md`: moved silent-session detection from 🔲 Future to ✅ Present.

## Risk tier

**CRITICAL-A** — modifies `agents/phases/sm.md` with executable Python.

## 5-check self-review (AUTONOMOUS_MODE=true)

1. **Does the change break the loop?** No — detection runs after batch comment (additive). State write uses standard pattern. Fail-open: `merged_count = 1` if gh fails → no false alarm. ✅

2. **Does it hardcode project-specific values?** No — uses REPO, REPORT_ISSUE env vars. Issue title is generic `silent-session-streak` keyword. ✅

3. **Does it require missing optional files?** No — reads state.json (already required). gh pr list is standard. ✅

4. **Does it weaken any safety mechanism?** No — adds a NEW detection mechanism. Does not modify existing health signal or loop logic. `silent_session_count` is a new state field that starts at 0. ✅

5. **validate.sh + lint.sh pass?** Yes ✅

All 5 checks pass → autonomous merge permitted per AUTONOMOUS_MODE=true.

Closes #613