### PR TITLE
feat(metrics): add arch_convergence and sim_floor_delta columns to metrics.md schema

### DIFF
--- a/.specify/specs/issue-617/spec.md
+++ b/.specify/specs/issue-617/spec.md
@@ -1,0 +1,32 @@
+# Spec: metrics.md schema — arch_convergence and sim_floor_delta columns
+
+## Design reference
+- **Design doc**: `docs/design/35-quality-of-output-gaps.md`
+- **Section**: `§ Future`
+- **Implements**: `docs/aide/metrics.md` schema: add `arch_convergence` and `sim_floor_delta` columns (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — `arch_convergence` and `sim_floor_delta` are added to the Metric Definitions table.**
+With correct definitions and target directions.
+
+**O2 — The Batch Log table header is updated** to include both new columns.
+
+**O3 — SM §4b [AI-STEP] comment is updated** to mention including these columns when writing new rows.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- `arch_convergence`: from `scripts/sim-params.json` `arch_convergence_score` field, or 0.0 if missing.
+- `sim_floor_delta`: `actual_prs_merged - predicted_floor`, where predicted_floor comes from `scripts/sim-params.json`.
+- Historical rows are not modified.
+
+---
+
+## Zone 3 — Scoped out
+
+- Actually computing arch_convergence in SM §4b (requires calibration data — separate §4d)
+- Retroactively backfilling historical rows

--- a/agents/phases/sm.md
+++ b/agents/phases/sm.md
@@ -161,9 +161,12 @@ echo "[SM §4b] Session outcome: ${SESSION_OUTCOME} (vision_prs=${VISION_PRS}, p
 # Append row to metrics.md
 DATE=$(date +%Y-%m-%d)
 # [AI-STEP] Append a new row to docs/aide/metrics.md with today's metrics.
-# Row format (as of PR that added vision_prs + session_outcome):
-#   | $DATE | $BATCH | $MERGED | $NEEDS_HUMAN | 0 | $SKILLS | $TODO_SHIPPED | ~Xmin | $VISION_PRS | $SESSION_OUTCOME | <notes> |
-# Historical rows (before this PR) have only 9 columns — do not modify them.
+# Row format (as of PR that added arch_convergence + sim_floor_delta):
+#   | $DATE | $BATCH | $MERGED | $NEEDS_HUMAN | 0 | $SKILLS | $TODO_SHIPPED | ~Xmin | $VISION_PRS | $SESSION_OUTCOME | $ARCH_CONVERGENCE | $SIM_FLOOR_DELTA | <notes> |
+# $ARCH_CONVERGENCE: from scripts/sim-params.json arch_convergence_score field (default: — if calibration not run)
+# $SIM_FLOOR_DELTA: $MERGED - sim_predicted_floor from scripts/sim-params.json (default: — if missing)
+# Historical rows (before PR #655) have only 9 columns — do not modify them.
+# Historical rows from PR #655 (vision_prs + session_outcome) have 11 columns — do not modify them.
 # Use the pull-rebase-retry pattern to push directly to main (low-risk doc change).
 
 # Pull-rebase-retry push pattern (parallel-safe for direct main commits)

--- a/docs/aide/metrics.md
+++ b/docs/aide/metrics.md
@@ -17,13 +17,15 @@
 | `time_to_merge_avg_min` | Average minutes from PR open to merge (excl. CRITICAL tier wait) | ↓ (efficiency) |
 | `vision_prs` | PRs merged that moved a 🔲 Future item to ✅ Present in a design doc | ↑ (product impact) |
 | `session_outcome` | Session classification: `feature-rich` / `mixed` / `chore-only` based on vision_prs ratio | → feature-rich |
+| `arch_convergence` | Simulation architecture convergence score from last calibration (0–1); 1 = simulation perfectly tracks reality | → 1.0 |
+| `sim_floor_delta` | `actual_prs_merged - sim_predicted_floor`; positive = outpacing simulation predictions | ↑ (positive delta) |
 
 ---
 
 ## Batch Log
 
-| Date | Batch | prs_merged | needs_human | ci_red_hours | skills_count | todo_shipped | time_to_merge_avg_min | vision_prs | session_outcome | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
+| Date | Batch | prs_merged | needs_human | ci_red_hours | skills_count | todo_shipped | time_to_merge_avg_min | vision_prs | session_outcome | arch_convergence | sim_floor_delta | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | 2026-04-14 | 1 | 1 | 1 | ~0.5 | 4 | 0 | — | Bootstrap: CI fix PR; CRITICAL tier PRs awaiting review |
 | 2026-04-14 | 2 | 4 | 2 | 0 | 5 | 4 | ~12 | Shipped #11 #12 #14 #15; CRITICAL #13 #16 pending human |
 | 2026-04-14 | 3 | 5 | 0 | 0 | 5 | 6 | ~8 | Merged all CRITICAL PRs; shipped #17 #18; Stage 1 complete |

--- a/docs/design/35-quality-of-output-gaps.md
+++ b/docs/design/35-quality-of-output-gaps.md
@@ -41,7 +41,8 @@ commits to a specific item.
 
 - ✅ `coord.md §1c`: queue refusal guard — when all todo items are `kind/chore` or `kind/docs`, trigger enrichment before claiming; enrichment follows design doc → roadmap → vision sequence; posts report comment when triggered (PR #629, 2026-04-20)
 - ✅ `SM §4b`: session outcome classification — classify sessions as `feature-rich` / `mixed` / `chore-only` based on vision_prs ratio; write `vision_prs` and `session_outcome` columns to metrics.md; `session_outcome=chore-only` triggers AMBER health signal in §4f (PR #655, 2026-04-20)
-- ✅ `SM §4f`: silent-session detection — when session ends with 0 merged PRs AND 0 open PRs, increment `silent_session_count` in state.json; when streak ≥ 2 consecutive sessions, open `[NEEDS HUMAN: silent-session-streak]` issue with diagnosis guide; resets to 0 when any PR ships (PR #TBD, 2026-04-20)
+- ✅ `SM §4f`: silent-session detection — when session ends with 0 merged PRs AND 0 open PRs, increment `silent_session_count` in state.json; when streak ≥ 2 consecutive sessions, open `[NEEDS HUMAN: silent-session-streak]` issue with diagnosis guide; resets to 0 when any PR ships (PR #657, 2026-04-20)
+- ✅ `docs/aide/metrics.md` schema: added `arch_convergence` and `sim_floor_delta` columns to batch log — tells the human whether the simulation is tracking reality; SM §4b [AI-STEP] updated to include these values (from sim-params.json) in new rows (PR #TBD, 2026-04-20)
 
 ## Future (🔲)
 


### PR DESCRIPTION
## Summary

- Add `arch_convergence` and `sim_floor_delta` columns to `docs/aide/metrics.md` Metric Definitions table
- Update Batch Log table header with both new columns
- Update SM §4b [AI-STEP] comment: row format now includes `$ARCH_CONVERGENCE` and `$SIM_FLOOR_DELTA`

These two numbers tell the human whether the simulation is tracking reality — currently not persisted in the batch log.

## Design doc

Updated `docs/design/35-quality-of-output-gaps.md`: moved arch_convergence/sim_floor_delta schema addition to ✅ Present.

## Risk tier

**CRITICAL-B** — sm.md changes are all `#` comment lines (`[AI-STEP]` row format comments). Zero executable code added.

Diff check: `git diff --unified=0 origin/main...HEAD -- agents/phases/ | grep '^+' | grep -v '^+++\|^+#\|^+\s*#\|^+\s*$\|^\+\`\`\`' | grep -v '\[AI-STEP\]'` → empty output → CRITICAL-B.

Autonomous merge permitted per AGENTS.md CRITICAL-B rules (5-check not required for comment-only changes).

Closes #617